### PR TITLE
feat: auto-upgrade zapbot when new version detected

### DIFF
--- a/bin/zapbot-update-check
+++ b/bin/zapbot-update-check
@@ -2,6 +2,7 @@
 # zapbot-update-check — periodic version check
 #
 # Output (one line, or nothing):
+#   JUST_UPGRADED <old> <new>      — upgrade just happened (marker consumed)
 #   UPGRADE_AVAILABLE <old> <new>  — remote VERSION differs from local
 #   (nothing)                      — up to date or check skipped
 set -euo pipefail
@@ -9,10 +10,21 @@ set -euo pipefail
 ZAPBOT_DIR="${ZAPBOT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 STATE_DIR="$HOME/.zapbot"
 CACHE_FILE="$STATE_DIR/last-update-check"
+MARKER_FILE="$STATE_DIR/just-upgraded-from"
 VERSION_FILE="$ZAPBOT_DIR/VERSION"
 REMOTE_URL="${ZAPBOT_REMOTE_URL:-https://raw.githubusercontent.com/chughtapan/zapbot/main/VERSION}"
 
 mkdir -p "$STATE_DIR"
+
+LOCAL_VERSION=$(cat "$VERSION_FILE" 2>/dev/null || echo "0.0.0")
+
+# If a just-upgraded marker exists, report it and delete
+if [ -f "$MARKER_FILE" ]; then
+  OLD_VERSION=$(cat "$MARKER_FILE" 2>/dev/null || echo "unknown")
+  rm -f "$MARKER_FILE"
+  echo "JUST_UPGRADED $OLD_VERSION $LOCAL_VERSION"
+  exit 0
+fi
 
 # Skip if checked recently (1 hour cache)
 if [ -f "$CACHE_FILE" ]; then
@@ -22,13 +34,16 @@ if [ -f "$CACHE_FILE" ]; then
   [ "$DIFF" -lt 3600 ] && exit 0
 fi
 
-LOCAL_VERSION=$(cat "$VERSION_FILE" 2>/dev/null || echo "0.0.0")
 REMOTE_VERSION=$(curl -fsSL --max-time 3 "$REMOTE_URL" 2>/dev/null | tr -d '[:space:]' || echo "")
 
 # Update cache timestamp
 date +%s > "$CACHE_FILE"
 
-[ -z "$REMOTE_VERSION" ] && exit 0
+# Validate remote version looks like a semver (reject HTML error pages)
+if ! echo "$REMOTE_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+  exit 0
+fi
+
 [ "$LOCAL_VERSION" = "$REMOTE_VERSION" ] && exit 0
 
 echo "UPGRADE_AVAILABLE $LOCAL_VERSION $REMOTE_VERSION"

--- a/setup
+++ b/setup
@@ -89,6 +89,27 @@ link_skill_dirs "$ZAPBOT_DIR" "$SKILLS_DIR"
 # Make scripts executable
 chmod +x "$ZAPBOT_DIR/bin/"* "$ZAPBOT_DIR/setup" "$ZAPBOT_DIR/start.sh" "$ZAPBOT_DIR/test/e2e-smoke.sh" 2>/dev/null || true
 
+# Write upgrade marker if version changed (for manual `git pull && ./setup` upgrades)
+STATE_DIR="$HOME/.zapbot"
+MARKER_FILE="$STATE_DIR/just-upgraded-from"
+NEW_VERSION=$(cat "$ZAPBOT_DIR/VERSION" 2>/dev/null || echo "0.0.0")
+if [ -f "$MARKER_FILE.prev" ]; then
+  PREV_VERSION=$(cat "$MARKER_FILE.prev" 2>/dev/null || echo "")
+  if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "$NEW_VERSION" ]; then
+    mkdir -p "$STATE_DIR"
+    echo "$PREV_VERSION" > "$MARKER_FILE"
+  fi
+  rm -f "$MARKER_FILE.prev"
+elif [ -f "$STATE_DIR/installed-version" ]; then
+  PREV_VERSION=$(cat "$STATE_DIR/installed-version" 2>/dev/null || echo "")
+  if [ -n "$PREV_VERSION" ] && [ "$PREV_VERSION" != "$NEW_VERSION" ]; then
+    mkdir -p "$STATE_DIR"
+    echo "$PREV_VERSION" > "$MARKER_FILE"
+  fi
+fi
+mkdir -p "$STATE_DIR"
+echo "$NEW_VERSION" > "$STATE_DIR/installed-version"
+
 echo ""
 echo "================================================"
 echo "  Zapbot v$(cat "$ZAPBOT_DIR/VERSION") installed!"

--- a/skills/zapbot-publish/SKILL.md
+++ b/skills/zapbot-publish/SKILL.md
@@ -14,8 +14,13 @@ _UPD=$(~/.claude/skills/zapbot/bin/zapbot-update-check 2>/dev/null || true)
 [ -n "$_UPD" ] && echo "$_UPD" || true
 ```
 
-If output shows `UPGRADE_AVAILABLE <old> <new>`: tell the user
-"Zapbot v{new} is available (you're on v{old}). Upgrade: `cd ~/.claude/skills/zapbot && git pull && ./setup`"
+If output shows `UPGRADE_AVAILABLE <old> <new>`:
+  1. Run: `cd ~/.claude/skills/zapbot && git pull origin main && ./setup`
+  2. Tell user: "Zapbot upgraded v{old} → v{new}."
+  3. Continue with the skill.
+
+If output shows `JUST_UPGRADED <old> <new>`:
+  Tell user: "Running zapbot v{new} (just updated!)" and continue.
 
 # /zapbot-publish
 


### PR DESCRIPTION
## Summary

Closes #1

- **`bin/zapbot-update-check`** — detects `~/.zapbot/just-upgraded-from` marker file, reports `JUST_UPGRADED <old> <new>`, and deletes it. Adds semver validation for remote VERSION responses (rejects HTML error pages).
- **`skills/zapbot-publish/SKILL.md`** — preamble now runs `git pull origin main && ./setup` on `UPGRADE_AVAILABLE` instead of printing manual instructions. Handles `JUST_UPGRADED` with a brief confirmation message.
- **`setup`** — tracks `~/.zapbot/installed-version` and writes the `just-upgraded-from` marker when version changes (for manual `git pull && ./setup` upgrades).

## Test plan

- [x] Simulated `JUST_UPGRADED`: wrote marker, ran update-check → outputs `JUST_UPGRADED 0.1.0 0.2.0`, marker deleted
- [x] Remote validation: pointed at HTML URL → silently exits (no false upgrade)
- [x] Setup marker: set `installed-version` to old value, ran setup → marker created with old version
- [x] Setup no-op: ran setup when versions match → no marker created
- [x] End-to-end: setup writes marker → update-check reads and reports it
- [x] Bash syntax check passes on both modified scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)