### PR TITLE
feat: add agent lifecycle notifications to GitHub issues

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -125,16 +125,55 @@ async function handleGitHubWebhook(req: Request, body: string): Promise<Response
       console.log(`[bridge] ${APPROVE_LABEL} on issue #${issueNum}, spawning...`);
       spawnedIssues.set(issueNum, Date.now());
 
+      const repo = process.env.ZAPBOT_REPO;
       const proc = Bun.spawn(["ao", "spawn", String(issueNum)], {
         stdout: "pipe",
         stderr: "pipe",
       });
-      proc.exited.then((code) => {
+
+      // Post "Agent spawning" comment and add in-progress label
+      if (repo) {
+        Bun.spawn(["gh", "issue", "comment", String(issueNum), "--repo", repo, "--body",
+          "🤖 **Agent spawning** — working on this plan now.\n\nFollow progress in the AO dashboard or wait for a PR."], {
+          stdout: "ignore", stderr: "ignore",
+        });
+        Bun.spawn(["gh", "issue", "edit", String(issueNum), "--repo", repo,
+          "--add-label", "in-progress"], {
+          stdout: "ignore", stderr: "ignore",
+        });
+      }
+
+      proc.exited.then(async (code) => {
         if (code !== 0) {
           console.error(`[bridge] ao spawn ${issueNum} failed with code ${code}`);
           spawnedIssues.delete(issueNum);
+          if (repo) {
+            let stderrText = "";
+            try {
+              stderrText = await new Response(proc.stderr).text();
+              if (stderrText.length > 500) stderrText = stderrText.slice(0, 500) + "…";
+            } catch {}
+            const body = `❌ **Agent failed** (exit code ${code})\n\n${stderrText ? "```\n" + stderrText + "\n```" : ""}`;
+            Bun.spawn(["gh", "issue", "comment", String(issueNum), "--repo", repo, "--body", body], {
+              stdout: "ignore", stderr: "ignore",
+            });
+            Bun.spawn(["gh", "issue", "edit", String(issueNum), "--repo", repo,
+              "--remove-label", "in-progress", "--add-label", "agent-failed"], {
+              stdout: "ignore", stderr: "ignore",
+            });
+          }
         } else {
           console.log(`[bridge] ao spawn ${issueNum} succeeded`);
+          if (repo) {
+            Bun.spawn(["gh", "issue", "comment", String(issueNum), "--repo", repo, "--body",
+              "✅ **Agent completed** — check for a new PR on this repo."], {
+              stdout: "ignore", stderr: "ignore",
+            });
+            Bun.spawn(["gh", "issue", "edit", String(issueNum), "--repo", repo,
+              "--remove-label", "in-progress"], {
+              stdout: "ignore", stderr: "ignore",
+            });
+          }
         }
       });
 

--- a/bin/zapbot-team-init
+++ b/bin/zapbot-team-init
@@ -117,6 +117,8 @@ echo ""
 echo "Creating GitHub labels..."
 gh label create "zapbot-plan" --repo "$REPO" --color "0E8A16" --description "Plan published via zapbot" --force 2>/dev/null || true
 gh label create "plan-approved" --repo "$REPO" --color "1D76DB" --description "Plan approved for agent implementation" --force 2>/dev/null || true
+gh label create "in-progress" --repo "$REPO" --color "FBCA04" --description "Agent is working on this plan" --force 2>/dev/null || true
+gh label create "agent-failed" --repo "$REPO" --color "D93F0B" --description "Agent errored out" --force 2>/dev/null || true
 echo "Labels ready"
 
 # --- .env ---


### PR DESCRIPTION
## Summary

- Posts a "Agent spawning" comment and adds `in-progress` label when an agent is spawned from a `plan-approved` label event
- Posts a "Agent completed" or "Agent failed" comment when the agent exits, with stderr output on failure (truncated to 500 chars)
- Manages labels: removes `in-progress` on completion/failure, adds `agent-failed` on failure
- Adds `in-progress` and `agent-failed` label creation to `zapbot-team-init`

Closes #5

## Test plan

- [ ] Start the bridge with `./start.sh`
- [ ] Create a test issue and add `plan-approved` label
- [ ] Verify "Agent spawning" comment appears on the issue
- [ ] Verify `in-progress` label is added
- [ ] Wait for agent to finish
- [ ] Verify completion or failure comment appears
- [ ] Verify `in-progress` label is removed
- [ ] Run `zapbot-team-init --repo <repo>` and verify new labels are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)