### PR TITLE
feat: repo-scoped token and callback handling for plannotator

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -81,6 +81,11 @@ if (!WEBHOOK_SECRET) {
 const BOT_USERNAME = process.env.ZAPBOT_BOT_USERNAME || "zapbot[bot]";
 const AO_URL = process.env.AO_URL || "http://localhost:3001";
 
+// ── Plannotator callback token store ────────────────────────────────
+// Maps callback tokens to { issueNumber, repo, createdAt } so plannotator
+// callbacks resolve to the correct repo without relying on a global env var.
+const callbackTokens = new Map<string, { issueNumber: number; repo: string; createdAt: number }>();
+
 // ── HMAC verification ───────────────────────────────────────────────
 
 async function verifySignature(
@@ -787,9 +792,12 @@ async function main() {
 
         const issueNumber = parseInt(pathname.split("/").pop()!, 10);
         const body = await req.json().catch(() => ({}));
-        const repo = body.repo || "";
 
-        log.info(`Plannotator callback for #${issueNumber}`, { issueNumber });
+        // Resolve repo: token store first, then request body, then env var fallback
+        const stored = body.token ? callbackTokens.get(body.token) : undefined;
+        const repo = stored?.repo || body.repo || process.env.ZAPBOT_REPO || "";
+
+        log.info(`Plannotator callback for #${issueNumber}`, { issueNumber, repo });
 
         // Handle plan_published event from zapbot-publish.sh
         if (body.event === "plan_published") {
@@ -867,9 +875,23 @@ async function main() {
         return resp;
       }
 
-      // Token management (passthrough to AO)
+      // Token registration for plannotator callbacks
       if (pathname === "/api/tokens" && req.method === "POST") {
-        return proxyToAO(req, pathname);
+        const body = await req.json().catch(() => ({}));
+        const { token, issueNumber, repo } = body;
+        if (!token || issueNumber == null) {
+          return new Response("missing token or issueNumber", { status: 400 });
+        }
+        callbackTokens.set(token, {
+          issueNumber,
+          repo: repo || process.env.ZAPBOT_REPO || "",
+          createdAt: Date.now(),
+        });
+        log.info(`Registered callback token for #${issueNumber}`, {
+          issueNumber,
+          repo: repo || process.env.ZAPBOT_REPO || "",
+        });
+        return Response.json({ ok: true });
       }
 
       return new Response("not found", { status: 404 });

--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -84,7 +84,18 @@ const AO_URL = process.env.AO_URL || "http://localhost:3001";
 // ── Plannotator callback token store ────────────────────────────────
 // Maps callback tokens to { issueNumber, repo, createdAt } so plannotator
 // callbacks resolve to the correct repo without relying on a global env var.
+// Tokens expire after TOKEN_TTL_MS to prevent unbounded memory growth.
 const callbackTokens = new Map<string, { issueNumber: number; repo: string; createdAt: number }>();
+const TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function pruneExpiredTokens(): void {
+  const now = Date.now();
+  for (const [key, val] of callbackTokens) {
+    if (now - val.createdAt > TOKEN_TTL_MS) {
+      callbackTokens.delete(key);
+    }
+  }
+}
 
 // ── HMAC verification ───────────────────────────────────────────────
 
@@ -879,9 +890,10 @@ async function main() {
       if (pathname === "/api/tokens" && req.method === "POST") {
         const body = await req.json().catch(() => ({}));
         const { token, issueNumber, repo } = body;
-        if (!token || issueNumber == null) {
-          return new Response("missing token or issueNumber", { status: 400 });
+        if (!token || typeof token !== "string" || issueNumber == null || typeof issueNumber !== "number") {
+          return new Response("missing or invalid token/issueNumber", { status: 400 });
         }
+        pruneExpiredTokens();
         callbackTokens.set(token, {
           issueNumber,
           repo: repo || process.env.ZAPBOT_REPO || "",
@@ -900,11 +912,15 @@ async function main() {
 
   log.info(`Webhook bridge listening on http://localhost:${PORT}`);
 
+  // Periodic token cleanup (every hour)
+  const tokenCleanupInterval = setInterval(pruneExpiredTokens, 60 * 60 * 1000);
+
   // Graceful shutdown
   process.on("SIGINT", async () => {
     log.info("Shutting down...");
     stopHeartbeatChecker();
     cancelPendingRetries();
+    clearInterval(tokenCleanupInterval);
     server.stop();
     await db.destroy();
     process.exit(0);
@@ -914,6 +930,7 @@ async function main() {
     log.info("Shutting down...");
     stopHeartbeatChecker();
     cancelPendingRetries();
+    clearInterval(tokenCleanupInterval);
     server.stop();
     await db.destroy();
     process.exit(0);

--- a/bin/zapbot-publish.sh
+++ b/bin/zapbot-publish.sh
@@ -88,11 +88,20 @@ else
   echo "Created issue #$ISSUE_NUM"
 fi
 
+# Register callback token with repo context for plannotator
+CB_TOKEN=$(openssl rand -hex 16)
+if [ -n "$ISSUE_NUM" ]; then
+  curl -s -X POST "${BRIDGE_URL}/api/tokens" \
+    -H "Content-Type: application/json" \
+    -d "{\"token\":\"${CB_TOKEN}\",\"issueNumber\":${ISSUE_NUM},\"repo\":\"${REPO}\"}" \
+    >/dev/null 2>&1 || true
+fi
+
 # Notify the bridge about the plan publication
 if [ -n "$ISSUE_NUM" ]; then
   curl -s -X POST "$BRIDGE_URL/api/callbacks/plannotator/$ISSUE_NUM" \
     -H "Content-Type: application/json" \
-    -d "{\"repo\": \"$REPO\", \"event\": \"plan_published\"}" \
+    -d "{\"token\":\"${CB_TOKEN}\",\"repo\":\"${REPO}\",\"event\":\"plan_published\"}" \
     >/dev/null 2>&1 || true
 fi
 


### PR DESCRIPTION
## Summary

- Adds a local callback token store in `webhook-bridge.ts` that maps tokens to `{ issueNumber, repo, createdAt }`
- `zapbot-publish.sh` generates a callback token and registers it with the bridge, including the target repo
- Plannotator callback handler resolves repo from token store first, then falls back to `body.repo`, then `ZAPBOT_REPO` env var
- Backward compatible: existing callbacks without tokens still work via the fallback chain

Closes #16

## Test plan

- [x] All existing tests pass (`bun test` — 48/48)
- [ ] Verify `zapbot-publish.sh` registers token with repo when publishing from different repo working directories
- [ ] Verify plannotator callbacks post comments to the correct repo via token lookup
- [ ] Verify backward compat: callbacks without a token fall back to `body.repo` or `ZAPBOT_REPO`

🤖 Generated with [Claude Code](https://claude.com/claude-code)