### PR TITLE
feat: make webhook bridge repo-aware for multi-repo routing

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -24,6 +24,7 @@ import { spawnAgent, cancelPendingRetries, type AgentRole, type AgentFailureHand
 import { startHeartbeatChecker, stopHeartbeatChecker } from "../src/agents/heartbeat.js";
 import type { WorkflowTable } from "../src/store/database.js";
 import { createLogger } from "../src/logger.js";
+import { loadConfig, resolveWebhookSecret, type RepoMap } from "../src/config/loader.js";
 
 // Prevent crashes from unhandled async errors
 process.on("unhandledRejection", (err) => {
@@ -81,6 +82,9 @@ if (!WEBHOOK_SECRET) {
 const BOT_USERNAME = process.env.ZAPBOT_BOT_USERNAME || "zapbot[bot]";
 const AO_URL = process.env.AO_URL || "http://localhost:3001";
 
+// Multi-repo config: loaded from agent-orchestrator.yaml or ZAPBOT_REPO env var
+const { repoMap } = loadConfig(process.env.ZAPBOT_CONFIG || undefined);
+
 // ── Plannotator callback token store ────────────────────────────────
 // Maps callback tokens to { issueNumber, repo, createdAt } so plannotator
 // callbacks resolve to the correct repo without relying on a global env var.
@@ -101,14 +105,15 @@ function pruneExpiredTokens(): void {
 
 async function verifySignature(
   payload: string,
-  signature: string | null
+  signature: string | null,
+  secret: string
 ): Promise<boolean> {
   if (!signature) return false;
 
   const encoder = new TextEncoder();
   const key = await crypto.subtle.importKey(
     "raw",
-    encoder.encode(WEBHOOK_SECRET),
+    encoder.encode(secret),
     { name: "HMAC", hash: "SHA-256" },
     false,
     ["sign"]
@@ -241,6 +246,7 @@ async function executeSideEffects(
   effects: SideEffect[],
   repo: string
 ): Promise<void> {
+  const projectName = repoMap.get(repo)?.projectName;
   for (const effect of effects) {
     try {
       switch (effect.type) {
@@ -252,6 +258,7 @@ async function executeSideEffects(
               repo,
               role: effect.role as AgentRole,
               workflowId: wf.id,
+              projectName,
             }, { onFailed: onAgentFailed });
           }
           break;
@@ -714,16 +721,28 @@ async function main() {
         const eventType = req.headers.get("x-github-event") || "";
         const deliveryId = req.headers.get("x-github-delivery") || "";
 
-        if (!(await verifySignature(body, signature))) {
-          return new Response("invalid signature", { status: 401 });
-        }
-
+        // Parse payload first to extract repo for per-repo secret lookup
         let payload: any;
         try {
           payload = JSON.parse(body);
         } catch {
           return new Response("invalid JSON", { status: 400 });
         }
+
+        const repoFullName: string = payload.repository?.full_name || "";
+
+        // Reject webhooks from unconfigured repos (only when config is loaded)
+        if (repoMap.size > 0 && repoFullName && !repoMap.has(repoFullName)) {
+          log.warn("Webhook from unconfigured repo, rejecting", { repo: repoFullName, deliveryId });
+          return new Response(`repo '${repoFullName}' is not configured`, { status: 403 });
+        }
+
+        // Per-repo HMAC verification with shared secret fallback
+        const secret = resolveWebhookSecret(repoFullName, repoMap, WEBHOOK_SECRET!);
+        if (!(await verifySignature(body, signature, secret))) {
+          return new Response("invalid signature", { status: 401 });
+        }
+
         const result = await handleWebhook(eventType, deliveryId, payload);
         return new Response(result.body, { status: result.status });
       }

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "zap-1",
       "dependencies": {
         "kysely": "^0.28.16",
+        "yaml": "^2.8.3",
       },
       "devDependencies": {
         "bun-types": "^1.3.12",
@@ -224,5 +225,7 @@
     "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": "vitest.mjs" }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "kysely": "^0.28.16"
+    "kysely": "^0.28.16",
+    "yaml": "^2.8.3"
   }
 }

--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -18,6 +18,7 @@ export interface SpawnContext {
   repo: string;
   role: AgentRole;
   workflowId: string;
+  projectName?: string;
 }
 
 interface SpawnOptions {
@@ -137,8 +138,14 @@ export async function spawnAgent(
   }
 
   try {
+    const spawnArgs = ["ao", "spawn"];
+    if (ctx.projectName) {
+      spawnArgs.push("--project", ctx.projectName);
+    }
+    spawnArgs.push(String(ctx.issueNumber));
+
     const proc = Bun.spawn(
-      ["ao", "spawn", String(ctx.issueNumber)],
+      spawnArgs,
       {
         env: {
           ...process.env,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from "fs";
+import { parse as parseYaml } from "yaml";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("config");
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface WebhookConfig {
+  path: string;
+  secretEnvVar: string;
+  signatureHeader: string;
+  eventHeader: string;
+}
+
+export interface ScmConfig {
+  plugin: string;
+  webhook: WebhookConfig;
+}
+
+export interface ProjectConfig {
+  repo: string;
+  path: string;
+  defaultBranch: string;
+  sessionPrefix: string;
+  agentRulesFile: string;
+  scm: ScmConfig;
+}
+
+export interface ZapbotConfig {
+  port: number;
+  projects: Record<string, ProjectConfig>;
+}
+
+/** Lookup entry returned by the repo map. */
+export interface RepoEntry {
+  projectName: string;
+  config: ProjectConfig;
+}
+
+/** Immutable lookup from repo full_name → project info. */
+export type RepoMap = ReadonlyMap<string, RepoEntry>;
+
+// ── Loading ────────────────────────────────────────────────────────
+
+/**
+ * Load and parse agent-orchestrator.yaml, returning the repo→project map.
+ *
+ * Falls back to a single-repo map built from ZAPBOT_REPO env var when
+ * no config file is provided (backward compat).
+ */
+export function loadConfig(configPath?: string): {
+  config: ZapbotConfig | null;
+  repoMap: RepoMap;
+} {
+  if (configPath) {
+    try {
+      const raw = readFileSync(configPath, "utf-8");
+      const parsed = parseYaml(raw) as ZapbotConfig;
+      const repoMap = buildRepoMap(parsed);
+      log.info(`Loaded config from ${configPath}`, { repos: repoMap.size });
+      return { config: parsed, repoMap };
+    } catch (err) {
+      log.error(`Failed to load config from ${configPath}: ${err}`);
+      throw new Error(`Cannot load config: ${configPath}: ${err}`);
+    }
+  }
+
+  // Backward compat: single-repo from env var
+  const singleRepo = process.env.ZAPBOT_REPO;
+  if (singleRepo) {
+    log.info("No config file; using ZAPBOT_REPO env var for single-repo mode", { repo: singleRepo });
+    const repoMap = new Map<string, RepoEntry>([
+      [singleRepo, {
+        projectName: singleRepo.split("/").pop() || singleRepo,
+        config: {
+          repo: singleRepo,
+          path: process.cwd(),
+          defaultBranch: "main",
+          sessionPrefix: (singleRepo.split("/").pop() || "zap").slice(0, 3),
+          agentRulesFile: ".agent-rules.md",
+          scm: {
+            plugin: "github",
+            webhook: {
+              path: "/api/webhooks/github",
+              secretEnvVar: "GITHUB_WEBHOOK_SECRET",
+              signatureHeader: "x-hub-signature-256",
+              eventHeader: "x-github-event",
+            },
+          },
+        },
+      }],
+    ]);
+    return { config: null, repoMap };
+  }
+
+  // No config, no env var — empty map (open mode, any repo accepted)
+  log.warn("No config file and no ZAPBOT_REPO — bridge will accept webhooks from any repo");
+  return { config: null, repoMap: new Map() };
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function buildRepoMap(config: ZapbotConfig): RepoMap {
+  const map = new Map<string, RepoEntry>();
+  if (!config.projects) return map;
+
+  for (const [projectName, project] of Object.entries(config.projects)) {
+    if (!project.repo) continue;
+    map.set(project.repo, { projectName, config: project });
+  }
+  return map;
+}
+
+/**
+ * Resolve the webhook secret for a given repo.
+ *
+ * Priority:
+ * 1. Per-repo secret from the config's secretEnvVar (if different from shared)
+ * 2. Shared GITHUB_WEBHOOK_SECRET
+ */
+export function resolveWebhookSecret(
+  repoFullName: string,
+  repoMap: RepoMap,
+  sharedSecret: string
+): string {
+  const entry = repoMap.get(repoFullName);
+  if (!entry) return sharedSecret;
+
+  const envVar = entry.config.scm?.webhook?.secretEnvVar;
+  if (envVar && envVar !== "GITHUB_WEBHOOK_SECRET") {
+    const perRepoSecret = process.env[envVar];
+    if (perRepoSecret) return perRepoSecret;
+  }
+
+  return sharedSecret;
+}

--- a/start.sh
+++ b/start.sh
@@ -133,18 +133,32 @@ if [ "$USE_NGROK" = true ]; then
   WEBHOOK_URL="${NGROK_URL}/api/webhooks/github"
   for repo in "${ZAPBOT_REPOS[@]}"; do
     echo "Configuring webhook for ${repo}..."
+
+    # Resolve per-repo webhook secret: look up secretEnvVar from YAML, fall back to shared
+    REPO_SECRET="$GITHUB_WEBHOOK_SECRET"
+    SECRET_ENV_VAR=$(awk -v target="$repo" '
+      /repo:/ && $2 == target { found=1; next }
+      found && /secretEnvVar:/ { print $2; exit }
+    ' "$PROJECT_DIR/agent-orchestrator.yaml")
+    if [ -n "$SECRET_ENV_VAR" ] && [ "$SECRET_ENV_VAR" != "GITHUB_WEBHOOK_SECRET" ]; then
+      RESOLVED="${!SECRET_ENV_VAR:-}"
+      if [ -n "$RESOLVED" ]; then
+        REPO_SECRET="$RESOLVED"
+      fi
+    fi
+
     EXISTING_HOOK=$(gh api "repos/${repo}/hooks" --jq '[.[] | select(.config.url | test("ngrok|zapbot"))] | .[0].id // empty' 2>/dev/null || echo "")
 
     if [ -n "$EXISTING_HOOK" ]; then
       gh api "repos/${repo}/hooks/${EXISTING_HOOK}" --method PATCH \
         -f "config[url]=${WEBHOOK_URL}" -f "config[content_type]=json" \
-        -f "config[secret]=${GITHUB_WEBHOOK_SECRET}" >/dev/null
+        -f "config[secret]=${REPO_SECRET}" >/dev/null
       WEBHOOK_IDS+=("${repo}:${EXISTING_HOOK}")
       echo "  Updated existing webhook for ${repo}"
     else
       HOOK_ID=$(gh api "repos/${repo}/hooks" --method POST \
         -f "config[url]=${WEBHOOK_URL}" -f "config[content_type]=json" \
-        -f "config[secret]=${GITHUB_WEBHOOK_SECRET}" \
+        -f "config[secret]=${REPO_SECRET}" \
         -F "events[]=issues" -F "events[]=pull_request" -F "events[]=pull_request_review" \
         -F "events[]=check_run" -F "events[]=issue_comment" -F "active=true" --jq '.id')
       WEBHOOK_IDS+=("${repo}:${HOOK_ID}")

--- a/start.sh
+++ b/start.sh
@@ -96,7 +96,7 @@ echo "AO ready on port ${AO_PORT}"
 
 # Start webhook bridge
 echo "Starting webhook bridge on port ${BRIDGE_PORT}..."
-export GITHUB_WEBHOOK_SECRET ZAPBOT_REPO ZAPBOT_BRIDGE_PORT=$BRIDGE_PORT ZAPBOT_AO_PORT=$AO_PORT ZAPBOT_APPROVE_LABEL=$APPROVE_LABEL
+export GITHUB_WEBHOOK_SECRET ZAPBOT_REPO ZAPBOT_CONFIG="$PROJECT_DIR/agent-orchestrator.yaml" ZAPBOT_BRIDGE_PORT=$BRIDGE_PORT ZAPBOT_AO_PORT=$AO_PORT ZAPBOT_APPROVE_LABEL=$APPROVE_LABEL
 bun "$ZAPBOT_DIR/bin/webhook-bridge.ts" > /tmp/zapbot-bridge.log 2>&1 &
 BRIDGE_PID=$!
 

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { loadConfig, resolveWebhookSecret, type RepoMap } from "../src/config/loader.js";
+
+// ── loadConfig ─────────────────────────────────────────────────────
+
+describe("loadConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "zapbot-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ZAPBOT_REPO;
+  });
+
+  it("parses a valid agent-orchestrator.yaml", () => {
+    const yaml = `
+port: 3000
+projects:
+  zapbot:
+    repo: chughtapan/zapbot
+    path: /home/user/zapbot
+    defaultBranch: main
+    sessionPrefix: zap
+    agentRulesFile: .agent-rules.md
+    scm:
+      plugin: github
+      webhook:
+        path: /api/webhooks/github
+        secretEnvVar: GITHUB_WEBHOOK_SECRET
+        signatureHeader: x-hub-signature-256
+        eventHeader: x-github-event
+`;
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    writeFileSync(configPath, yaml);
+
+    const { config, repoMap } = loadConfig(configPath);
+    expect(config).not.toBeNull();
+    expect(config!.port).toBe(3000);
+    expect(repoMap.size).toBe(1);
+    expect(repoMap.has("chughtapan/zapbot")).toBe(true);
+    expect(repoMap.get("chughtapan/zapbot")!.projectName).toBe("zapbot");
+  });
+
+  it("builds repo map for multiple projects", () => {
+    const yaml = `
+port: 3000
+projects:
+  zapbot:
+    repo: chughtapan/zapbot
+    path: /home/user/zapbot
+    defaultBranch: main
+    sessionPrefix: zap
+    agentRulesFile: .agent-rules.md
+    scm:
+      plugin: github
+      webhook:
+        path: /api/webhooks/github
+        secretEnvVar: GITHUB_WEBHOOK_SECRET
+        signatureHeader: x-hub-signature-256
+        eventHeader: x-github-event
+  frontend:
+    repo: chughtapan/frontend-app
+    path: /home/user/frontend
+    defaultBranch: main
+    sessionPrefix: fe
+    agentRulesFile: .agent-rules.md
+    scm:
+      plugin: github
+      webhook:
+        path: /api/webhooks/github
+        secretEnvVar: GITHUB_WEBHOOK_SECRET_FRONTEND
+        signatureHeader: x-hub-signature-256
+        eventHeader: x-github-event
+`;
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    writeFileSync(configPath, yaml);
+
+    const { repoMap } = loadConfig(configPath);
+    expect(repoMap.size).toBe(2);
+    expect(repoMap.get("chughtapan/zapbot")!.projectName).toBe("zapbot");
+    expect(repoMap.get("chughtapan/frontend-app")!.projectName).toBe("frontend");
+  });
+
+  it("falls back to ZAPBOT_REPO env var when no config path", () => {
+    process.env.ZAPBOT_REPO = "owner/my-repo";
+    const { config, repoMap } = loadConfig();
+    expect(config).toBeNull();
+    expect(repoMap.size).toBe(1);
+    expect(repoMap.has("owner/my-repo")).toBe(true);
+    expect(repoMap.get("owner/my-repo")!.projectName).toBe("my-repo");
+  });
+
+  it("returns empty repoMap when no config and no env var", () => {
+    delete process.env.ZAPBOT_REPO;
+    const { config, repoMap } = loadConfig();
+    expect(config).toBeNull();
+    expect(repoMap.size).toBe(0);
+  });
+
+  it("throws on invalid config file path", () => {
+    expect(() => loadConfig("/nonexistent/path.yaml")).toThrow("Cannot load config");
+  });
+});
+
+// ── resolveWebhookSecret ───────────────────────────────────────────
+
+describe("resolveWebhookSecret", () => {
+  const sharedSecret = "shared-secret-123";
+
+  function buildRepoMap(entries: Array<{ repo: string; projectName: string; secretEnvVar: string }>): RepoMap {
+    const map = new Map();
+    for (const e of entries) {
+      map.set(e.repo, {
+        projectName: e.projectName,
+        config: {
+          repo: e.repo,
+          path: "/tmp",
+          defaultBranch: "main",
+          sessionPrefix: "zap",
+          agentRulesFile: ".agent-rules.md",
+          scm: {
+            plugin: "github",
+            webhook: {
+              path: "/api/webhooks/github",
+              secretEnvVar: e.secretEnvVar,
+              signatureHeader: "x-hub-signature-256",
+              eventHeader: "x-github-event",
+            },
+          },
+        },
+      });
+    }
+    return map;
+  }
+
+  afterEach(() => {
+    delete process.env.GITHUB_WEBHOOK_SECRET_FRONTEND;
+  });
+
+  it("returns shared secret for unknown repo", () => {
+    const map = buildRepoMap([]);
+    expect(resolveWebhookSecret("unknown/repo", map, sharedSecret)).toBe(sharedSecret);
+  });
+
+  it("returns shared secret when repo uses GITHUB_WEBHOOK_SECRET", () => {
+    const map = buildRepoMap([
+      { repo: "owner/repo", projectName: "repo", secretEnvVar: "GITHUB_WEBHOOK_SECRET" },
+    ]);
+    expect(resolveWebhookSecret("owner/repo", map, sharedSecret)).toBe(sharedSecret);
+  });
+
+  it("returns per-repo secret when configured and env var is set", () => {
+    process.env.GITHUB_WEBHOOK_SECRET_FRONTEND = "frontend-secret-456";
+    const map = buildRepoMap([
+      { repo: "owner/frontend", projectName: "frontend", secretEnvVar: "GITHUB_WEBHOOK_SECRET_FRONTEND" },
+    ]);
+    expect(resolveWebhookSecret("owner/frontend", map, sharedSecret)).toBe("frontend-secret-456");
+  });
+
+  it("falls back to shared secret when per-repo env var is not set", () => {
+    const map = buildRepoMap([
+      { repo: "owner/frontend", projectName: "frontend", secretEnvVar: "GITHUB_WEBHOOK_SECRET_FRONTEND" },
+    ]);
+    expect(resolveWebhookSecret("owner/frontend", map, sharedSecret)).toBe(sharedSecret);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #14. Part of #12.

- **Config loader** (`src/config/loader.ts`): Parses `agent-orchestrator.yaml` to build a repo→project map. Falls back to `ZAPBOT_REPO` env var for single-repo backward compatibility.
- **Repo validation**: Webhooks from unconfigured repos are rejected with 403 when a config is loaded.
- **Per-repo webhook secrets**: HMAC verification resolves the secret from the config's `secretEnvVar` per project, falling back to the shared `GITHUB_WEBHOOK_SECRET`.
- **Project-scoped `ao spawn`**: The spawner passes `--project <projectName>` so AO routes to the correct project.
- **`start.sh`**: Exports `ZAPBOT_CONFIG` env var pointing to `agent-orchestrator.yaml`.

## Acceptance criteria

- [x] Webhook payloads from different repos are correctly identified and routed
- [x] Issue deduplication is scoped per-repo (already done via DB queries with repo column)
- [x] `ao spawn` receives project context so AO routes to the correct project
- [x] Plannotator callbacks post comments to the correct repo (already done via `body.repo`)
- [x] Webhooks from unconfigured repos are rejected with an informative error
- [x] Existing single-repo setups continue to work (backward compatible)

## Test plan

- [x] New config loader tests: valid YAML parsing, multi-project map, env var fallback, empty fallback, per-repo secret resolution
- [x] All 57 existing tests pass (state-machine + store + config-loader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)