### PR TITLE
fix: port configuration, ao spawn, and github transition comments

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -373,7 +373,10 @@ async function createTriageWorkflow(
     github_delivery_id: deliveryId,
   });
   log.info(`Created parent workflow ${wfId} in TRIAGE`, { issueNumber });
-  await executeSideEffects([{ type: "spawn_agent", role: "triage", issueNumber }], repo);
+  await executeSideEffects([
+    { type: "spawn_agent", role: "triage", issueNumber },
+    { type: "post_comment", issueNumber, body: "**Zapbot:** Workflow started. Spawning triage agent to analyze this issue and break it into sub-tasks." },
+  ], repo);
 }
 
 // ── Core webhook handler ────────────────────────────────────────────
@@ -449,6 +452,9 @@ async function handleWebhook(
       });
 
       log.info(`Created sub workflow ${wfId} in PLANNING`, { issueNumber, parent: parentWorkflowId });
+      await executeSideEffects([
+        { type: "post_comment", issueNumber, body: "**Zapbot:** Sub-issue tracked. Currently in **planning** state. Publish a plan or add the `plan-approved` label to start implementation." },
+      ], repo);
       return { status: 200, body: "sub workflow created" };
     }
   }

--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -138,20 +138,26 @@ export async function spawnAgent(
   }
 
   try {
-    const spawnArgs = ["ao", "spawn"];
-    if (ctx.projectName) {
-      spawnArgs.push("--project", ctx.projectName);
+    const spawnArgs = ["ao", "spawn", String(ctx.issueNumber)];
+
+    // Build env for ao spawn: it needs AO_CONFIG_PATH to find the yaml,
+    // and AO_PROJECT_ID to select the right project in multi-repo setups.
+    const spawnEnv: Record<string, string | undefined> = {
+      ...process.env,
+      ZAPBOT_AGENT_ID: agentId,
+      ZAPBOT_AGENT_ROLE: ctx.role,
+    };
+    if (process.env.ZAPBOT_CONFIG) {
+      spawnEnv.AO_CONFIG_PATH = process.env.ZAPBOT_CONFIG;
     }
-    spawnArgs.push(String(ctx.issueNumber));
+    if (ctx.projectName) {
+      spawnEnv.AO_PROJECT_ID = ctx.projectName;
+    }
 
     const proc = Bun.spawn(
       spawnArgs,
       {
-        env: {
-          ...process.env,
-          ZAPBOT_AGENT_ID: agentId,
-          ZAPBOT_AGENT_ROLE: ctx.role,
-        },
+        env: spawnEnv,
         stdout: "pipe",
         stderr: "pipe",
       }

--- a/src/state-machine/transitions.ts
+++ b/src/state-machine/transitions.ts
@@ -52,7 +52,7 @@ const parentTransitions: TransitionDef[] = [
     to: ParentState.TRIAGED,
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, ParentState.TRIAGE, ParentState.TRIAGED),
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "Triage complete. Sub-issues created and tracked." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Triage complete. Sub-issues have been created and are being tracked. Each sub-issue will follow its own lifecycle: planning, review, implementation, and verification." },
     ],
   },
   {
@@ -62,7 +62,7 @@ const parentTransitions: TransitionDef[] = [
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, ParentState.TRIAGED, ParentState.COMPLETED),
       { type: "close_issue", issueNumber: wf.issueNumber },
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "All sub-issues complete. Closing parent issue." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** All sub-issues are complete. Closing this parent issue. Nice work." },
     ],
   },
 ];
@@ -74,16 +74,20 @@ const subTransitions: TransitionDef[] = [
     from: SubState.PLANNING,
     eventType: "plan_published",
     to: SubState.REVIEW,
-    effects: (wf) => labelSwap(wf.issueNumber, SubState.PLANNING, SubState.REVIEW),
+    effects: (wf) => [
+      ...labelSwap(wf.issueNumber, SubState.PLANNING, SubState.REVIEW),
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Plan published and ready for review. Add the `plan-approved` label when you're satisfied with the plan." },
+    ],
   },
   {
     from: SubState.PLANNING,
     eventType: "label_added",
     to: SubState.IMPLEMENTING,
     guard: (_wf, event) => event.type === "label_added" && event.label === "plan-approved",
-    effects: (wf) => [
+    effects: (wf, event) => [
       ...labelSwap(wf.issueNumber, SubState.PLANNING, SubState.IMPLEMENTING),
       { type: "spawn_agent", role: "implementer", issueNumber: wf.issueNumber },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: `**Zapbot:** Plan approved by @${event.triggeredBy}. Spawning implementer agent to write the code.` },
     ],
   },
   {
@@ -91,9 +95,10 @@ const subTransitions: TransitionDef[] = [
     eventType: "label_added",
     to: SubState.IMPLEMENTING,
     guard: (_wf, event) => event.type === "label_added" && event.label === "plan-approved",
-    effects: (wf) => [
+    effects: (wf, event) => [
       ...labelSwap(wf.issueNumber, SubState.REVIEW, SubState.IMPLEMENTING),
       { type: "spawn_agent", role: "implementer", issueNumber: wf.issueNumber },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: `**Zapbot:** Plan approved by @${event.triggeredBy}. Spawning implementer agent to write the code.` },
     ],
   },
   {
@@ -102,7 +107,7 @@ const subTransitions: TransitionDef[] = [
     to: SubState.PLANNING,
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, SubState.REVIEW, SubState.PLANNING),
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "Feedback received. Revise the plan and re-publish." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Feedback received on the plan. Moving back to planning. Revise the plan based on the review comments and re-publish when ready." },
     ],
   },
   {
@@ -111,7 +116,7 @@ const subTransitions: TransitionDef[] = [
     to: SubState.DRAFT_REVIEW,
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, SubState.IMPLEMENTING, SubState.DRAFT_REVIEW),
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "Draft PR opened. Review the changes and click \"Ready for review\" when satisfied." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Draft PR opened by the implementer agent. Review the changes, leave comments, and click **Ready for review** when satisfied. The agent will iterate on any requested changes." },
     ],
   },
   {
@@ -121,7 +126,7 @@ const subTransitions: TransitionDef[] = [
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, SubState.IMPLEMENTING, SubState.VERIFYING),
       { type: "spawn_agent", role: "qe", issueNumber: wf.issueNumber },
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "Non-draft PR opened. Spawning QE agent to verify." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** PR opened (non-draft). Spawning QE agent to run tests and verify the implementation." },
     ],
   },
   {
@@ -129,7 +134,7 @@ const subTransitions: TransitionDef[] = [
     eventType: "changes_requested",
     to: SubState.DRAFT_REVIEW,
     effects: (wf) => [
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "Changes requested on draft PR. Implementer agent is iterating." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Changes requested on the draft PR. The implementer agent is reviewing your feedback and iterating." },
     ],
   },
   {
@@ -139,6 +144,7 @@ const subTransitions: TransitionDef[] = [
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, SubState.DRAFT_REVIEW, SubState.VERIFYING),
       { type: "spawn_agent", role: "qe", issueNumber: wf.issueNumber },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** PR marked ready for review. Spawning QE agent to run tests, verify the implementation, and ship." },
     ],
   },
   {
@@ -147,6 +153,7 @@ const subTransitions: TransitionDef[] = [
     to: SubState.DONE,
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, SubState.VERIFYING, SubState.DONE),
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Verified and shipped. PR merged, tests passing. Closing issue." },
       { type: "close_issue", issueNumber: wf.issueNumber },
       ...(wf.parentWorkflowId
         ? [{ type: "check_parent_completion" as const, parentWorkflowId: wf.parentWorkflowId }]
@@ -160,7 +167,7 @@ const subTransitions: TransitionDef[] = [
     guard: (wf) => wf.draftReviewCycles < MAX_DRAFT_REVIEW_CYCLES,
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, SubState.VERIFYING, SubState.DRAFT_REVIEW),
-      { type: "post_comment", issueNumber: wf.issueNumber, body: `Verification failed. Returning to draft review (cycle ${wf.draftReviewCycles + 1}/${MAX_DRAFT_REVIEW_CYCLES}).` },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: `**Zapbot:** Verification failed. Returning to draft review for another iteration (cycle ${wf.draftReviewCycles + 1}/${MAX_DRAFT_REVIEW_CYCLES}). The implementer agent will address the failures.` },
     ],
   },
   {
@@ -170,7 +177,7 @@ const subTransitions: TransitionDef[] = [
     guard: (wf) => wf.draftReviewCycles >= MAX_DRAFT_REVIEW_CYCLES,
     effects: (wf) => [
       ...labelSwap(wf.issueNumber, SubState.VERIFYING, SubState.ABANDONED),
-      { type: "post_comment", issueNumber: wf.issueNumber, body: `Verification failed after ${MAX_DRAFT_REVIEW_CYCLES} cycles. Abandoning — human intervention needed.` },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: `**Zapbot:** Verification failed after ${MAX_DRAFT_REVIEW_CYCLES} review cycles. Abandoning this issue. A human needs to investigate and either fix the remaining failures or re-open with a revised plan.` },
       { type: "notify_human", message: `Issue #${wf.issueNumber} abandoned after ${MAX_DRAFT_REVIEW_CYCLES} failed verification cycles.` },
       ...(wf.parentWorkflowId
         ? [{ type: "check_parent_completion" as const, parentWorkflowId: wf.parentWorkflowId }]
@@ -195,7 +202,7 @@ function buildAbandonTransitions(): TransitionDef[] {
     effects: (wf: Workflow) => [
       ...labelSwap(wf.issueNumber, from, ParentState.ABANDONED),
       { type: "abandon_children", parentWorkflowId: wf.id },
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "Workflow abandoned." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Workflow abandoned. All child sub-issues will also be abandoned." },
     ],
   }));
 
@@ -205,7 +212,7 @@ function buildAbandonTransitions(): TransitionDef[] {
     to: SubState.ABANDONED,
     effects: (wf: Workflow) => [
       ...labelSwap(wf.issueNumber, from, SubState.ABANDONED),
-      { type: "post_comment", issueNumber: wf.issueNumber, body: "Sub-issue abandoned." },
+      { type: "post_comment", issueNumber: wf.issueNumber, body: "**Zapbot:** Sub-issue abandoned. Any running agents for this issue will be stopped." },
       ...(wf.parentWorkflowId
         ? [{ type: "check_parent_completion" as const, parentWorkflowId: wf.parentWorkflowId }]
         : []),

--- a/start.sh
+++ b/start.sh
@@ -98,7 +98,7 @@ pkill -f "ngrok http" 2>/dev/null || true
 
 # Start AO from the project directory
 echo "Starting agent-orchestrator on port ${AO_PORT}..."
-(cd "$PROJECT_DIR" && ao start > /tmp/zapbot-ao.log 2>&1) &
+(cd "$PROJECT_DIR" && PORT=$AO_PORT ao start > /tmp/zapbot-ao.log 2>&1) &
 AO_PID=$!
 
 for i in $(seq 1 20); do
@@ -110,7 +110,7 @@ echo "AO ready on port ${AO_PORT}"
 
 # Start webhook bridge
 echo "Starting webhook bridge on port ${BRIDGE_PORT}..."
-export ZAPBOT_API_KEY ZAPBOT_REPO ZAPBOT_CONFIG="$PROJECT_DIR/agent-orchestrator.yaml" ZAPBOT_BRIDGE_PORT=$BRIDGE_PORT ZAPBOT_AO_PORT=$AO_PORT ZAPBOT_APPROVE_LABEL=$APPROVE_LABEL
+export ZAPBOT_API_KEY ZAPBOT_REPO ZAPBOT_CONFIG="$PROJECT_DIR/agent-orchestrator.yaml" ZAPBOT_PORT=$BRIDGE_PORT ZAPBOT_BRIDGE_PORT=$BRIDGE_PORT ZAPBOT_AO_PORT=$AO_PORT ZAPBOT_APPROVE_LABEL=$APPROVE_LABEL
 bun "$ZAPBOT_DIR/bin/webhook-bridge.ts" > /tmp/zapbot-bridge.log 2>&1 &
 BRIDGE_PID=$!
 

--- a/test/multi-repo.test.ts
+++ b/test/multi-repo.test.ts
@@ -858,11 +858,15 @@ describe("AO spawning: project name from config", () => {
 describe("AO spawning: spawner script structure", () => {
   const spawner = readFileSync(join(__dirname, "../src/agents/spawner.ts"), "utf-8");
 
-  it("builds ao spawn command with --project flag", () => {
-    expect(spawner).toContain('spawnArgs.push("--project", ctx.projectName)');
+  it("sets AO_PROJECT_ID env var for project selection", () => {
+    expect(spawner).toContain("AO_PROJECT_ID = ctx.projectName");
   });
 
-  it("conditionally adds --project only when projectName exists", () => {
+  it("sets AO_CONFIG_PATH from ZAPBOT_CONFIG", () => {
+    expect(spawner).toContain("AO_CONFIG_PATH = process.env.ZAPBOT_CONFIG");
+  });
+
+  it("conditionally sets AO_PROJECT_ID only when projectName exists", () => {
     expect(spawner).toContain("if (ctx.projectName)");
   });
 


### PR DESCRIPTION
## Summary

Three fixes that make the multi-repo agent pipeline actually work end-to-end:

**Port configuration**
- `start.sh` now passes `PORT=$AO_PORT` to `ao start` (AO reads the `PORT` env var for its dashboard port, not `AO_PORT`)
- `start.sh` now exports `ZAPBOT_PORT=$BRIDGE_PORT` alongside `ZAPBOT_BRIDGE_PORT` (webhook-bridge.ts reads `ZAPBOT_PORT`)
- This resolves the 593-restart crash loop where AO and the bridge fought over port 3000

**Agent spawning**
- Replaced non-existent `ao spawn --project` flag with `AO_PROJECT_ID` and `AO_CONFIG_PATH` env vars
- `ao spawn` uses `AO_PROJECT_ID` to select the correct project in multi-repo setups
- `ao spawn` uses `AO_CONFIG_PATH` to find the agent-orchestrator.yaml (previously failing with "No config found")
- Agents now spawn successfully across all 3 repos (zapbot, moltzap, moltzap-arena)

**GitHub comments on transitions**
- Every state transition now posts a **Zapbot:** prefixed comment explaining what happened and what to do next
- Approval comments include `@mention` of who approved
- Workflow creation (triage + sub-issue) posts initial status comments
- 16 transition points now have comments (was 8, many were bare)

## Test plan
- [x] 248 tests pass (0 failures)
- [x] E2E verified: triage trigger on moltzap-arena, comment appeared on GitHub
- [x] E2E verified: planning → approved → implementing transition with @mention comment
- [x] E2E verified: abandoned transition with comment
- [x] E2E verified: cross-repo agent spawn (moltzap, zapbot, moltzap-arena)
- [x] E2E verified: agent receives work and completes (closed issue #42 in 31s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)