### PR TITLE
feat: update planner agent prompt to use gstack skills

### DIFF
--- a/templates/agent-rules-planner.md
+++ b/templates/agent-rules-planner.md
@@ -1,14 +1,26 @@
 # Zapbot Agent Rules — Planner
 
 You are a planner agent. Your job is to draft a detailed implementation plan for
-a sub-issue.
+a sub-issue using gstack's planning and review skills.
+
+## Planning workflow
 
 1. Read the sub-issue body (scoped description from triage)
 2. Read the parent issue for broader context
 3. Analyze the codebase to understand what needs to change
-4. Draft a detailed step-by-step implementation plan
-5. Publish the plan via `/zapbot-publish`
-6. The sub-issue will transition to REVIEW for human feedback
+4. Run `/autoplan` to generate a comprehensive plan with automated review decisions
+5. Run `/plan-eng-review` to validate architecture, data flow, and edge cases
+6. If the sub-issue involves UI/UX components, run `/plan-design-review`
+7. If the sub-issue involves developer-facing APIs, CLIs, or SDKs, run `/plan-devex-review`
+8. Publish the plan via `/zapbot-publish`
+9. The sub-issue will transition to REVIEW for human feedback
+
+## When to run conditional reviews
+
+- **`/plan-design-review`**: Run when the issue mentions UI, frontend, components,
+  layouts, pages, styles, user-facing screens, or visual changes.
+- **`/plan-devex-review`**: Run when the issue mentions APIs, SDKs, CLIs, developer
+  documentation, onboarding flows, or public interfaces consumed by developers.
 
 ## Before committing:
 - Run all existing tests

--- a/templates/agent-rules.md.tmpl
+++ b/templates/agent-rules.md.tmpl
@@ -35,14 +35,17 @@ and decompose it into independent sub-issues.
 
 ### Planner agent
 You are a planner agent. Your job is to draft a detailed implementation plan for
-a sub-issue.
+a sub-issue using gstack's planning and review skills.
 
 1. Read the sub-issue body (scoped description from triage)
 2. Read the parent issue for broader context
 3. Analyze the codebase to understand what needs to change
-4. Draft a detailed step-by-step implementation plan
-5. Publish the plan via `/zapbot-publish`
-6. The sub-issue will transition to REVIEW for human feedback
+4. Run `/autoplan` to generate a comprehensive plan with automated review decisions
+5. Run `/plan-eng-review` to validate architecture, data flow, and edge cases
+6. If the sub-issue involves UI/UX components, run `/plan-design-review`
+7. If the sub-issue involves developer-facing APIs, CLIs, or SDKs, run `/plan-devex-review`
+8. Publish the plan via `/zapbot-publish`
+9. The sub-issue will transition to REVIEW for human feedback
 
 ### Implementer agent
 You are an implementer agent. Your job is to write code from an approved plan.


### PR DESCRIPTION
## Summary

Updates the planner agent prompt to use gstack's planning and review skills instead of a manual planning workflow.

- `/autoplan` runs first to generate a comprehensive plan with automated review decisions
- `/plan-eng-review` always runs for architecture, data flow, and edge case validation
- `/plan-design-review` conditionally runs when the sub-issue involves UI/UX components
- `/plan-devex-review` conditionally runs when the sub-issue involves developer-facing APIs, CLIs, or SDKs
- `/zapbot-publish` remains the final step for team review

## Files changed

- `templates/agent-rules-planner.md` — standalone planner rules
- `templates/agent-rules.md.tmpl` — planner section in the combined template

Closes #38
Part of #36

## Test plan

- [x] Existing tests pass (116 pass; 7 pre-existing failures unrelated to templates)
- [x] Only template markdown files modified — no code changes
- [ ] Verify planner agent uses `/autoplan` on next sub-issue assignment
- [ ] Verify `/plan-eng-review` runs after autoplan
- [ ] Verify conditional reviews trigger appropriately based on issue scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)