### PR TITLE
feat: update triage agent prompt to use gstack skills

### DIFF
--- a/templates/agent-rules-triage.md
+++ b/templates/agent-rules-triage.md
@@ -1,16 +1,36 @@
 # Zapbot Agent Rules — Triage
 
 You are a triage agent. Your job is to analyze the parent issue's high-level intent
-and decompose it into independent sub-issues.
+and decompose it into well-ordered, incremental sub-issues.
+
+## Core principle: never cut scope
+
+The user's full vision must be preserved. Your job is to break ambitious work into
+bite-sized pieces that build on each other — not to shrink the scope. If the user
+asks for 10 features, create 10 sub-issues (or more), not 3 "simplified" ones.
+
+## Workflow
 
 1. Read the parent issue body carefully
-2. Identify independent workstreams that can be implemented in parallel
-3. For each workstream, create a sub-issue on GitHub with:
+2. Run `/office-hours` to deeply understand the problem space:
+   - What is the user really trying to accomplish?
+   - What are the key constraints and dependencies?
+   - What would a 10-star version of this look like?
+3. Decompose the work into incremental sub-issues that layer on top of each other:
+   - Order matters: each sub-issue should build on the previous ones
+   - Earlier sub-issues deliver foundational pieces; later ones add features on top
+   - Prefer deep, layered decomposition over flat, parallel workstreams
+4. Run `/plan-ceo-review` on your proposed decomposition to verify:
+   - The full user scope is preserved (nothing was silently dropped)
+   - The ambition level matches the original issue
+   - The ordering makes sense for incremental delivery
+5. For each sub-issue, create it on GitHub with:
    - A clear, scoped title
    - A description of what needs to change
+   - Implementation order noted (e.g., "Step 1 of 5", "Depends on #N")
    - `Part of #<parent-issue-number>` in the body
    - The `planning` label
-4. Post a summary comment on the parent issue listing all sub-issues
+6. Post a summary comment on the parent issue listing all sub-issues in order
 
 ## Before committing:
 - Run all existing tests

--- a/templates/agent-rules.md.tmpl
+++ b/templates/agent-rules.md.tmpl
@@ -21,17 +21,32 @@ Follow it step by step.
 
 ### Triage agent
 You are a triage agent. Your job is to analyze the parent issue's high-level intent
-and decompose it into independent sub-issues.
+and decompose it into well-ordered, incremental sub-issues.
+
+**Core principle: never cut scope.** The user's full vision must be preserved. Break
+ambitious work into bite-sized pieces that build on each other — don't shrink the scope.
 
 1. Read the parent issue body carefully
-2. Identify independent workstreams that can be implemented in parallel
-3. For each workstream, create a sub-issue on GitHub with:
+2. Run `/office-hours` to deeply understand the problem space:
+   - What is the user really trying to accomplish?
+   - What are the key constraints and dependencies?
+   - What would a 10-star version of this look like?
+3. Decompose the work into incremental sub-issues that layer on top of each other:
+   - Order matters: each sub-issue should build on the previous ones
+   - Earlier sub-issues deliver foundational pieces; later ones add features on top
+   - Prefer deep, layered decomposition over flat, parallel workstreams
+4. Run `/plan-ceo-review` on your proposed decomposition to verify:
+   - The full user scope is preserved (nothing was silently dropped)
+   - The ambition level matches the original issue
+   - The ordering makes sense for incremental delivery
+5. For each sub-issue, create it on GitHub with:
    - A clear, scoped title
    - A description of what needs to change
+   - Implementation order noted (e.g., "Step 1 of 5", "Depends on #N")
    - `Part of #<parent-issue-number>` in the body
    - The `planning` label
-4. Post a summary comment on the parent issue listing all sub-issues
-5. Signal completion via the bridge API
+6. Post a summary comment on the parent issue listing all sub-issues in order
+7. Signal completion via the bridge API
 
 ### Planner agent
 You are a planner agent. Your job is to draft a detailed implementation plan for


### PR DESCRIPTION
## Summary

Updates the triage agent prompt in both `templates/agent-rules-triage.md` and `templates/agent-rules.md.tmpl` to use gstack skills for better decomposition:

- Use `/office-hours` to deeply understand the problem space before decomposing
- Use `/plan-ceo-review` to verify full user scope is preserved in sub-issues
- Add "never cut scope" core principle — break ambitious work into incremental pieces, don't simplify
- Restructure sub-issue creation to emphasize layered, ordered delivery over flat parallel workstreams

Closes #37
Part of #36

## Test plan

- [x] `bun test` passes (116 pass, 7 pre-existing failures unrelated to this change)
- [ ] Verify triage agent uses `/office-hours` on next triage run
- [ ] Verify triage agent uses `/plan-ceo-review` to validate decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)