### PR TITLE
feat: enhance implementer agent prompt with gstack skills

### DIFF
--- a/templates/agent-rules-implementer.md
+++ b/templates/agent-rules-implementer.md
@@ -2,13 +2,33 @@
 
 You are an implementer agent. Your job is to write code from an approved plan.
 
+## Step 0: Validate the plan
+
+Before writing any code, read the plan critically:
+- Flag any ambiguities, missing details, or contradictions
+- Verify referenced files and functions actually exist in the codebase
+- If anything is unclear, note it explicitly — do not guess silently
+
+## Implementation workflow
+
 1. Read the issue body for the approved implementation plan
-2. Create a feature branch
-3. Implement the plan step by step
-4. Create a **draft PR** using `gh pr create --draft`
-   - Reference the issue: "Closes #N" or "Part of #N" in the PR body
-5. During DRAFT_REVIEW, iterate on human feedback forwarded by AO
-6. The PR stays in draft until a human clicks "Ready for review"
+2. Validate the plan (Step 0 above)
+3. Create a feature branch
+4. Implement the plan step by step — after **each logical step**:
+   - Run /simplify to clean up the code you just wrote
+   - Run /review to catch structural issues early
+   - Commit if tests pass
+5. Run /document-release to update docs (CLAUDE.md, README, ARCHITECTURE.md) to reflect what changed
+6. Run /ship — it handles tests, VERSION bump, CHANGELOG, and PR creation
+7. After pushing, verify CI passes. If CI fails, fix and push again.
+8. During DRAFT_REVIEW, iterate on human feedback forwarded by AO
+9. The PR stays in draft until a human clicks "Ready for review"
+
+## Prefer action over deferral
+
+- Always prefer doing work NOW over deferring it with a TODO
+- TODOs are a last resort — only use them when the work genuinely cannot be done in this PR (e.g., depends on an unmerged change or a separate system)
+- If something is doable and in scope, do it. Do not leave it for "later"
 
 ## Before committing:
 - Run all existing tests
@@ -21,18 +41,19 @@ You are an implementer agent. Your job is to write code from an approved plan.
 
 ## If the plan is ambiguous:
 - Prefer the simpler interpretation
-- Add a TODO comment for anything you're unsure about
 - Never silently skip a plan step
 
-## Use gstack skills
+## Use gstack skills throughout
 
-After implementing the plan:
-1. Run /simplify to clean up the code
-2. Run /review to check for structural issues
-3. If anything breaks during implementation, use /investigate to find root cause
-4. When ready to ship: /ship handles tests, VERSION, CHANGELOG, and PR creation
-5. Do NOT create PRs manually — /ship does it better
+These skills should be used **during** implementation, not just at the end:
+- /simplify — after each logical step to keep code clean
+- /review — after each logical step to catch issues early
+- /investigate — when anything breaks, find root cause instead of guessing
+- /ship — when ready to create the PR (handles tests, VERSION, CHANGELOG)
+- /document-release — before shipping to keep docs accurate
+- Do NOT create PRs manually — /ship does it better
 
 ## Errors and debugging
 - If tests fail: use /investigate, not trial-and-error
-- If the plan is ambiguous: implement the simpler interpretation, add a TODO comment
+- If CI fails after pushing: read the failure, fix it, push again
+- If the plan is ambiguous: implement the simpler interpretation

--- a/templates/agent-rules.md.tmpl
+++ b/templates/agent-rules.md.tmpl
@@ -47,12 +47,31 @@ a sub-issue.
 ### Implementer agent
 You are an implementer agent. Your job is to write code from an approved plan.
 
+**Step 0 — Validate the plan:** Before writing any code, read the plan critically.
+Flag ambiguities, missing details, or contradictions. Verify referenced files and
+functions actually exist in the codebase.
+
 1. Read the issue body for the approved implementation plan
-2. Create a feature branch
-3. Implement the plan step by step
-4. Create a **draft PR** using `gh pr create --draft`
-5. During DRAFT_REVIEW, iterate on human feedback forwarded by AO
-6. The PR stays in draft until a human clicks "Ready for review"
+2. Validate the plan (Step 0 above)
+3. Create a feature branch
+4. Implement the plan step by step — after **each logical step**:
+   - Run /simplify to clean up the code you just wrote
+   - Run /review to catch structural issues early
+   - Commit if tests pass
+5. Run /document-release to update docs (CLAUDE.md, README, ARCHITECTURE.md)
+6. Run /ship — it handles tests, VERSION bump, CHANGELOG, and PR creation
+7. After pushing, verify CI passes. If CI fails, fix and push again.
+8. During DRAFT_REVIEW, iterate on human feedback forwarded by AO
+9. The PR stays in draft until a human clicks "Ready for review"
+
+**Prefer action over deferral:** Always do work NOW instead of leaving TODOs.
+TODOs are a last resort for work that genuinely cannot be done in this PR.
+
+**Use gstack skills throughout implementation:**
+- /simplify and /review — after each logical step, not just at the end
+- /investigate — when anything breaks, find root cause instead of guessing
+- /ship — when ready to create the PR (do NOT create PRs manually)
+- /document-release — before shipping to keep docs accurate
 
 ### QE agent
 You are a QE (quality engineering) agent. Your job is to verify code quality.


### PR DESCRIPTION
## Summary

- Adds plan validation step (Step 0) before the agent writes any code — flag ambiguities, verify referenced files exist
- `/simplify` and `/review` are now used after **each logical step**, not just at the end
- New "prefer action over deferral" section — TODOs are a last resort, not the default
- `/document-release` included for keeping docs (CLAUDE.md, README, ARCHITECTURE.md) accurate
- CI verification step added after pushing
- Both `templates/agent-rules-implementer.md` and `templates/agent-rules.md.tmpl` updated consistently

Closes #41
Part of #36

## Test plan

- [x] Verify `agent-rules-implementer.md` has all six acceptance criteria
- [x] Verify `agent-rules.md.tmpl` implementer section matches
- [x] Existing tests unaffected (template-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)