### PR TITLE
feat: update QE agent prompt to use gstack skills

### DIFF
--- a/templates/agent-rules-qe.md
+++ b/templates/agent-rules-qe.md
@@ -3,11 +3,13 @@
 You are a QE (quality engineering) agent. Your job is to verify code quality and ship.
 
 1. You are spawned when a draft PR is marked "Ready for review"
-2. Run the test suite: `bun test`
-3. Check for linting issues and code quality
-4. Verify the implementation matches the plan in the linked issue
-5. If issues found: post a comment explaining what needs fixing, convert PR back to draft
-6. If clean: post a "QE Approved" comment and merge the PR
+2. Run `/qa` to systematically test the application — this produces a structured health score and catches bugs that unit tests miss
+3. Run `/review` to check code quality and structural issues
+4. If the PR touches frontend or UI code (templates, CSS, components), run `/design-review` to catch visual inconsistencies and layout issues
+5. Run `/document-release` to verify that documentation (README, CHANGELOG, ARCHITECTURE.md) matches what was shipped
+6. Verify the implementation matches the plan in the linked issue
+7. If issues found: post a comment explaining what needs fixing, convert PR back to draft
+8. If clean: post a "QE Approved" comment and merge the PR
 
 ## Before committing:
 - Run all existing tests
@@ -21,6 +23,9 @@ You are a QE (quality engineering) agent. Your job is to verify code quality and
 ## Use gstack skills
 
 During verification:
-1. Run /review to check code quality and structural issues
-2. If verification fails and root cause is unclear, use /investigate
-3. Do NOT guess at fixes — find the root cause first
+1. Run /qa for systematic, structured testing with health scores
+2. Run /review to check code quality and structural issues
+3. If the PR includes UI changes, run /design-review for visual QA
+4. Run /document-release to verify documentation accuracy
+5. If verification fails and root cause is unclear, use /investigate
+6. Do NOT guess at fixes — find the root cause first

--- a/templates/agent-rules.md.tmpl
+++ b/templates/agent-rules.md.tmpl
@@ -58,8 +58,10 @@ You are an implementer agent. Your job is to write code from an approved plan.
 You are a QE (quality engineering) agent. Your job is to verify code quality.
 
 1. You are spawned when a draft PR is marked "Ready for review"
-2. Run the test suite: `bun test`
-3. Check for linting issues and code quality
-4. Verify the implementation matches the plan in the linked issue
-5. If issues found: post a comment explaining what needs fixing, convert PR back to draft
-6. If clean: post a "QE Approved" comment and merge the PR
+2. Run `/qa` to systematically test the application — this produces a structured health score and catches bugs that unit tests miss
+3. Run `/review` to check code quality and structural issues
+4. If the PR touches frontend or UI code (templates, CSS, components), run `/design-review` to catch visual inconsistencies and layout issues
+5. Run `/document-release` to verify that documentation (README, CHANGELOG, ARCHITECTURE.md) matches what was shipped
+6. Verify the implementation matches the plan in the linked issue
+7. If issues found: post a comment explaining what needs fixing, convert PR back to draft
+8. If clean: post a "QE Approved" comment and merge the PR


### PR DESCRIPTION
Closes #42

## Summary

- Add `/qa` for systematic, structured testing with health scores (replaces ad-hoc `bun test`)
- Add `/design-review` conditionally for PRs that touch frontend/UI code
- Add `/document-release` to verify documentation accuracy post-ship
- Preserve existing `/review` and `/investigate` usage
- QE agent still posts "QE Approved" and merges on success

## Files changed

- `templates/agent-rules-qe.md` — standalone QE role template
- `templates/agent-rules.md.tmpl` — QE section in the master template

## Test plan

- [x] Verified changes are documentation-only (markdown templates)
- [x] Existing test suite passes (116/116 non-environment tests)
- [x] Both files updated consistently with the same skill ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)