### PR TITLE
feat: add investigator agent role with /investigate skill

### DIFF
--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -9,7 +9,7 @@ const ZAPBOT_DIR = path.resolve(import.meta.dir, "../..");
 
 const log = createLogger("agents");
 
-export type AgentRole = "triage" | "planner" | "implementer" | "qe";
+export type AgentRole = "triage" | "planner" | "implementer" | "qe" | "investigator";
 
 export type AgentFailureHandler = (db: Kysely<Database>, agentId: string) => Promise<void>;
 

--- a/src/state-machine/effects.ts
+++ b/src/state-machine/effects.ts
@@ -1,5 +1,5 @@
 export type SideEffect =
-  | { type: "spawn_agent"; role: "triage" | "planner" | "implementer" | "qe"; issueNumber: number }
+  | { type: "spawn_agent"; role: "triage" | "planner" | "implementer" | "qe" | "investigator"; issueNumber: number }
   | { type: "add_label"; issueNumber: number; label: string }
   | { type: "remove_label"; issueNumber: number; label: string }
   | { type: "post_comment"; issueNumber: number; body: string }

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -25,7 +25,7 @@ export interface WorkflowTable {
 export interface AgentSessionTable {
   id: string; // "agent-{uuid}"
   workflow_id: string;
-  role: string; // "triage" | "planner" | "implementer" | "qe"
+  role: string; // "triage" | "planner" | "implementer" | "qe" | "investigator"
   worktree_path: string | null;
   pr_number: number | null;
   status: string; // "spawning" | "running" | "completed" | "failed" | "timeout"

--- a/templates/agent-rules-investigator.md
+++ b/templates/agent-rules-investigator.md
@@ -21,8 +21,9 @@ You are an investigator agent. Your job is to diagnose bugs and write minimal re
 - Every finding must be backed by a reproduction test that fails
 
 ## Before committing:
+- Mark your reproduction test with `.skip` or `.todo` so it does not break CI for other agents
 - Run all existing tests to confirm they still pass
-- Only commit if existing tests pass (your new reproduction test is expected to fail)
+- Only commit if the test suite passes (your skipped reproduction test documents the bug without blocking CI)
 - Do not modify files outside the investigation scope
 
 ## Commit style:

--- a/templates/agent-rules-investigator.md
+++ b/templates/agent-rules-investigator.md
@@ -1,0 +1,37 @@
+# Zapbot Agent Rules — Investigator
+
+You are an investigator agent. Your job is to diagnose bugs and write minimal reproduction tests. You do NOT fix bugs — only find root causes and prove them with tests.
+
+1. Read the issue body for the bug report or verification failure
+2. **Use `/investigate`** as your primary tool — systematic root cause investigation with the Iron Law: no fixes without root cause
+3. Write a minimal test to reproduce the issue, in this priority order:
+   - **Unit test** (fastest, most isolated — prefer this)
+   - **Integration test** (when the bug spans components)
+   - **Eval** (for LLM/AI behavior regressions)
+   - **End-to-end script** (last resort, for full-stack issues)
+4. Post findings as a structured comment on the issue:
+   - **Root cause**: what is broken and why
+   - **Reproduction steps**: how to trigger the bug
+   - **Recommended fix approach**: what should change (without implementing it)
+   - **Test file locations**: where the reproduction test lives
+
+## Important constraints
+- Do NOT fix the bug — diagnosis and reproduction only
+- The fix is a separate implementation task assigned to an implementer agent
+- Every finding must be backed by a reproduction test that fails
+
+## Before committing:
+- Run all existing tests to confirm they still pass
+- Only commit if existing tests pass (your new reproduction test is expected to fail)
+- Do not modify files outside the investigation scope
+
+## Commit style:
+- Use conventional commits (test:, chore:)
+- Reference the issue number: "test: reproduce #N — <root cause summary>"
+
+## Use gstack skills
+
+During investigation:
+1. Use `/investigate` for systematic root cause analysis
+2. If you need to understand code flow, read the relevant source files
+3. Do NOT use trial-and-error — find the root cause first

--- a/templates/agent-rules.md.tmpl
+++ b/templates/agent-rules.md.tmpl
@@ -102,3 +102,17 @@ You are a QE (quality engineering) agent. Your job is to verify code quality.
 6. Verify the implementation matches the plan in the linked issue
 7. If issues found: post a comment explaining what needs fixing, convert PR back to draft
 8. If clean: post a "QE Approved" comment and merge the PR
+
+### Investigator agent
+You are an investigator agent. Your job is to diagnose bugs and write minimal
+reproduction tests. You do NOT fix bugs — only find root causes and prove them.
+
+1. Read the issue body for the bug report or verification failure
+2. Use `/investigate` for systematic root cause analysis (Iron Law: no fixes without root cause)
+3. Write a minimal reproduction test, in priority order:
+   - Unit test (fastest, most isolated — prefer this)
+   - Integration test (when the bug spans components)
+   - Eval (for LLM/AI behavior regressions)
+   - End-to-end script (last resort, for full-stack issues)
+4. Post findings as a structured comment: root cause, reproduction steps, recommended fix, test locations
+5. Do NOT fix the bug — diagnosis and reproduction only


### PR DESCRIPTION
## Summary

Adds a new **investigator** agent role to zapbot that uses `/investigate` for systematic root cause analysis of bug reports.

- Created `templates/agent-rules-investigator.md` with instructions to use `/investigate`, write minimal reproduction tests (unit > integration > evals > e2e), and post structured findings
- Added `"investigator"` to `AgentRole` type in `src/agents/spawner.ts`
- Added `"investigator"` to `SideEffect` spawn_agent role union in `src/state-machine/effects.ts`
- Added investigator section to master template `templates/agent-rules.md.tmpl`

The investigator agent does NOT fix bugs — it diagnoses and writes reproduction tests only. State machine integration (triggering via labels or verification failures) is deferred per the issue.

Closes #43
Part of #36

## Test plan

- [x] Existing tests pass (53/53 state machine + effects tests)
- [x] New template file exists at `templates/agent-rules-investigator.md`
- [x] `AgentRole` type includes `"investigator"`
- [x] `SideEffect` spawn_agent role includes `"investigator"`
- [x] Master template includes investigator section
- [ ] Spawner correctly copies `agent-rules-investigator.md` when role is `"investigator"` (uses existing `templates/agent-rules-${ctx.role}.md` pattern)