### PR TITLE
feat: gateway registration and ngrok removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Key routing rules:
 ```bash
 bun test              # run unit + store + state-machine tests
 bun run bridge        # start webhook bridge (port 3000)
-./start.sh            # one-click: ngrok + webhook + bridge
+./start.sh            # one-click: gateway/ngrok + webhook + bridge
 ./test/e2e-smoke.sh   # end-to-end smoke test
 ./setup --server      # install server dependencies
 ```
@@ -42,6 +42,7 @@ DRAFT_REVIEW → VERIFYING → DONE. See ARCHITECTURE.md for details.
 - `src/state-machine/` — Pure-function state machine engine
 - `src/agents/` — Agent spawning, heartbeat, role-specific logic
 - `src/config/` — Config loader for agent-orchestrator.yaml, repo map, per-repo webhook secrets
+- `src/gateway/` — Gateway client (register/deregister/heartbeat with Railway gateway)
 - `src/webhook/` — Webhook event mapping (extracted for testability)
 - `src/logger.ts` — Structured logging
 - `bin/` — CLI entry points (webhook-bridge, team-init, publish)

--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -30,7 +30,7 @@ import { createGitHubClient } from "../src/github/client.js";
 import { makeWorkflowId } from "../src/workflow-id.js";
 import { errorResponse } from "../src/http/error-response.js";
 import { verifySignature } from "../src/http/verify-signature.js";
-import { setupGateway, stopHeartbeats } from "../src/gateway/client.js";
+import { setupGateway } from "../src/gateway/client.js";
 
 // Prevent crashes from unhandled async errors
 process.on("unhandledRejection", (err) => {
@@ -1088,7 +1088,10 @@ async function main() {
   }
 
   // Graceful shutdown
+  let shuttingDown = false;
   async function shutdown(): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
     log.info("Shutting down...");
     stopHeartbeatChecker();
     cancelPendingRetries();

--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -30,6 +30,7 @@ import { createGitHubClient } from "../src/github/client.js";
 import { makeWorkflowId } from "../src/workflow-id.js";
 import { errorResponse } from "../src/http/error-response.js";
 import { verifySignature } from "../src/http/verify-signature.js";
+import { setupGateway, stopHeartbeats } from "../src/gateway/client.js";
 
 // Prevent crashes from unhandled async errors
 process.on("unhandledRejection", (err) => {
@@ -1062,26 +1063,46 @@ async function main() {
   // Periodic token cleanup (every hour)
   const tokenCleanupInterval = setInterval(pruneExpiredTokens, 60 * 60 * 1000);
 
-  // Graceful shutdown
-  process.on("SIGINT", async () => {
-    log.info("Shutting down...");
-    stopHeartbeatChecker();
-    cancelPendingRetries();
-    clearInterval(tokenCleanupInterval);
-    server.stop();
-    await db.destroy();
-    process.exit(0);
-  });
+  // Gateway registration (if configured)
+  let gatewayCleanup: (() => Promise<void>) | null = null;
+  const gatewayUrl = process.env.ZAPBOT_GATEWAY_URL;
+  const gatewaySecret = process.env.ZAPBOT_GATEWAY_SECRET;
+  const bridgeUrl = process.env.ZAPBOT_BRIDGE_URL;
 
-  process.on("SIGTERM", async () => {
+  if (gatewayUrl && gatewaySecret && bridgeUrl) {
+    const repos = Array.from(repoMap.keys());
+    if (repos.length > 0) {
+      try {
+        gatewayCleanup = await setupGateway(
+          { gatewayUrl, secret: gatewaySecret },
+          repos,
+          bridgeUrl,
+        );
+        log.info(`Registered ${repos.length} repo(s) with gateway at ${gatewayUrl}`);
+      } catch (err) {
+        log.error(`Failed to register with gateway: ${err}`);
+      }
+    }
+  } else if (gatewayUrl) {
+    log.warn("ZAPBOT_GATEWAY_URL is set but ZAPBOT_GATEWAY_SECRET or ZAPBOT_BRIDGE_URL is missing — skipping gateway registration");
+  }
+
+  // Graceful shutdown
+  async function shutdown(): Promise<void> {
     log.info("Shutting down...");
     stopHeartbeatChecker();
     cancelPendingRetries();
     clearInterval(tokenCleanupInterval);
+    if (gatewayCleanup) {
+      await gatewayCleanup();
+    }
     server.stop();
     await db.destroy();
     process.exit(0);
-  });
+  }
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
 }
 
 main().catch((err) => {

--- a/bin/zapbot-team-init
+++ b/bin/zapbot-team-init
@@ -267,6 +267,12 @@ ZAPBOT_API_KEY=${GENERATED_SECRET}
 
 # Per-repo webhook secrets (optional, overrides shared secret):
 # ZAPBOT_API_KEY_FRONTEND_APP=<secret>
+
+# Gateway mode (replaces ngrok): set these to register with the Railway gateway.
+# The gateway receives GitHub webhooks and forwards them to your bridge.
+# ZAPBOT_GATEWAY_URL=https://zapbot-gateway.up.railway.app
+# ZAPBOT_GATEWAY_SECRET=<must match GATEWAY_SECRET on the gateway>
+# ZAPBOT_BRIDGE_URL=<public URL of this bridge, e.g. your tunnel URL>
 EOF
   echo "  Generated .env with webhook secret"
 else
@@ -277,12 +283,19 @@ fi
 
 echo ""
 echo "--- Webhook setup ---"
-echo "  To set up the webhook, run ./start.sh which handles ngrok + webhook automatically."
-echo "  Or manually create a webhook at:"
+echo "  Option A (recommended): Use the gateway."
+echo "    1. Set ZAPBOT_GATEWAY_URL and ZAPBOT_GATEWAY_SECRET in .env"
+echo "    2. Set ZAPBOT_BRIDGE_URL to your bridge's public URL"
+echo "    3. Run ./start.sh — it registers with the gateway automatically"
+echo ""
+echo "  Option B (legacy): Use ngrok."
+echo "    Run ./start.sh — it starts ngrok and registers GitHub webhooks automatically."
+echo ""
+echo "  Option C: Manual webhook."
 echo "    https://github.com/$ZAPBOT_REPO/settings/hooks/new"
-echo "  Payload URL: <your-ngrok-url>/api/webhooks/github"
-echo "  Content type: application/json"
-echo "  Events: Issues, Pull requests, Pull request reviews"
+echo "    Payload URL: <your-public-url>/api/webhooks/github"
+echo "    Content type: application/json"
+echo "    Events: Issues, Pull requests, Pull request reviews"
 
 # ── Done ─────────────────────────────────────────────────────────────
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -1,0 +1,182 @@
+/**
+ * Gateway client — registers/deregisters this bridge with the Railway gateway.
+ *
+ * The gateway forwards GitHub webhooks to registered bridges. On startup the
+ * bridge registers its public URL; on shutdown it deregisters. A periodic
+ * heartbeat (re-registration) keeps the entry fresh so the gateway's liveness
+ * sweep doesn't mark it stale.
+ */
+
+import { createLogger } from "../logger.js";
+
+const log = createLogger("gateway-client");
+
+// ── Retry helper ───────────────────────────────────────────────────
+
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  { retries = 3, baseDelayMs = 1000 }: { retries?: number; baseDelayMs?: number } = {},
+): Promise<Response> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const resp = await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (resp.ok || resp.status < 500) return resp;
+      lastError = new Error(`HTTP ${resp.status}: ${await resp.text()}`);
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt < retries) {
+      const delay = baseDelayMs * 2 ** attempt;
+      log.warn(`Gateway request failed (attempt ${attempt + 1}/${retries + 1}), retrying in ${delay}ms`, {
+        url,
+      });
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastError;
+}
+
+// ── Public API ─────────────────────────────────────────────────────
+
+export interface GatewayClientConfig {
+  gatewayUrl: string;   // e.g. https://zapbot-gateway.up.railway.app
+  secret: string;       // GATEWAY_SECRET for Bearer auth
+}
+
+/**
+ * Register this bridge with the gateway for a given repo.
+ * The gateway will forward webhooks for `repo` to `bridgeUrl`.
+ */
+export async function registerBridge(
+  config: GatewayClientConfig,
+  repo: string,
+  bridgeUrl: string,
+): Promise<void> {
+  const url = `${config.gatewayUrl}/api/bridges/register`;
+  const resp = await fetchWithRetry(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.secret}`,
+    },
+    body: JSON.stringify({ repo, bridgeUrl }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`Gateway registration failed for ${repo}: HTTP ${resp.status} — ${body}`);
+  }
+
+  log.info(`Registered with gateway: ${repo} → ${bridgeUrl}`, { repo, bridgeUrl });
+}
+
+/**
+ * Deregister this bridge from the gateway for a given repo.
+ * Called on graceful shutdown.
+ */
+export async function deregisterBridge(
+  config: GatewayClientConfig,
+  repo: string,
+): Promise<void> {
+  const url = `${config.gatewayUrl}/api/bridges/register`;
+  try {
+    const resp = await fetch(url, {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.secret}`,
+      },
+      body: JSON.stringify({ repo }),
+      signal: AbortSignal.timeout(5_000),
+    });
+
+    if (!resp.ok) {
+      log.warn(`Gateway deregistration failed for ${repo}: HTTP ${resp.status}`, { repo });
+      return;
+    }
+
+    log.info(`Deregistered from gateway: ${repo}`, { repo });
+  } catch (err) {
+    // Best-effort on shutdown — don't block exit
+    log.warn(`Gateway deregistration error for ${repo}: ${err}`, { repo });
+  }
+}
+
+/**
+ * Heartbeat — re-registers with the gateway to update `lastSeen`.
+ * The gateway's liveness sweep marks bridges stale after STALE_TIMEOUT_MS
+ * (default 60s), so heartbeats should run more frequently than that.
+ */
+export async function heartbeat(
+  config: GatewayClientConfig,
+  repo: string,
+  bridgeUrl: string,
+): Promise<void> {
+  try {
+    await registerBridge(config, repo, bridgeUrl);
+  } catch (err) {
+    log.warn(`Heartbeat failed for ${repo}: ${err}`, { repo });
+  }
+}
+
+// ── Heartbeat manager ──────────────────────────────────────────────
+
+const heartbeatTimers: ReturnType<typeof setInterval>[] = [];
+
+/**
+ * Start periodic heartbeats for all registered repos.
+ * Default interval is 30s (half the gateway's default 60s stale timeout).
+ */
+export function startHeartbeats(
+  config: GatewayClientConfig,
+  repos: string[],
+  bridgeUrl: string,
+  intervalMs = 30_000,
+): void {
+  for (const repo of repos) {
+    const timer = setInterval(() => heartbeat(config, repo, bridgeUrl), intervalMs);
+    heartbeatTimers.push(timer);
+  }
+  log.info(`Started gateway heartbeats for ${repos.length} repo(s) every ${intervalMs}ms`);
+}
+
+/**
+ * Stop all heartbeat timers. Called on shutdown.
+ */
+export function stopHeartbeats(): void {
+  for (const timer of heartbeatTimers) {
+    clearInterval(timer);
+  }
+  heartbeatTimers.length = 0;
+}
+
+/**
+ * Register all repos with the gateway and start heartbeats.
+ * Returns a cleanup function that deregisters all repos and stops heartbeats.
+ */
+export async function setupGateway(
+  config: GatewayClientConfig,
+  repos: string[],
+  bridgeUrl: string,
+): Promise<() => Promise<void>> {
+  // Register all repos
+  for (const repo of repos) {
+    await registerBridge(config, repo, bridgeUrl);
+  }
+
+  // Start periodic heartbeats
+  startHeartbeats(config, repos, bridgeUrl);
+
+  // Return cleanup function
+  return async () => {
+    stopHeartbeats();
+    await Promise.allSettled(
+      repos.map((repo) => deregisterBridge(config, repo)),
+    );
+  };
+}

--- a/start.sh
+++ b/start.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Start zapbot: webhook-bridge + agent-orchestrator + optional ngrok
-# Usage: start.sh [project-dir] [--no-ngrok]
+# Start zapbot: webhook-bridge + agent-orchestrator + optional ngrok/gateway
+# Usage: start.sh [project-dir] [--no-ngrok] [--gateway]
 #
 # Run from a project directory that has agent-orchestrator.yaml (created by zapbot-team-init).
 # Or pass the project path as the first argument.
+#
+# Tunnel modes (in order of precedence):
+#   --gateway         Use ZAPBOT_GATEWAY_URL (auto-detected from env if set)
+#   --no-ngrok        No tunnel; bridge URL = ZAPBOT_BRIDGE_URL or localhost
+#   (default)         Start ngrok tunnel and register GitHub webhooks
 #
 # Supports multiple repos defined in agent-orchestrator.yaml. The bridge
 # routes webhooks by the `repository.full_name` in each payload, so a
@@ -16,10 +21,12 @@ ZAPBOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Parse args
 PROJECT_DIR=""
 USE_NGROK=true
+USE_GATEWAY=false
 for arg in "$@"; do
   case "$arg" in
     --no-ngrok) USE_NGROK=false ;;
-    --help) echo "Usage: start.sh [project-dir] [--no-ngrok]"; exit 0 ;;
+    --gateway) USE_GATEWAY=true ;;
+    --help) echo "Usage: start.sh [project-dir] [--no-ngrok] [--gateway]"; exit 0 ;;
     *) [ -z "$PROJECT_DIR" ] && PROJECT_DIR="$arg" ;;
   esac
 done
@@ -45,6 +52,17 @@ if [ -z "${ZAPBOT_API_KEY:-}" ]; then
   echo "ERROR: ZAPBOT_API_KEY is not set."
   echo "FIX: Run '$ZAPBOT_DIR/bin/zapbot-team-init' to generate .env, or set it manually."
   exit 1
+fi
+
+# Auto-detect gateway mode when ZAPBOT_GATEWAY_URL is set
+if [ -n "${ZAPBOT_GATEWAY_URL:-}" ] && [ "$USE_GATEWAY" = false ] && [ "$USE_NGROK" = true ]; then
+  USE_GATEWAY=true
+  echo "Detected ZAPBOT_GATEWAY_URL — using gateway mode (pass --no-ngrok to disable tunnel entirely)"
+fi
+
+# Gateway mode implies no ngrok
+if [ "$USE_GATEWAY" = true ]; then
+  USE_NGROK=false
 fi
 
 # Build repo list from agent-orchestrator.yaml projects section.
@@ -111,6 +129,9 @@ echo "AO ready on port ${AO_PORT}"
 # Start webhook bridge
 echo "Starting webhook bridge on port ${BRIDGE_PORT}..."
 export ZAPBOT_API_KEY ZAPBOT_REPO ZAPBOT_CONFIG="$PROJECT_DIR/agent-orchestrator.yaml" ZAPBOT_PORT=$BRIDGE_PORT ZAPBOT_BRIDGE_PORT=$BRIDGE_PORT ZAPBOT_AO_PORT=$AO_PORT ZAPBOT_APPROVE_LABEL=$APPROVE_LABEL
+# Pass gateway env vars through to the bridge process
+[ -n "${ZAPBOT_GATEWAY_URL:-}" ] && export ZAPBOT_GATEWAY_URL
+[ -n "${ZAPBOT_GATEWAY_SECRET:-}" ] && export ZAPBOT_GATEWAY_SECRET
 bun "$ZAPBOT_DIR/bin/webhook-bridge.ts" > /tmp/zapbot-bridge.log 2>&1 &
 BRIDGE_PID=$!
 
@@ -121,11 +142,54 @@ for i in $(seq 1 10); do
 done
 echo "Bridge ready on port ${BRIDGE_PORT}"
 
-# Track webhook IDs for cleanup
+# Track webhook IDs for cleanup (ngrok mode only)
 WEBHOOK_IDS=()
+NGROK_PID=""
 
-# Ngrok (optional)
-if [ "$USE_NGROK" = true ]; then
+# Gateway mode: register bridge with the Railway gateway
+if [ "$USE_GATEWAY" = true ]; then
+  GATEWAY_URL="${ZAPBOT_GATEWAY_URL:-}"
+  GATEWAY_SECRET="${ZAPBOT_GATEWAY_SECRET:-}"
+  BRIDGE_URL="${ZAPBOT_BRIDGE_URL:-}"
+
+  if [ -z "$GATEWAY_URL" ]; then
+    echo "ERROR: --gateway mode requires ZAPBOT_GATEWAY_URL."
+    echo "FIX: Set ZAPBOT_GATEWAY_URL in .env (e.g., https://zapbot-gateway.up.railway.app)"
+    kill $BRIDGE_PID $AO_PID 2>/dev/null || true
+    exit 1
+  fi
+  if [ -z "$GATEWAY_SECRET" ]; then
+    echo "ERROR: --gateway mode requires ZAPBOT_GATEWAY_SECRET."
+    echo "FIX: Set ZAPBOT_GATEWAY_SECRET in .env (must match GATEWAY_SECRET on the gateway)"
+    kill $BRIDGE_PID $AO_PID 2>/dev/null || true
+    exit 1
+  fi
+  if [ -z "$BRIDGE_URL" ]; then
+    echo "ERROR: --gateway mode requires ZAPBOT_BRIDGE_URL (public URL of this bridge)."
+    echo "FIX: Set ZAPBOT_BRIDGE_URL in .env (e.g., your tunnel URL or public IP)"
+    kill $BRIDGE_PID $AO_PID 2>/dev/null || true
+    exit 1
+  fi
+
+  export ZAPBOT_BRIDGE_URL="$BRIDGE_URL"
+
+  echo "Registering with gateway at ${GATEWAY_URL}..."
+  for repo in "${ZAPBOT_REPOS[@]}"; do
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+      -H "Authorization: Bearer ${GATEWAY_SECRET}" \
+      -H "Content-Type: application/json" \
+      "${GATEWAY_URL}/api/bridges/register" \
+      -d "$(jq -n --arg repo "$repo" --arg url "$BRIDGE_URL" \
+        '{repo:$repo,bridgeUrl:$url}')" 2>/dev/null || echo "000")
+    if [ "$HTTP_STATUS" = "200" ]; then
+      echo "  Registered ${repo} → ${BRIDGE_URL}"
+    else
+      echo "  WARNING: Gateway registration returned HTTP ${HTTP_STATUS} for ${repo}"
+    fi
+  done
+
+# Ngrok mode (legacy): start tunnel and register GitHub webhooks
+elif [ "$USE_NGROK" = true ]; then
   echo "Starting ngrok tunnel..."
   ngrok http "$BRIDGE_PORT" --log=stdout > /tmp/zapbot-ngrok.log 2>&1 &
   NGROK_PID=$!
@@ -213,19 +277,31 @@ if [ "$USE_NGROK" = true ]; then
     grep -v '^ZAPBOT_BRIDGE_URL=' "$PROJECT_DIR/.env" > "$TMPENV"
     echo "ZAPBOT_BRIDGE_URL=${NGROK_URL}" >> "$TMPENV"
     mv "$TMPENV" "$PROJECT_DIR/.env"
-    # No trap needed — mv succeeded, temp file is gone
   fi
   export ZAPBOT_BRIDGE_URL="${NGROK_URL}"
 else
   NGROK_URL="${ZAPBOT_BRIDGE_URL:-http://localhost:${BRIDGE_PORT}}"
-  NGROK_PID=""
-  echo "ngrok disabled. Bridge URL: $NGROK_URL"
+  echo "No tunnel. Bridge URL: $NGROK_URL"
 fi
 
-# Cleanup on exit: deactivate webhooks and stop processes
+# Cleanup on exit: deregister from gateway, deactivate webhooks, stop processes
 cleanup() {
   echo ""
   echo "Shutting down..."
+
+  # Gateway deregistration
+  if [ "$USE_GATEWAY" = true ] && [ -n "${ZAPBOT_GATEWAY_URL:-}" ] && [ -n "${ZAPBOT_GATEWAY_SECRET:-}" ]; then
+    for repo in "${ZAPBOT_REPOS[@]}"; do
+      echo "  Deregistering ${repo} from gateway..."
+      curl -s -X DELETE \
+        -H "Authorization: Bearer ${ZAPBOT_GATEWAY_SECRET}" \
+        -H "Content-Type: application/json" \
+        "${ZAPBOT_GATEWAY_URL}/api/bridges/register" \
+        -d "$(jq -n --arg repo "$repo" '{repo:$repo}')" >/dev/null 2>&1 || true
+    done
+  fi
+
+  # Ngrok webhook deactivation
   for entry in "${WEBHOOK_IDS[@]}"; do
     repo="${entry%%:*}"
     hook_id="${entry##*:}"
@@ -240,6 +316,7 @@ cleanup() {
       gh api "repos/${repo}/hooks/${hook_id}" --method PATCH -F "active=false" >/dev/null 2>&1 || true
     fi
   done
+
   [ -n "${NGROK_PID:-}" ] && kill $NGROK_PID 2>/dev/null || true
   # Kill process trees (not just direct PIDs) to avoid orphaned AO children
   for pid in ${BRIDGE_PID:-} ${AO_PID:-}; do
@@ -260,12 +337,17 @@ echo "  Repo:      https://github.com/${repo}"
 done
 echo "  Bridge:    http://localhost:${BRIDGE_PORT}"
 echo "  Dashboard: http://localhost:${AO_PORT}"
-[ "$USE_NGROK" = true ] && echo "  ngrok:     ${NGROK_URL}"
+if [ "$USE_GATEWAY" = true ]; then
+  echo "  Gateway:   ${ZAPBOT_GATEWAY_URL}"
+  echo "  Public:    ${ZAPBOT_BRIDGE_URL}"
+elif [ "$USE_NGROK" = true ]; then
+  echo "  ngrok:     ${NGROK_URL}"
+fi
 echo ""
 echo "  Publish:   bash $ZAPBOT_DIR/bin/zapbot-publish.sh <plan-file> --key <name>"
 echo "  Approve:   Add '${APPROVE_LABEL}' label on the GitHub issue"
 echo ""
-echo "  Logs: /tmp/zapbot-{ao,bridge,ngrok}.log"
+echo "  Logs: /tmp/zapbot-{ao,bridge}.log"
 echo "  Press Ctrl+C to stop everything."
 echo "================================================"
 

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import {
+  registerBridge,
+  deregisterBridge,
+  heartbeat,
+  setupGateway,
+  stopHeartbeats,
+  type GatewayClientConfig,
+} from "../src/gateway/client.js";
+import { createFetchHandler } from "../gateway/src/handler.js";
+import { clearRegistry, getBridge } from "../gateway/src/registry.js";
+
+/**
+ * Tests for the gateway client module (src/gateway/client.ts).
+ *
+ * Spins up a real gateway handler so we test registration, deregistration,
+ * and heartbeat end-to-end without mocking HTTP.
+ */
+
+const GATEWAY_SECRET = "test-secret-abc123";
+
+let gatewayServer: ReturnType<typeof Bun.serve>;
+let gatewayUrl: string;
+let config: GatewayClientConfig;
+
+beforeAll(() => {
+  const handler = createFetchHandler({
+    gatewaySecret: GATEWAY_SECRET,
+    forwardTimeoutMs: 5000,
+  });
+  gatewayServer = Bun.serve({ port: 0, fetch: handler });
+  gatewayUrl = `http://localhost:${gatewayServer.port}`;
+  config = { gatewayUrl, secret: GATEWAY_SECRET };
+});
+
+afterAll(() => {
+  gatewayServer.stop(true);
+});
+
+beforeEach(() => {
+  clearRegistry();
+});
+
+afterEach(() => {
+  stopHeartbeats();
+});
+
+describe("gateway client", () => {
+  describe("registerBridge", () => {
+    it("registers a bridge with the gateway", async () => {
+      await registerBridge(config, "owner/repo", "http://localhost:3000");
+      const bridge = getBridge("owner/repo");
+      expect(bridge).toBeDefined();
+      expect(bridge!.bridgeUrl).toBe("http://localhost:3000");
+      expect(bridge!.active).toBe(true);
+    });
+
+    it("registers multiple repos", async () => {
+      await registerBridge(config, "owner/repo-a", "http://localhost:3000");
+      await registerBridge(config, "owner/repo-b", "http://localhost:3000");
+      expect(getBridge("owner/repo-a")).toBeDefined();
+      expect(getBridge("owner/repo-b")).toBeDefined();
+    });
+
+    it("throws on invalid secret", async () => {
+      const badConfig = { gatewayUrl, secret: "wrong-secret" };
+      await expect(registerBridge(badConfig, "owner/repo", "http://localhost:3000"))
+        .rejects.toThrow();
+    });
+  });
+
+  describe("deregisterBridge", () => {
+    it("removes a bridge from the gateway", async () => {
+      await registerBridge(config, "owner/repo", "http://localhost:3000");
+      expect(getBridge("owner/repo")).toBeDefined();
+
+      await deregisterBridge(config, "owner/repo");
+      expect(getBridge("owner/repo")).toBeUndefined();
+    });
+
+    it("does not throw for non-existent repo", async () => {
+      // Deregistering a repo that doesn't exist should not throw
+      await deregisterBridge(config, "owner/nonexistent");
+    });
+  });
+
+  describe("heartbeat", () => {
+    it("re-registers to update lastSeen", async () => {
+      await registerBridge(config, "owner/repo", "http://localhost:3000");
+      const firstSeen = getBridge("owner/repo")!.lastSeen;
+
+      // Small delay to ensure timestamp differs
+      await new Promise((r) => setTimeout(r, 10));
+      await heartbeat(config, "owner/repo", "http://localhost:3000");
+
+      const secondSeen = getBridge("owner/repo")!.lastSeen;
+      expect(secondSeen).toBeGreaterThanOrEqual(firstSeen);
+    });
+
+    it("does not throw on auth failure", async () => {
+      // Use a reachable URL with bad credentials — avoids retry backoff on connection errors
+      const badConfig = { gatewayUrl, secret: "wrong-secret" };
+      // heartbeat swallows errors (registerBridge throws on auth failure, heartbeat catches it)
+      await heartbeat(badConfig, "owner/repo", "http://localhost:3000");
+      // Should not have registered
+      expect(getBridge("owner/repo")).toBeUndefined();
+    });
+  });
+
+  describe("setupGateway", () => {
+    it("registers all repos and returns cleanup function", async () => {
+      const cleanup = await setupGateway(config, ["owner/a", "owner/b"], "http://localhost:3000");
+
+      expect(getBridge("owner/a")).toBeDefined();
+      expect(getBridge("owner/b")).toBeDefined();
+
+      await cleanup();
+      expect(getBridge("owner/a")).toBeUndefined();
+      expect(getBridge("owner/b")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #47. Part of #44.

- **New module `src/gateway/client.ts`**: Gateway client with `registerBridge`, `deregisterBridge`, `heartbeat`, and `setupGateway` functions. Includes retry with exponential backoff on registration failure and periodic heartbeat to keep bridge entries fresh.
- **Updated `bin/webhook-bridge.ts`**: On startup, registers all configured repos with the gateway when `ZAPBOT_GATEWAY_URL` + `ZAPBOT_GATEWAY_SECRET` + `ZAPBOT_BRIDGE_URL` are set. Deregisters on SIGTERM/SIGINT. Consolidated duplicate shutdown handlers into a single function.
- **Updated `start.sh`**: New `--gateway` flag (auto-detected from env). Gateway mode replaces the ngrok tunnel + GitHub webhook registration flow with gateway registration/deregistration. Falls back to ngrok when gateway is not configured. `--no-ngrok` still works for static IP setups.
- **Updated `bin/zapbot-team-init`**: `.env` template now includes `ZAPBOT_GATEWAY_URL`, `ZAPBOT_GATEWAY_SECRET`, and `ZAPBOT_BRIDGE_URL` comments. Webhook setup instructions updated to recommend gateway as Option A.
- **New test `test/gateway-client.test.ts`**: 8 tests covering register, deregister, heartbeat, auth failure, and full setup/cleanup lifecycle against a real gateway handler.

## Env vars

| Variable | Purpose |
|----------|---------|
| `ZAPBOT_GATEWAY_URL` | Gateway URL (e.g. `https://zapbot-gateway.up.railway.app`) |
| `ZAPBOT_GATEWAY_SECRET` | Must match `GATEWAY_SECRET` on the gateway |
| `ZAPBOT_BRIDGE_URL` | Public URL of this bridge (tunnel URL or public IP) |

## Test plan

- [x] All 498 existing tests pass (1 pre-existing plannotator timeout failure unrelated to this PR)
- [x] 8 new gateway client tests pass (register, deregister, heartbeat, auth, setup/cleanup)
- [x] Gateway test suite (31 tests) continues to pass
- [ ] Manual: set `ZAPBOT_GATEWAY_URL` + `ZAPBOT_GATEWAY_SECRET` + `ZAPBOT_BRIDGE_URL` and run `./start.sh` — verify bridge registers with gateway
- [ ] Manual: Ctrl+C → verify bridge deregisters from gateway
- [ ] Manual: run `./start.sh` without gateway env vars → verify ngrok flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)