### PR TITLE
feat: automatic session garbage collection

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -22,6 +22,7 @@ import type { SideEffect } from "../src/state-machine/effects.js";
 import type { Workflow } from "../src/state-machine/transitions.js";
 import { spawnAgent, cancelPendingRetries, type AgentRole, type AgentFailureHandler } from "../src/agents/spawner.js";
 import { startHeartbeatChecker, stopHeartbeatChecker } from "../src/agents/heartbeat.js";
+import { cleanupWorkflowSessions, cleanupStaleSessions } from "../src/agents/cleanup.js";
 import type { WorkflowTable } from "../src/store/database.js";
 import { createLogger } from "../src/logger.js";
 import { loadConfig, resolveWebhookSecret, type RepoMap } from "../src/config/loader.js";
@@ -362,6 +363,13 @@ async function checkParentCompletion(parentWorkflowId: string, repo: string): Pr
       trigger: "all_subs_done",
     });
     await executeSideEffects(result.sideEffects, repo);
+
+    // GC: clean up parent workflow sessions when it reaches terminal state
+    if (TERMINAL_STATES.has(result.newState)) {
+      cleanupWorkflowSessions(db, parentWorkflowId).catch((err) =>
+        log.warn(`Parent completion cleanup failed for ${parentWorkflowId}: ${err}`)
+      );
+    }
   }
 }
 
@@ -660,6 +668,13 @@ async function handleWebhook(
     }
   }
 
+  // GC: clean up agent sessions when a workflow reaches a terminal state
+  if (TERMINAL_STATES.has(result.newState)) {
+    cleanupWorkflowSessions(db, workflow.id).catch((err) =>
+      log.warn(`Post-transition cleanup failed for ${workflow.id}: ${err}`)
+    );
+  }
+
   return { status: 200, body: `${result.transition.from} → ${result.transition.to}` };
 }
 
@@ -912,6 +927,13 @@ async function main() {
                   event: event.type,
                 });
                 await executeSideEffects(result.sideEffects, wfRow.repo);
+
+                // GC: clean up sessions when agent completion triggers terminal state
+                if (TERMINAL_STATES.has(result.newState)) {
+                  cleanupWorkflowSessions(db, workflow.id).catch((err) =>
+                    log.warn(`Agent-complete cleanup failed for ${workflow.id}: ${err}`)
+                  );
+                }
               }
             }
           }
@@ -1063,6 +1085,14 @@ async function main() {
   // Periodic token cleanup (every hour)
   const tokenCleanupInterval = setInterval(pruneExpiredTokens, 60 * 60 * 1000);
 
+  // Periodic session GC sweep (every hour) — catches leaked sessions
+  const gcSweepInterval = setInterval(() => {
+    cleanupStaleSessions(db).catch((err) => log.error(`GC sweep failed: ${err}`));
+  }, 60 * 60 * 1000);
+
+  // Run initial GC sweep on startup to clean backlog
+  cleanupStaleSessions(db).catch((err) => log.error(`Initial GC sweep failed: ${err}`));
+
   // Gateway registration (if configured)
   let gatewayCleanup: (() => Promise<void>) | null = null;
   const gatewayUrl = process.env.ZAPBOT_GATEWAY_URL;
@@ -1096,6 +1126,7 @@ async function main() {
     stopHeartbeatChecker();
     cancelPendingRetries();
     clearInterval(tokenCleanupInterval);
+    clearInterval(gcSweepInterval);
     if (gatewayCleanup) {
       await gatewayCleanup();
     }

--- a/src/agents/cleanup.ts
+++ b/src/agents/cleanup.ts
@@ -1,0 +1,157 @@
+import { Kysely } from "kysely";
+import type { Database } from "../store/database.js";
+import { getSessionsForCleanup, markSessionCleaned, getAgentSessions } from "../store/queries.js";
+import { TERMINAL_STATES } from "../state-machine/states.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("cleanup");
+
+const KILL_TIMEOUT_MS = 10_000;
+
+/**
+ * Kill an AO session by name. Returns true if the kill succeeded (exit 0).
+ * Swallows errors and returns false on failure or timeout.
+ */
+async function killSession(sessionName: string): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["ao", "session", "kill", sessionName], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const timeoutPromise = new Promise<number>((resolve) =>
+      setTimeout(() => {
+        proc.kill();
+        resolve(-1);
+      }, KILL_TIMEOUT_MS)
+    );
+
+    const exitCode = await Promise.race([proc.exited, timeoutPromise]);
+
+    if (exitCode === 0) {
+      log.info(`Killed session ${sessionName}`, { session: sessionName });
+      return true;
+    }
+
+    const stderr = await new Response(proc.stderr).text().catch(() => "");
+    log.warn(`ao session kill ${sessionName} exited with code ${exitCode}: ${stderr.trim()}`, {
+      session: sessionName,
+      exitCode,
+    });
+    return false;
+  } catch (err) {
+    log.warn(`Failed to kill session ${sessionName}: ${err}`, { session: sessionName });
+    return false;
+  }
+}
+
+/**
+ * Find the AO session name for a given issue number by parsing `ao session ls` output.
+ * Looks for lines containing the branch pattern `feat/issue-{N}`.
+ */
+async function findSessionNameForIssue(issueNumber: number): Promise<string | null> {
+  const branch = `feat/issue-${issueNumber}`;
+
+  for (const cmd of [["ao", "session", "ls"], ["ao", "status"]]) {
+    try {
+      const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) continue;
+
+      for (const line of stdout.split("\n")) {
+        if (line.includes(branch)) {
+          const match = line.match(/(zap-\d+)/);
+          if (match) return match[1];
+        }
+      }
+    } catch {
+      // Command failed, try next
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Clean up all agent sessions for a given workflow.
+ * Kills the AO session and marks the agent session as cleaned.
+ * Only marks cleaned_up_at on successful kill.
+ */
+export async function cleanupWorkflowSessions(
+  db: Kysely<Database>,
+  workflowId: string
+): Promise<void> {
+  const sessions = await getAgentSessions(db, workflowId);
+  const uncleaned = sessions.filter((s) => s.cleaned_up_at === null);
+
+  if (uncleaned.length === 0) return;
+
+  log.info(`Cleaning up ${uncleaned.length} session(s) for workflow ${workflowId}`, {
+    workflowId,
+    count: uncleaned.length,
+  });
+
+  for (const session of uncleaned) {
+    // Extract issue number from workflow ID (format: "wf-{issueNumber}")
+    const issueMatch = workflowId.match(/^wf-(\d+)/);
+    if (!issueMatch) {
+      log.warn(`Cannot parse issue number from workflow ${workflowId}`, { workflowId });
+      continue;
+    }
+
+    const issueNumber = parseInt(issueMatch[1], 10);
+    const sessionName = await findSessionNameForIssue(issueNumber);
+
+    if (!sessionName) {
+      // Session not found in AO — it may already be dead. Mark as cleaned.
+      log.info(`No AO session found for issue #${issueNumber}, marking as cleaned`, {
+        agentId: session.id,
+        issueNumber,
+      });
+      await markSessionCleaned(db, session.id);
+      continue;
+    }
+
+    const killed = await killSession(sessionName);
+    if (killed) {
+      await markSessionCleaned(db, session.id);
+    } else {
+      log.warn(`Kill failed for ${sessionName}, will retry on next sweep`, {
+        agentId: session.id,
+        session: sessionName,
+      });
+    }
+  }
+}
+
+/**
+ * Periodic sweep: find all agent sessions where the parent workflow is in a
+ * terminal state and the session hasn't been cleaned up yet.
+ */
+export async function cleanupStaleSessions(
+  db: Kysely<Database>
+): Promise<void> {
+  const terminalStatesList = Array.from(TERMINAL_STATES);
+  const stale = await getSessionsForCleanup(db, terminalStatesList);
+
+  if (stale.length === 0) return;
+
+  log.info(`Sweep found ${stale.length} stale session(s) to clean`, { count: stale.length });
+
+  // Group by workflow to avoid duplicate AO lookups
+  const byWorkflow = new Map<string, typeof stale>();
+  for (const session of stale) {
+    const list = byWorkflow.get(session.workflow_id) ?? [];
+    list.push(session);
+    byWorkflow.set(session.workflow_id, list);
+  }
+
+  for (const workflowId of byWorkflow.keys()) {
+    try {
+      await cleanupWorkflowSessions(db, workflowId);
+    } catch (err) {
+      log.error(`Cleanup failed for workflow ${workflowId}: ${err}`, { workflowId });
+    }
+  }
+}

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -47,6 +47,7 @@ export interface AgentSessionTable {
   last_heartbeat: number;
   spawned_at: number;
   completed_at: number | null;
+  cleaned_up_at: number | null;
 }
 
 export interface TransitionTable {

--- a/src/store/migrations.ts
+++ b/src/store/migrations.ts
@@ -129,4 +129,10 @@ const migrations: Migration[] = [
       await sql`ALTER TABLE workflows ADD COLUMN dependencies TEXT DEFAULT NULL`.execute(db);
     },
   },
+  {
+    name: "004_add_cleanup_columns",
+    up: async (db: Kysely<Database>) => {
+      await sql`ALTER TABLE agent_sessions ADD COLUMN cleaned_up_at INTEGER DEFAULT NULL`.execute(db);
+    },
+  },
 ];

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -185,6 +185,37 @@ export async function getStaleAgents(
     .execute();
 }
 
+// ── Cleanup ─────────────────────────────────────────────────────
+
+/**
+ * Find agent sessions eligible for cleanup: parent workflow is in a terminal
+ * state and the session has not been cleaned up yet.
+ */
+export async function getSessionsForCleanup(
+  db: Kysely<Database>,
+  terminalStates: string[]
+): Promise<AgentSessionTable[]> {
+  return db
+    .selectFrom("agent_sessions")
+    .innerJoin("workflows", "workflows.id", "agent_sessions.workflow_id")
+    .selectAll("agent_sessions")
+    .where("workflows.state", "in", terminalStates)
+    .where("agent_sessions.cleaned_up_at", "is", null)
+    .execute();
+}
+
+export async function markSessionCleaned(
+  db: Kysely<Database>,
+  agentId: string
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await db
+    .updateTable("agent_sessions")
+    .set({ cleaned_up_at: now })
+    .where("id", "=", agentId)
+    .execute();
+}
+
 // ── Transitions ─────────────────────────────────────────────────────
 
 export async function addTransition(

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Kysely } from "kysely";
+import { initDatabase, type Database } from "../src/store/database.js";
+import {
+  upsertWorkflow,
+  createAgentSession,
+  getAgentSession,
+  getSessionsForCleanup,
+  markSessionCleaned,
+  updateWorkflowState,
+} from "../src/store/queries.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+let db: Kysely<Database>;
+let dbPath: string;
+
+beforeEach(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `zapbot-cleanup-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+  db = await initDatabase(dbPath);
+});
+
+afterEach(async () => {
+  await db.destroy();
+  try { fs.unlinkSync(dbPath); } catch {}
+  try { fs.unlinkSync(dbPath + "-wal"); } catch {}
+  try { fs.unlinkSync(dbPath + "-shm"); } catch {}
+});
+
+async function createWorkflow(id: string, issueNumber: number, state: string): Promise<void> {
+  await upsertWorkflow(db, {
+    id,
+    issue_number: issueNumber,
+    repo: "owner/repo",
+    state,
+    level: "sub",
+    parent_workflow_id: null,
+    author: "tester",
+    intent: "test",
+  });
+}
+
+async function createAgent(id: string, workflowId: string, status = "running"): Promise<void> {
+  await createAgentSession(db, {
+    id,
+    workflow_id: workflowId,
+    role: "implementer",
+    worktree_path: null,
+    pr_number: null,
+  });
+  if (status !== "spawning") {
+    await db
+      .updateTable("agent_sessions")
+      .set({ status })
+      .where("id", "=", id)
+      .execute();
+  }
+}
+
+describe("cleanup queries", () => {
+  it("getSessionsForCleanup returns sessions in terminal workflow states", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-done-1", "wf-done", "completed");
+
+    await createWorkflow("wf-active", 2, "IMPLEMENTING");
+    await createAgent("agent-active-1", "wf-active", "running");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].id).toBe("agent-done-1");
+  });
+
+  it("getSessionsForCleanup excludes already-cleaned sessions", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-cleaned", "wf-done", "completed");
+    await markSessionCleaned(db, "agent-cleaned");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("markSessionCleaned sets cleaned_up_at timestamp", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-mark", "wf-done", "completed");
+
+    const before = await getAgentSession(db, "agent-mark");
+    expect(before!.cleaned_up_at).toBeNull();
+
+    await markSessionCleaned(db, "agent-mark");
+
+    const after = await getAgentSession(db, "agent-mark");
+    expect(after!.cleaned_up_at).not.toBeNull();
+    expect(after!.cleaned_up_at).toBeGreaterThan(0);
+  });
+
+  it("markSessionCleaned is idempotent", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-idem", "wf-done", "completed");
+
+    await markSessionCleaned(db, "agent-idem");
+    const first = await getAgentSession(db, "agent-idem");
+
+    await markSessionCleaned(db, "agent-idem");
+    const second = await getAgentSession(db, "agent-idem");
+
+    // Both calls set a timestamp; the second just overwrites with a new one
+    expect(first!.cleaned_up_at).not.toBeNull();
+    expect(second!.cleaned_up_at).not.toBeNull();
+  });
+
+  it("getSessionsForCleanup handles ABANDONED state", async () => {
+    await createWorkflow("wf-abandon", 3, "ABANDONED");
+    await createAgent("agent-abandon", "wf-abandon", "failed");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].id).toBe("agent-abandon");
+  });
+
+  it("getSessionsForCleanup handles COMPLETED parent state", async () => {
+    await upsertWorkflow(db, {
+      id: "wf-parent",
+      issue_number: 10,
+      repo: "owner/repo",
+      state: "COMPLETED",
+      level: "parent",
+      parent_workflow_id: null,
+      author: "tester",
+      intent: "parent",
+    });
+    await createAgent("agent-parent", "wf-parent", "timeout");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].id).toBe("agent-parent");
+  });
+
+  it("getSessionsForCleanup returns multiple sessions for one workflow", async () => {
+    await createWorkflow("wf-multi", 5, "DONE");
+    await createAgent("agent-impl", "wf-multi", "completed");
+    await createAgent("agent-qe", "wf-multi", "completed");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(2);
+    const ids = stale.map((s) => s.id).sort();
+    expect(ids).toEqual(["agent-impl", "agent-qe"]);
+  });
+
+  it("non-terminal workflows are never returned", async () => {
+    const nonTerminal = ["PLANNING", "REVIEW", "IMPLEMENTING", "DRAFT_REVIEW", "VERIFYING", "TRIAGE", "TRIAGED"];
+    for (let i = 0; i < nonTerminal.length; i++) {
+      await createWorkflow(`wf-nt-${i}`, 100 + i, nonTerminal[i]);
+      await createAgent(`agent-nt-${i}`, `wf-nt-${i}`, "running");
+    }
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds event-driven + periodic GC for dead agent sessions
- Sessions cleaned when workflows reach DONE/ABANDONED/COMPLETED
- Hourly sweep catches leaked sessions, startup sweep handles the existing 68-session backlog
- Only marks `cleaned_up_at` on successful `ao session kill` (failed kills retry)
- GC hooks in all 3 terminal-transition code paths (handleWebhook, agent-complete, checkParentCompletion)

## Files

- `src/agents/cleanup.ts` — new GC module
- `src/store/migrations.ts` — migration 004 (cleaned_up_at column)
- `src/store/database.ts` — type update
- `src/store/queries.ts` — getSessionsForCleanup, markSessionCleaned
- `bin/webhook-bridge.ts` — GC hooks + sweep interval
- `test/cleanup.test.ts` — 8 new tests

## Test plan

- [x] All 499 tests pass (491 existing + 8 new)
- [ ] Restart bridge, verify `ao session cleanup --dry-run` count drops
- [ ] Verify `du -sh ~/.worktrees/` shrinks after GC runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)