### PR TITLE
feat: gateway Supabase JWT authentication

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -1066,15 +1066,17 @@ async function main() {
   // Gateway registration (if configured)
   let gatewayCleanup: (() => Promise<void>) | null = null;
   const gatewayUrl = process.env.ZAPBOT_GATEWAY_URL;
+  const gatewayToken = process.env.ZAPBOT_GATEWAY_TOKEN;
   const gatewaySecret = process.env.ZAPBOT_GATEWAY_SECRET;
   const bridgeUrl = process.env.ZAPBOT_BRIDGE_URL;
+  const hasGatewayAuth = !!(gatewayToken || gatewaySecret);
 
-  if (gatewayUrl && gatewaySecret && bridgeUrl) {
+  if (gatewayUrl && hasGatewayAuth && bridgeUrl) {
     const repos = Array.from(repoMap.keys());
     if (repos.length > 0) {
       try {
         gatewayCleanup = await setupGateway(
-          { gatewayUrl, secret: gatewaySecret },
+          { gatewayUrl, token: gatewayToken, secret: gatewaySecret },
           repos,
           bridgeUrl,
         );
@@ -1084,7 +1086,7 @@ async function main() {
       }
     }
   } else if (gatewayUrl) {
-    log.warn("ZAPBOT_GATEWAY_URL is set but ZAPBOT_GATEWAY_SECRET or ZAPBOT_BRIDGE_URL is missing — skipping gateway registration");
+    log.warn("ZAPBOT_GATEWAY_URL is set but ZAPBOT_GATEWAY_TOKEN/ZAPBOT_GATEWAY_SECRET or ZAPBOT_BRIDGE_URL is missing — skipping gateway registration");
   }
 
   // Graceful shutdown

--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -22,6 +22,8 @@ import type { SideEffect } from "../src/state-machine/effects.js";
 import type { Workflow } from "../src/state-machine/transitions.js";
 import { spawnAgent, cancelPendingRetries, type AgentRole, type AgentFailureHandler } from "../src/agents/spawner.js";
 import { startHeartbeatChecker, stopHeartbeatChecker } from "../src/agents/heartbeat.js";
+import { cleanupWorkflowSessions, cleanupStaleSessions } from "../src/agents/cleanup.js";
+import { startProgressPoller } from "../src/agents/progress.js";
 import type { WorkflowTable } from "../src/store/database.js";
 import { createLogger } from "../src/logger.js";
 import { loadConfig, resolveWebhookSecret, type RepoMap } from "../src/config/loader.js";
@@ -362,6 +364,13 @@ async function checkParentCompletion(parentWorkflowId: string, repo: string): Pr
       trigger: "all_subs_done",
     });
     await executeSideEffects(result.sideEffects, repo);
+
+    // GC: clean up parent workflow sessions when it reaches terminal state
+    if (TERMINAL_STATES.has(result.newState)) {
+      cleanupWorkflowSessions(db, parentWorkflowId).catch((err) =>
+        log.warn(`Parent completion cleanup failed for ${parentWorkflowId}: ${err}`)
+      );
+    }
   }
 }
 
@@ -660,6 +669,13 @@ async function handleWebhook(
     }
   }
 
+  // GC: clean up agent sessions when a workflow reaches a terminal state
+  if (TERMINAL_STATES.has(result.newState)) {
+    cleanupWorkflowSessions(db, workflow.id).catch((err) =>
+      log.warn(`Post-transition cleanup failed for ${workflow.id}: ${err}`)
+    );
+  }
+
   return { status: 200, body: `${result.transition.from} → ${result.transition.to}` };
 }
 
@@ -912,6 +928,13 @@ async function main() {
                   event: event.type,
                 });
                 await executeSideEffects(result.sideEffects, wfRow.repo);
+
+                // GC: clean up sessions when agent completion triggers terminal state
+                if (TERMINAL_STATES.has(result.newState)) {
+                  cleanupWorkflowSessions(db, workflow.id).catch((err) =>
+                    log.warn(`Agent-complete cleanup failed for ${workflow.id}: ${err}`)
+                  );
+                }
               }
             }
           }
@@ -1063,6 +1086,17 @@ async function main() {
   // Periodic token cleanup (every hour)
   const tokenCleanupInterval = setInterval(pruneExpiredTokens, 60 * 60 * 1000);
 
+  // Periodic session GC sweep (every hour) — catches leaked sessions
+  const gcSweepInterval = setInterval(() => {
+    cleanupStaleSessions(db).catch((err) => log.error(`GC sweep failed: ${err}`));
+  }, 60 * 60 * 1000);
+
+  // Run initial GC sweep on startup to clean backlog
+  cleanupStaleSessions(db).catch((err) => log.error(`Initial GC sweep failed: ${err}`));
+
+  // Live agent progress poller (updates GitHub comments with task status)
+  const progressPoller = startProgressPoller(db, gh);
+
   // Gateway registration (if configured)
   let gatewayCleanup: (() => Promise<void>) | null = null;
   const gatewayUrl = process.env.ZAPBOT_GATEWAY_URL;
@@ -1097,7 +1131,9 @@ async function main() {
     log.info("Shutting down...");
     stopHeartbeatChecker();
     cancelPendingRetries();
+    progressPoller.stop();
     clearInterval(tokenCleanupInterval);
+    clearInterval(gcSweepInterval);
     if (gatewayCleanup) {
       await gatewayCleanup();
     }

--- a/bin/zapbot-team-init
+++ b/bin/zapbot-team-init
@@ -271,7 +271,13 @@ ZAPBOT_API_KEY=${GENERATED_SECRET}
 # Gateway mode (replaces ngrok): set these to register with the Railway gateway.
 # The gateway receives GitHub webhooks and forwards them to your bridge.
 # ZAPBOT_GATEWAY_URL=https://zapbot-gateway.up.railway.app
+#
+# Auth option 1 (recommended): Supabase JWT token
+# ZAPBOT_GATEWAY_TOKEN=<your Supabase JWT>
+#
+# Auth option 2 (legacy, deprecated): Shared secret
 # ZAPBOT_GATEWAY_SECRET=<must match GATEWAY_SECRET on the gateway>
+#
 # ZAPBOT_BRIDGE_URL=<public URL of this bridge, e.g. your tunnel URL>
 EOF
   echo "  Generated .env with webhook secret"
@@ -284,9 +290,10 @@ fi
 echo ""
 echo "--- Webhook setup ---"
 echo "  Option A (recommended): Use the gateway."
-echo "    1. Set ZAPBOT_GATEWAY_URL and ZAPBOT_GATEWAY_SECRET in .env"
-echo "    2. Set ZAPBOT_BRIDGE_URL to your bridge's public URL"
-echo "    3. Run ./start.sh — it registers with the gateway automatically"
+echo "    1. Set ZAPBOT_GATEWAY_URL in .env"
+echo "    2. Set ZAPBOT_GATEWAY_TOKEN (Supabase JWT) or ZAPBOT_GATEWAY_SECRET (legacy) in .env"
+echo "    3. Set ZAPBOT_BRIDGE_URL to your bridge's public URL"
+echo "    4. Run ./start.sh — it registers with the gateway automatically"
 echo ""
 echo "  Option B (legacy): Use ngrok."
 echo "    Run ./start.sh — it starts ngrok and registers GitHub webhooks automatically."

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "zap-1",
       "dependencies": {
+        "jose": "^6.2.2",
         "kysely": "^0.28.16",
         "yaml": "^2.8.3",
       },
@@ -167,6 +168,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -1,6 +1,20 @@
-# Shared secret for bridge registration authentication.
+# Supabase JWT secret for token verification.
+# Required unless GATEWAY_SECRET is set (at least one auth method needed).
+# SUPABASE_JWT_SECRET=your-jwt-secret-from-supabase-dashboard
+
+# Supabase project URL (optional). Used to validate JWT issuer claim.
+# SUPABASE_URL=https://your-project.supabase.co
+
+# Legacy shared secret for bridge registration authentication (deprecated).
 # Bridges must send this as Bearer token when registering/deregistering.
+# Migrate to Supabase JWT and set LEGACY_AUTH_ENABLED=false.
 GATEWAY_SECRET=change-me-to-a-random-secret
+
+# Set to "false" to disable legacy shared-secret auth after migrating to JWT.
+# LEGACY_AUTH_ENABLED=true
+
+# Maximum JWT age in seconds. Tokens issued longer ago are rejected.
+# JWT_MAX_AGE_SECONDS=3600
 
 # Port the gateway listens on. Railway sets this automatically.
 # PORT=8080

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "zapbot-gateway",
+      "dependencies": {
+        "jose": "^6.2.2",
+      },
       "devDependencies": {
         "bun-types": "^1.3.12",
         "typescript": "^6.0.2",
@@ -163,6 +166,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -12,5 +12,8 @@
     "bun-types": "^1.3.12",
     "typescript": "^6.0.2",
     "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "jose": "^6.2.2"
   }
 }

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -1,0 +1,306 @@
+/**
+ * Gateway authentication — JWT verification with legacy shared-secret fallback.
+ *
+ * Uses the `jose` library for direct JWT verification with SUPABASE_JWT_SECRET.
+ * No Supabase client SDK dependency — the gateway stays stateless.
+ */
+
+import { jwtVerify, errors as joseErrors } from "jose";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface GatewayUser {
+  sub: string;            // Supabase user ID (or "legacy" for shared-secret auth)
+  email?: string;
+  role: "owner" | "member";
+  authorizedRepos: string[];  // ["org/repo1", "org/repo2"] or ["*"] for legacy
+}
+
+export interface AuthConfig {
+  jwtSecret: string;              // SUPABASE_JWT_SECRET
+  jwtIssuer?: string;             // Expected JWT issuer (Supabase project URL + /auth/v1)
+  legacySecret?: string;          // GATEWAY_SECRET (backward compat)
+  legacyEnabled: boolean;         // LEGACY_AUTH_ENABLED
+  maxAgeSeconds: number;          // Max JWT age (default: 3600 = 1 hour)
+}
+
+export interface AuthError {
+  type: string;
+  message: string;
+  fix: string;
+}
+
+export type AuthResult =
+  | { ok: true; user: GatewayUser }
+  | { ok: false; error: AuthError };
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const encoder = new TextEncoder();
+
+/** Track whether we've logged the legacy deprecation warning this startup. */
+let legacyDeprecationLogged = false;
+
+/** Reset the deprecation flag — exposed for tests. */
+export function resetLegacyDeprecationFlag(): void {
+  legacyDeprecationLogged = false;
+}
+
+function authError(type: string, message: string, fix: string): AuthResult {
+  return { ok: false, error: { type, message, fix } };
+}
+
+function tokenHash(token: string): string {
+  return token.slice(0, 8);
+}
+
+// ── JWT verification ───────────────────────────────────────────────
+
+interface SupabaseJwtPayload {
+  sub?: string;
+  email?: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  iat?: number;
+  app_metadata?: {
+    role?: string;
+    authorized_repos?: string[];
+  };
+}
+
+async function verifyJwt(
+  token: string,
+  config: AuthConfig,
+): Promise<AuthResult> {
+  const secret = encoder.encode(config.jwtSecret);
+
+  let payload: SupabaseJwtPayload;
+  try {
+    const result = await jwtVerify(token, secret, {
+      algorithms: ["HS256"],
+      ...(config.jwtIssuer ? { issuer: config.jwtIssuer } : {}),
+      audience: "authenticated",
+    });
+    payload = result.payload as SupabaseJwtPayload;
+  } catch (err) {
+    if (err instanceof joseErrors.JWTExpired) {
+      return authError(
+        "token_expired",
+        `Token expired at ${err.payload?.exp ? new Date((err.payload.exp as number) * 1000).toISOString() : "unknown"}`,
+        "Refresh your Supabase JWT.",
+      );
+    }
+    if (err instanceof joseErrors.JWSSignatureVerificationFailed) {
+      return authError(
+        "invalid_signature",
+        "Token signature verification failed.",
+        "Verify SUPABASE_JWT_SECRET matches your Supabase project.",
+      );
+    }
+    if (err instanceof joseErrors.JWTClaimValidationFailed) {
+      const claim = err.claim || "unknown";
+      if (claim === "iss") {
+        return authError(
+          "invalid_issuer",
+          "Token issuer does not match expected.",
+          "Check SUPABASE_URL configuration.",
+        );
+      }
+      if (claim === "aud") {
+        return authError(
+          "invalid_audience",
+          "Token audience does not match expected.",
+          'Ensure your Supabase JWT has audience "authenticated".',
+        );
+      }
+      return authError(
+        "invalid_claims",
+        `JWT claim validation failed: ${claim}`,
+        "Check your Supabase JWT configuration.",
+      );
+    }
+    return authError(
+      "invalid_token",
+      "Token verification failed.",
+      "Ensure you are sending a valid Supabase JWT.",
+    );
+  }
+
+  // Check max age (iat must be within maxAgeSeconds)
+  if (payload.iat) {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const age = nowSeconds - payload.iat;
+    if (age > config.maxAgeSeconds) {
+      return authError(
+        "token_too_old",
+        `Token issued more than ${config.maxAgeSeconds} seconds ago.`,
+        "Obtain a fresh JWT.",
+      );
+    }
+  }
+
+  // Extract and validate claims
+  if (!payload.sub) {
+    return authError(
+      "missing_claims",
+      "Token missing required claim: sub",
+      "Ensure your Supabase JWT includes a subject claim.",
+    );
+  }
+
+  const appMeta = payload.app_metadata;
+  const role = appMeta?.role;
+  if (role !== "owner" && role !== "member") {
+    return authError(
+      "missing_claims",
+      "Token missing required claim: app_metadata.role (must be 'owner' or 'member')",
+      "Set app_metadata.role in Supabase.",
+    );
+  }
+
+  const authorizedRepos = appMeta?.authorized_repos;
+  if (!Array.isArray(authorizedRepos) || authorizedRepos.length === 0) {
+    return authError(
+      "missing_claims",
+      "Token missing required claim: app_metadata.authorized_repos",
+      "Set app_metadata.authorized_repos in Supabase.",
+    );
+  }
+
+  return {
+    ok: true,
+    user: {
+      sub: payload.sub,
+      email: payload.email,
+      role,
+      authorizedRepos,
+    },
+  };
+}
+
+// ── Legacy shared-secret verification ──────────────────────────────
+
+function verifyLegacy(token: string, config: AuthConfig): AuthResult {
+  if (!config.legacyEnabled || !config.legacySecret) {
+    return authError(
+      "invalid_token",
+      "Token verification failed.",
+      "Ensure you are sending a valid Supabase JWT.",
+    );
+  }
+
+  if (token !== config.legacySecret) {
+    return authError(
+      "invalid_signature",
+      "Token signature verification failed.",
+      "Verify SUPABASE_JWT_SECRET matches your Supabase project.",
+    );
+  }
+
+  // Log deprecation warning once per startup
+  if (!legacyDeprecationLogged) {
+    console.warn(
+      "[gateway] DEPRECATION: Legacy shared-secret auth used. Migrate to Supabase JWT. " +
+      "Set LEGACY_AUTH_ENABLED=false after migrating all bridges.",
+    );
+    legacyDeprecationLogged = true;
+  }
+
+  return {
+    ok: true,
+    user: {
+      sub: "legacy",
+      role: "owner",
+      authorizedRepos: ["*"],
+    },
+  };
+}
+
+// ── Public API ─────────────────────────────────────────────────────
+
+/**
+ * Verify an incoming request's authentication.
+ *
+ * Flow:
+ * 1. Extract Bearer token from Authorization header
+ * 2. Try JWT verification first
+ * 3. If JWT fails and legacy auth is enabled, try shared-secret check
+ * 4. Return GatewayUser on success, structured AuthError on failure
+ */
+export async function verifyRequest(
+  req: Request,
+  config: AuthConfig,
+): Promise<AuthResult> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) {
+    return authError(
+      "missing_token",
+      "No Authorization header provided.",
+      "Include `Authorization: Bearer <jwt>` header.",
+    );
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer" || !parts[1]) {
+    return authError(
+      "invalid_token_format",
+      "Authorization header must be `Bearer <token>`.",
+      "Check header format.",
+    );
+  }
+
+  const token = parts[1];
+
+  // Try JWT verification first (if jwtSecret is configured)
+  if (config.jwtSecret) {
+    const jwtResult = await verifyJwt(token, config);
+    if (jwtResult.ok) {
+      return jwtResult;
+    }
+
+    // JWT failed — try legacy if enabled
+    if (config.legacyEnabled && config.legacySecret) {
+      const legacyResult = verifyLegacy(token, config);
+      if (legacyResult.ok) {
+        return legacyResult;
+      }
+    }
+
+    // Return the JWT error (more informative than legacy error)
+    return jwtResult;
+  }
+
+  // No JWT secret configured — only legacy auth available
+  return verifyLegacy(token, config);
+}
+
+/**
+ * Check if a user has the required role.
+ * Owners satisfy both "owner" and "member" requirements.
+ */
+export function requireRole(
+  user: GatewayUser,
+  role: "owner" | "member",
+): boolean {
+  if (role === "member") return true; // Both owner and member satisfy "member"
+  return user.role === "owner";
+}
+
+/**
+ * Check if a user is authorized for a specific repo.
+ * Wildcard "*" (used by legacy auth) matches any repo.
+ */
+export function requireRepoAccess(
+  user: GatewayUser,
+  repo: string,
+): boolean {
+  if (user.authorizedRepos.includes("*")) return true;
+  if (user.authorizedRepos.includes(repo)) return true;
+
+  // Check org-level wildcard: if user has "org" authorized, it matches "org/any-repo"
+  const repoOrg = repo.split("/")[0];
+  if (repoOrg && user.authorizedRepos.includes(repoOrg)) return true;
+
+  return false;
+}

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -6,6 +6,7 @@
  */
 
 import { jwtVerify, errors as joseErrors } from "jose";
+import { timingSafeEqual } from "crypto";
 
 // ── Types ──────────────────────────────────────────────────────────
 
@@ -48,10 +49,6 @@ export function resetLegacyDeprecationFlag(): void {
 
 function authError(type: string, message: string, fix: string): AuthResult {
   return { ok: false, error: { type, message, fix } };
-}
-
-function tokenHash(token: string): string {
-  return token.slice(0, 8);
 }
 
 // ── JWT verification ───────────────────────────────────────────────
@@ -128,16 +125,21 @@ async function verifyJwt(
   }
 
   // Check max age (iat must be within maxAgeSeconds)
-  if (payload.iat) {
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    const age = nowSeconds - payload.iat;
-    if (age > config.maxAgeSeconds) {
-      return authError(
-        "token_too_old",
-        `Token issued more than ${config.maxAgeSeconds} seconds ago.`,
-        "Obtain a fresh JWT.",
-      );
-    }
+  if (payload.iat === undefined || payload.iat === null) {
+    return authError(
+      "missing_claims",
+      "Token missing required claim: iat",
+      "Ensure your Supabase JWT includes an issued-at (iat) claim.",
+    );
+  }
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const age = nowSeconds - payload.iat;
+  if (age > config.maxAgeSeconds) {
+    return authError(
+      "token_too_old",
+      `Token issued more than ${config.maxAgeSeconds} seconds ago.`,
+      "Obtain a fresh JWT.",
+    );
   }
 
   // Extract and validate claims
@@ -182,7 +184,14 @@ async function verifyJwt(
 // ── Legacy shared-secret verification ──────────────────────────────
 
 function verifyLegacy(token: string, config: AuthConfig): AuthResult {
-  if (!config.legacyEnabled || !config.legacySecret) {
+  if (!config.legacyEnabled) {
+    return authError(
+      "invalid_token",
+      "Legacy shared-secret auth is disabled.",
+      "Use a Supabase JWT for authentication.",
+    );
+  }
+  if (!config.legacySecret) {
     return authError(
       "invalid_token",
       "Token verification failed.",
@@ -190,11 +199,16 @@ function verifyLegacy(token: string, config: AuthConfig): AuthResult {
     );
   }
 
-  if (token !== config.legacySecret) {
+  const tokenBuf = encoder.encode(token);
+  const secretBuf = encoder.encode(config.legacySecret);
+  const secretsMatch =
+    tokenBuf.length === secretBuf.length &&
+    timingSafeEqual(tokenBuf, secretBuf);
+  if (!secretsMatch) {
     return authError(
-      "invalid_signature",
-      "Token signature verification failed.",
-      "Verify SUPABASE_JWT_SECRET matches your Supabase project.",
+      "invalid_token",
+      "Token verification failed.",
+      "Check your GATEWAY_SECRET or use a valid Supabase JWT.",
     );
   }
 

--- a/gateway/src/handler.ts
+++ b/gateway/src/handler.ts
@@ -14,6 +14,7 @@ import {
 import {
   verifyRequest,
   requireRole,
+  requireRepoAccess,
   type AuthConfig,
   type GatewayUser,
   type AuthError,
@@ -175,6 +176,14 @@ async function handleBridgeRegister(req: Request, authConfig: AuthConfig): Promi
     return errorResponse(400, "invalid_request", "Missing or invalid 'bridgeUrl' field.");
   }
 
+  if (!requireRepoAccess(userOrResp, repo)) {
+    return authErrorResponse({
+      type: "repo_not_authorized",
+      message: `Not authorized for repo ${repo}.`,
+      fix: "Add repo to your authorized_repos in Supabase.",
+    });
+  }
+
   const entry = registerBridge(repo, bridgeUrl);
   return Response.json({ ok: true, repo: entry.repo, registeredAt: entry.registeredAt });
 }
@@ -193,6 +202,14 @@ async function handleBridgeDeregister(req: Request, authConfig: AuthConfig): Pro
   const { repo } = body;
   if (!repo || typeof repo !== "string") {
     return errorResponse(400, "invalid_request", "Missing or invalid 'repo' field.");
+  }
+
+  if (!requireRepoAccess(userOrResp, repo)) {
+    return authErrorResponse({
+      type: "repo_not_authorized",
+      message: `Not authorized for repo ${repo}.`,
+      fix: "Add repo to your authorized_repos in Supabase.",
+    });
   }
 
   const removed = deregisterBridge(repo);

--- a/gateway/src/handler.ts
+++ b/gateway/src/handler.ts
@@ -11,28 +11,26 @@ import {
   getBridge,
   getAllBridges,
 } from "./registry.js";
+import {
+  verifyRequest,
+  requireRole,
+  type AuthConfig,
+  type GatewayUser,
+  type AuthError,
+} from "./auth.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-function errorResponse(status: number, type: string, message: string): Response {
-  return Response.json({ error: { type, message, status } }, { status });
+function errorResponse(status: number, type: string, message: string, extra?: Record<string, string>): Response {
+  return Response.json({ error: { type, message, status, ...extra } }, { status });
 }
 
-function verifyAuth(req: Request, secret: string): boolean {
-  if (!secret) return false;
-  const auth = req.headers.get("authorization");
-  return auth === `Bearer ${secret}`;
-}
-
-async function parseAuthenticatedBody(req: Request, secret: string): Promise<any | Response> {
-  if (!verifyAuth(req, secret)) {
-    return errorResponse(401, "authentication_error", "Invalid or missing gateway secret.");
-  }
-  try {
-    return await req.json();
-  } catch {
-    return errorResponse(400, "invalid_request", "Request body is not valid JSON.");
-  }
+function authErrorResponse(error: AuthError): Response {
+  const status = error.type === "insufficient_role" || error.type === "repo_not_authorized" ? 403 : 401;
+  return Response.json(
+    { error: { type: error.type, message: error.message, fix: error.fix, status } },
+    { status },
+  );
 }
 
 const FORWARDED_HEADERS = [
@@ -48,14 +46,14 @@ const FORWARDED_HEADERS = [
 // ── Config ──────────────────────────────────────────────────────────
 
 export interface GatewayConfig {
-  gatewaySecret: string;
+  authConfig: AuthConfig;
   forwardTimeoutMs: number;
 }
 
 // ── Handler factory ─────────────────────────────────────────────────
 
 export function createFetchHandler(config: GatewayConfig) {
-  const { gatewaySecret, forwardTimeoutMs } = config;
+  const { authConfig, forwardTimeoutMs } = config;
 
   return async function fetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
@@ -72,15 +70,42 @@ export function createFetchHandler(config: GatewayConfig) {
     }
 
     if (pathname === "/api/bridges/register" && req.method === "POST") {
-      return handleBridgeRegister(req, gatewaySecret);
+      return handleBridgeRegister(req, authConfig);
     }
 
     if (pathname === "/api/bridges/register" && req.method === "DELETE") {
-      return handleBridgeDeregister(req, gatewaySecret);
+      return handleBridgeDeregister(req, authConfig);
+    }
+
+    if (pathname === "/api/auth/me" && req.method === "GET") {
+      return handleAuthMe(req, authConfig);
     }
 
     return errorResponse(404, "not_found", "Resource not found.");
   };
+}
+
+// ── Auth helper ────────────────────────────────────────────────────
+
+async function authenticateRequest(
+  req: Request,
+  authConfig: AuthConfig,
+  requiredRole?: "owner" | "member",
+): Promise<GatewayUser | Response> {
+  const result = await verifyRequest(req, authConfig);
+  if (!result.ok) {
+    return authErrorResponse(result.error);
+  }
+
+  if (requiredRole && !requireRole(result.user, requiredRole)) {
+    return authErrorResponse({
+      type: "insufficient_role",
+      message: `Operation requires ${requiredRole} role, you have ${result.user.role}.`,
+      fix: "Contact bot owner for role upgrade.",
+    });
+  }
+
+  return result.user;
 }
 
 // ── Request handlers ────────────────────────────────────────────────
@@ -131,9 +156,16 @@ async function handleWebhookForward(req: Request, timeoutMs: number): Promise<Re
   }
 }
 
-async function handleBridgeRegister(req: Request, secret: string): Promise<Response> {
-  const body = await parseAuthenticatedBody(req, secret);
-  if (body instanceof Response) return body;
+async function handleBridgeRegister(req: Request, authConfig: AuthConfig): Promise<Response> {
+  const userOrResp = await authenticateRequest(req, authConfig, "owner");
+  if (userOrResp instanceof Response) return userOrResp;
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse(400, "invalid_request", "Request body is not valid JSON.");
+  }
 
   const { repo, bridgeUrl } = body;
   if (!repo || typeof repo !== "string") {
@@ -147,9 +179,16 @@ async function handleBridgeRegister(req: Request, secret: string): Promise<Respo
   return Response.json({ ok: true, repo: entry.repo, registeredAt: entry.registeredAt });
 }
 
-async function handleBridgeDeregister(req: Request, secret: string): Promise<Response> {
-  const body = await parseAuthenticatedBody(req, secret);
-  if (body instanceof Response) return body;
+async function handleBridgeDeregister(req: Request, authConfig: AuthConfig): Promise<Response> {
+  const userOrResp = await authenticateRequest(req, authConfig, "owner");
+  if (userOrResp instanceof Response) return userOrResp;
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse(400, "invalid_request", "Request body is not valid JSON.");
+  }
 
   const { repo } = body;
   if (!repo || typeof repo !== "string") {
@@ -158,4 +197,16 @@ async function handleBridgeDeregister(req: Request, secret: string): Promise<Res
 
   const removed = deregisterBridge(repo);
   return Response.json({ ok: true, removed });
+}
+
+async function handleAuthMe(req: Request, authConfig: AuthConfig): Promise<Response> {
+  const userOrResp = await authenticateRequest(req, authConfig);
+  if (userOrResp instanceof Response) return userOrResp;
+
+  return Response.json({
+    sub: userOrResp.sub,
+    email: userOrResp.email,
+    role: userOrResp.role,
+    authorizedRepos: userOrResp.authorizedRepos,
+  });
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -11,11 +11,16 @@ import {
   sweepStaleBridges,
 } from "./registry.js";
 import { createFetchHandler } from "./handler.js";
+import type { AuthConfig } from "./auth.js";
 
 // ── Config ──────────────────────────────────────────────────────────
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
+const SUPABASE_JWT_SECRET = process.env.SUPABASE_JWT_SECRET || "";
+const SUPABASE_URL = process.env.SUPABASE_URL || "";
 const GATEWAY_SECRET = process.env.GATEWAY_SECRET || "";
+const LEGACY_AUTH_ENABLED = process.env.LEGACY_AUTH_ENABLED !== "false";
+const JWT_MAX_AGE_SECONDS = parseInt(process.env.JWT_MAX_AGE_SECONDS || "3600", 10);
 const LIVENESS_INTERVAL_MS = parseInt(process.env.LIVENESS_INTERVAL_MS || "30000", 10);
 const STALE_TIMEOUT_MS = parseInt(process.env.STALE_TIMEOUT_MS || "60000", 10);
 const FORWARD_TIMEOUT_MS = parseInt(process.env.FORWARD_TIMEOUT_MS || "30000", 10);
@@ -35,15 +40,39 @@ function log(level: string, message: string, kv: Record<string, unknown> = {}): 
 
 // ── Startup validation ──────────────────────────────────────────────
 
-if (!GATEWAY_SECRET) {
-  log("error", "GATEWAY_SECRET is not set — bridge registration will be rejected. Set this env var before deploying.");
+if (!SUPABASE_JWT_SECRET && !GATEWAY_SECRET) {
+  log("error", "Either SUPABASE_JWT_SECRET or GATEWAY_SECRET must be set.");
   process.exit(1);
 }
+
+if (!SUPABASE_JWT_SECRET) {
+  log("warn", "SUPABASE_JWT_SECRET not set. Only legacy auth available.");
+}
+
+if (GATEWAY_SECRET && LEGACY_AUTH_ENABLED) {
+  log("warn", "Legacy auth enabled. Set LEGACY_AUTH_ENABLED=false after migrating bridges to JWT.");
+}
+
+log("info", "Auth config", {
+  jwt_enabled: !!SUPABASE_JWT_SECRET,
+  legacy_enabled: LEGACY_AUTH_ENABLED && !!GATEWAY_SECRET,
+  max_age_s: JWT_MAX_AGE_SECONDS,
+});
+
+// ── Auth config ────────────────────────────────────────────────────
+
+const authConfig: AuthConfig = {
+  jwtSecret: SUPABASE_JWT_SECRET,
+  jwtIssuer: SUPABASE_URL ? `${SUPABASE_URL}/auth/v1` : undefined,
+  legacySecret: GATEWAY_SECRET || undefined,
+  legacyEnabled: LEGACY_AUTH_ENABLED,
+  maxAgeSeconds: JWT_MAX_AGE_SECONDS,
+};
 
 // ── Server ──────────────────────────────────────────────────────────
 
 const handler = createFetchHandler({
-  gatewaySecret: GATEWAY_SECRET,
+  authConfig,
   forwardTimeoutMs: FORWARD_TIMEOUT_MS,
 });
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -20,7 +20,7 @@ const SUPABASE_JWT_SECRET = process.env.SUPABASE_JWT_SECRET || "";
 const SUPABASE_URL = process.env.SUPABASE_URL || "";
 const GATEWAY_SECRET = process.env.GATEWAY_SECRET || "";
 const LEGACY_AUTH_ENABLED = process.env.LEGACY_AUTH_ENABLED !== "false";
-const JWT_MAX_AGE_SECONDS = parseInt(process.env.JWT_MAX_AGE_SECONDS || "3600", 10);
+const JWT_MAX_AGE_SECONDS = parseInt(process.env.JWT_MAX_AGE_SECONDS || "3600", 10) || 3600;
 const LIVENESS_INTERVAL_MS = parseInt(process.env.LIVENESS_INTERVAL_MS || "30000", 10);
 const STALE_TIMEOUT_MS = parseInt(process.env.STALE_TIMEOUT_MS || "60000", 10);
 const FORWARD_TIMEOUT_MS = parseInt(process.env.FORWARD_TIMEOUT_MS || "30000", 10);

--- a/gateway/test/auth.test.ts
+++ b/gateway/test/auth.test.ts
@@ -29,7 +29,7 @@ function defaultConfig(overrides?: Partial<AuthConfig>): AuthConfig {
 
 async function createTestJWT(
   claims: Record<string, unknown> = {},
-  options?: { expiresIn?: string; iat?: number; secret?: string; issuer?: string; audience?: string },
+  options?: { expiresIn?: string; iat?: number; skipIat?: boolean; secret?: string; issuer?: string; audience?: string },
 ): Promise<string> {
   const secret = options?.secret || TEST_JWT_SECRET;
   const builder = new SignJWT({
@@ -46,7 +46,9 @@ async function createTestJWT(
     .setAudience(options?.audience ?? "authenticated")
     .setExpirationTime(options?.expiresIn || "1h");
 
-  if (options?.iat !== undefined) {
+  if (options?.skipIat) {
+    // Don't set iat at all
+  } else if (options?.iat !== undefined) {
     builder.setIssuedAt(options.iat);
   } else {
     builder.setIssuedAt();
@@ -177,6 +179,18 @@ describe("verifyRequest", () => {
     }
   });
 
+  // ── Missing iat ─────────────────────────────────────────────────
+
+  it("rejects a JWT without iat claim", async () => {
+    const jwt = await createTestJWT({}, { skipIat: true });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("missing_claims");
+      expect(result.error.message).toContain("iat");
+    }
+  });
+
   // ── Missing claims ───────────────────────────────────────────────
 
   it("rejects JWT without sub claim", async () => {
@@ -237,6 +251,14 @@ describe("verifyRequest", () => {
       expect(result.user.role).toBe("owner");
       expect(result.user.authorizedRepos).toEqual(["*"]);
     }
+  });
+
+  it("rejects wrong legacy secret", async () => {
+    const result = await verifyRequest(
+      makeRequest("Bearer wrong-secret"),
+      defaultConfig(),
+    );
+    expect(result.ok).toBe(false);
   });
 
   it("rejects legacy secret when disabled", async () => {

--- a/gateway/test/auth.test.ts
+++ b/gateway/test/auth.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SignJWT } from "jose";
+import {
+  verifyRequest,
+  requireRole,
+  requireRepoAccess,
+  resetLegacyDeprecationFlag,
+  type AuthConfig,
+  type GatewayUser,
+} from "../src/auth.js";
+
+// ── Test helpers ───────────────────────────────────────────────────
+
+const TEST_JWT_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+const TEST_LEGACY_SECRET = "test-legacy-secret";
+const TEST_ISSUER = "https://test.supabase.co/auth/v1";
+const encoder = new TextEncoder();
+
+function defaultConfig(overrides?: Partial<AuthConfig>): AuthConfig {
+  return {
+    jwtSecret: TEST_JWT_SECRET,
+    jwtIssuer: TEST_ISSUER,
+    legacySecret: TEST_LEGACY_SECRET,
+    legacyEnabled: true,
+    maxAgeSeconds: 3600,
+    ...overrides,
+  };
+}
+
+async function createTestJWT(
+  claims: Record<string, unknown> = {},
+  options?: { expiresIn?: string; iat?: number; secret?: string; issuer?: string; audience?: string },
+): Promise<string> {
+  const secret = options?.secret || TEST_JWT_SECRET;
+  const builder = new SignJWT({
+    sub: "user-uuid-123",
+    email: "test@example.com",
+    app_metadata: {
+      role: "owner",
+      authorized_repos: ["acme/app", "acme/lib"],
+    },
+    ...claims,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(options?.issuer ?? TEST_ISSUER)
+    .setAudience(options?.audience ?? "authenticated")
+    .setExpirationTime(options?.expiresIn || "1h");
+
+  if (options?.iat !== undefined) {
+    builder.setIssuedAt(options.iat);
+  } else {
+    builder.setIssuedAt();
+  }
+
+  return builder.sign(encoder.encode(secret));
+}
+
+function makeRequest(token?: string): Request {
+  const headers: Record<string, string> = {};
+  if (token !== undefined) {
+    headers["authorization"] = token;
+  }
+  return new Request("http://localhost/test", { headers });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetLegacyDeprecationFlag();
+});
+
+describe("verifyRequest", () => {
+  // ── Missing/malformed auth header ────────────────────────────────
+
+  it("returns missing_token when no Authorization header", async () => {
+    const result = await verifyRequest(makeRequest(), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("missing_token");
+    }
+  });
+
+  it("returns invalid_token_format for non-Bearer header", async () => {
+    const result = await verifyRequest(makeRequest("Basic abc123"), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_token_format");
+    }
+  });
+
+  it("returns invalid_token_format for Bearer with no token", async () => {
+    const result = await verifyRequest(makeRequest("Bearer "), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_token_format");
+    }
+  });
+
+  // ── Valid JWT ────────────────────────────────────────────────────
+
+  it("accepts a valid owner JWT", async () => {
+    const jwt = await createTestJWT();
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.user.sub).toBe("user-uuid-123");
+      expect(result.user.email).toBe("test@example.com");
+      expect(result.user.role).toBe("owner");
+      expect(result.user.authorizedRepos).toEqual(["acme/app", "acme/lib"]);
+    }
+  });
+
+  it("accepts a valid member JWT", async () => {
+    const jwt = await createTestJWT({
+      app_metadata: { role: "member", authorized_repos: ["acme/app"] },
+    });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.user.role).toBe("member");
+    }
+  });
+
+  // ── Expired JWT ──────────────────────────────────────────────────
+
+  it("rejects an expired JWT", async () => {
+    const jwt = await createTestJWT({}, { expiresIn: "-1h" });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("token_expired");
+    }
+  });
+
+  // ── Invalid signature ────────────────────────────────────────────
+
+  it("rejects a JWT signed with wrong secret", async () => {
+    const jwt = await createTestJWT({}, { secret: "wrong-secret-that-is-at-least-32-chars!" });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_signature");
+    }
+  });
+
+  // ── Wrong issuer ─────────────────────────────────────────────────
+
+  it("rejects a JWT with wrong issuer", async () => {
+    const jwt = await createTestJWT({}, { issuer: "https://wrong.supabase.co/auth/v1" });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_issuer");
+    }
+  });
+
+  // ── Wrong audience ───────────────────────────────────────────────
+
+  it("rejects a JWT with wrong audience", async () => {
+    const jwt = await createTestJWT({}, { audience: "wrong-audience" });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_audience");
+    }
+  });
+
+  // ── Token too old ────────────────────────────────────────────────
+
+  it("rejects a JWT that is too old (iat check)", async () => {
+    const twoHoursAgo = Math.floor(Date.now() / 1000) - 7200;
+    const jwt = await createTestJWT({}, { iat: twoHoursAgo });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("token_too_old");
+    }
+  });
+
+  // ── Missing claims ───────────────────────────────────────────────
+
+  it("rejects JWT without sub claim", async () => {
+    const jwt = await createTestJWT({ sub: undefined });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("missing_claims");
+      expect(result.error.message).toContain("sub");
+    }
+  });
+
+  it("rejects JWT without app_metadata.role", async () => {
+    const jwt = await createTestJWT({
+      app_metadata: { authorized_repos: ["acme/app"] },
+    });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("missing_claims");
+      expect(result.error.message).toContain("role");
+    }
+  });
+
+  it("rejects JWT without app_metadata.authorized_repos", async () => {
+    const jwt = await createTestJWT({
+      app_metadata: { role: "owner" },
+    });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("missing_claims");
+      expect(result.error.message).toContain("authorized_repos");
+    }
+  });
+
+  it("rejects JWT with empty authorized_repos array", async () => {
+    const jwt = await createTestJWT({
+      app_metadata: { role: "owner", authorized_repos: [] },
+    });
+    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("missing_claims");
+    }
+  });
+
+  // ── Legacy auth ──────────────────────────────────────────────────
+
+  it("accepts legacy secret when enabled", async () => {
+    const result = await verifyRequest(
+      makeRequest(`Bearer ${TEST_LEGACY_SECRET}`),
+      defaultConfig(),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.user.sub).toBe("legacy");
+      expect(result.user.role).toBe("owner");
+      expect(result.user.authorizedRepos).toEqual(["*"]);
+    }
+  });
+
+  it("rejects legacy secret when disabled", async () => {
+    const result = await verifyRequest(
+      makeRequest(`Bearer ${TEST_LEGACY_SECRET}`),
+      defaultConfig({ legacyEnabled: false }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts legacy secret when jwtSecret is empty", async () => {
+    const result = await verifyRequest(
+      makeRequest(`Bearer ${TEST_LEGACY_SECRET}`),
+      defaultConfig({ jwtSecret: "" }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.user.sub).toBe("legacy");
+    }
+  });
+
+  // ── Issuer not configured ────────────────────────────────────────
+
+  it("accepts JWT when jwtIssuer is not configured (skip issuer check)", async () => {
+    const jwt = await createTestJWT({}, { issuer: "https://any-issuer.supabase.co/auth/v1" });
+    const result = await verifyRequest(
+      makeRequest(`Bearer ${jwt}`),
+      defaultConfig({ jwtIssuer: undefined }),
+    );
+    expect(result.ok).toBe(true);
+  });
+});
+
+// ── Role checks ────────────────────────────────────────────────────
+
+describe("requireRole", () => {
+  const owner: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme/app"] };
+  const member: GatewayUser = { sub: "u2", role: "member", authorizedRepos: ["acme/app"] };
+
+  it("owner satisfies owner requirement", () => {
+    expect(requireRole(owner, "owner")).toBe(true);
+  });
+
+  it("owner satisfies member requirement", () => {
+    expect(requireRole(owner, "member")).toBe(true);
+  });
+
+  it("member satisfies member requirement", () => {
+    expect(requireRole(member, "member")).toBe(true);
+  });
+
+  it("member does not satisfy owner requirement", () => {
+    expect(requireRole(member, "owner")).toBe(false);
+  });
+});
+
+// ── Repo access checks ────────────────────────────────────────────
+
+describe("requireRepoAccess", () => {
+  it("allows access to authorized repo", () => {
+    const user: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme/app"] };
+    expect(requireRepoAccess(user, "acme/app")).toBe(true);
+  });
+
+  it("denies access to unauthorized repo", () => {
+    const user: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme/app"] };
+    expect(requireRepoAccess(user, "other/repo")).toBe(false);
+  });
+
+  it("wildcard * allows access to any repo", () => {
+    const user: GatewayUser = { sub: "legacy", role: "owner", authorizedRepos: ["*"] };
+    expect(requireRepoAccess(user, "any/repo")).toBe(true);
+  });
+
+  it("org-level access allows any repo in that org", () => {
+    const user: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme"] };
+    expect(requireRepoAccess(user, "acme/app")).toBe(true);
+    expect(requireRepoAccess(user, "acme/lib")).toBe(true);
+    expect(requireRepoAccess(user, "other/repo")).toBe(false);
+  });
+});

--- a/gateway/test/gateway-endpoints.test.ts
+++ b/gateway/test/gateway-endpoints.test.ts
@@ -293,6 +293,37 @@ describe("gateway endpoints", () => {
     expect(body.removed).toBe(false);
   });
 
+  it("POST /api/bridges/register with JWT owner for unauthorized repo returns 403", async () => {
+    const jwt = await createOwnerJWT(); // authorized for acme/app, acme/lib
+    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+      method: "POST",
+      body: JSON.stringify({ repo: "other/repo", bridgeUrl: mockBridgeUrl }),
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${jwt}`,
+      },
+    });
+    expect(resp.status).toBe(403);
+    const body = await resp.json();
+    expect(body.error.type).toBe("repo_not_authorized");
+  });
+
+  it("DELETE /api/bridges/register with JWT member returns 403", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const jwt = await createMemberJWT();
+    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+      method: "DELETE",
+      body: JSON.stringify({ repo: "acme/app" }),
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${jwt}`,
+      },
+    });
+    expect(resp.status).toBe(403);
+    const body = await resp.json();
+    expect(body.error.type).toBe("insufficient_role");
+  });
+
   // ── /api/auth/me ─────────────────────────────────────────────────
 
   it("GET /api/auth/me with valid JWT returns user info", async () => {

--- a/gateway/test/gateway-endpoints.test.ts
+++ b/gateway/test/gateway-endpoints.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { SignJWT } from "jose";
 import { clearRegistry, registerBridge, getBridge } from "../src/registry.js";
 import { createFetchHandler } from "../src/handler.js";
+import { resetLegacyDeprecationFlag, type AuthConfig } from "../src/auth.js";
 
 /**
  * Integration tests for the gateway HTTP endpoints.
@@ -10,7 +12,52 @@ import { createFetchHandler } from "../src/handler.js";
  * and startup validation that would interfere with tests).
  */
 
-const TEST_SECRET = "test-gateway-secret";
+const TEST_LEGACY_SECRET = "test-gateway-secret";
+const TEST_JWT_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+const TEST_ISSUER = "https://test.supabase.co/auth/v1";
+const encoder = new TextEncoder();
+
+const authConfig: AuthConfig = {
+  jwtSecret: TEST_JWT_SECRET,
+  jwtIssuer: TEST_ISSUER,
+  legacySecret: TEST_LEGACY_SECRET,
+  legacyEnabled: true,
+  maxAgeSeconds: 3600,
+};
+
+async function createOwnerJWT(): Promise<string> {
+  return new SignJWT({
+    sub: "user-uuid-123",
+    email: "test@example.com",
+    app_metadata: {
+      role: "owner",
+      authorized_repos: ["acme/app", "acme/lib"],
+    },
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(TEST_ISSUER)
+    .setAudience("authenticated")
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(encoder.encode(TEST_JWT_SECRET));
+}
+
+async function createMemberJWT(): Promise<string> {
+  return new SignJWT({
+    sub: "member-uuid-456",
+    email: "member@example.com",
+    app_metadata: {
+      role: "member",
+      authorized_repos: ["acme/app"],
+    },
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(TEST_ISSUER)
+    .setAudience("authenticated")
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(encoder.encode(TEST_JWT_SECRET));
+}
 
 let server: ReturnType<typeof Bun.serve>;
 let baseUrl: string;
@@ -37,7 +84,7 @@ beforeAll(() => {
 
   // Start the gateway test server using the real handler
   const handler = createFetchHandler({
-    gatewaySecret: TEST_SECRET,
+    authConfig,
     forwardTimeoutMs: 5000,
   });
 
@@ -52,6 +99,7 @@ afterAll(() => {
 
 beforeEach(() => {
   clearRegistry();
+  resetLegacyDeprecationFlag();
 });
 
 // ── Tests ───────────────────────────────────────────────────────────
@@ -86,16 +134,16 @@ describe("gateway endpoints", () => {
     });
     expect(resp.status).toBe(401);
     const body = await resp.json();
-    expect(body.error.type).toBe("authentication_error");
+    expect(body.error.type).toBe("missing_token");
   });
 
-  it("POST /api/bridges/register with auth registers bridge", async () => {
+  it("POST /api/bridges/register with legacy auth registers bridge", async () => {
     const resp = await fetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: JSON.stringify({ repo: "acme/app", bridgeUrl: mockBridgeUrl }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_SECRET}`,
+        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
       },
     });
     expect(resp.status).toBe(200);
@@ -105,13 +153,44 @@ describe("gateway endpoints", () => {
     expect(body.bridgeUrl).toBeUndefined(); // bridge URLs must not leak
   });
 
+  it("POST /api/bridges/register with JWT owner registers bridge", async () => {
+    const jwt = await createOwnerJWT();
+    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", bridgeUrl: mockBridgeUrl }),
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${jwt}`,
+      },
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.ok).toBe(true);
+    expect(body.repo).toBe("acme/app");
+  });
+
+  it("POST /api/bridges/register with JWT member returns 403", async () => {
+    const jwt = await createMemberJWT();
+    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", bridgeUrl: mockBridgeUrl }),
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${jwt}`,
+      },
+    });
+    expect(resp.status).toBe(403);
+    const body = await resp.json();
+    expect(body.error.type).toBe("insufficient_role");
+  });
+
   it("POST /api/bridges/register with missing repo returns 400", async () => {
     const resp = await fetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: JSON.stringify({ bridgeUrl: mockBridgeUrl }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_SECRET}`,
+        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
@@ -125,7 +204,7 @@ describe("gateway endpoints", () => {
       body: JSON.stringify({ repo: "acme/app" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_SECRET}`,
+        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
@@ -137,7 +216,7 @@ describe("gateway endpoints", () => {
       body: "not json{{{",
       headers: {
         "content-type": "text/plain",
-        authorization: `Bearer ${TEST_SECRET}`,
+        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
@@ -161,7 +240,7 @@ describe("gateway endpoints", () => {
       body: JSON.stringify({ repo: "acme/app" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_SECRET}`,
+        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
       },
     });
     expect(resp.status).toBe(200);
@@ -171,13 +250,30 @@ describe("gateway endpoints", () => {
     expect(getBridge("acme/app")).toBeUndefined();
   });
 
+  it("DELETE /api/bridges/register with JWT owner succeeds", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const jwt = await createOwnerJWT();
+    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+      method: "DELETE",
+      body: JSON.stringify({ repo: "acme/app" }),
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${jwt}`,
+      },
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.ok).toBe(true);
+    expect(body.removed).toBe(true);
+  });
+
   it("DELETE /api/bridges/register with missing repo returns 400", async () => {
     const resp = await fetch(`${baseUrl}/api/bridges/register`, {
       method: "DELETE",
       body: JSON.stringify({}),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_SECRET}`,
+        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
@@ -189,12 +285,42 @@ describe("gateway endpoints", () => {
       body: JSON.stringify({ repo: "unknown/repo" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_SECRET}`,
+        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
       },
     });
     expect(resp.status).toBe(200);
     const body = await resp.json();
     expect(body.removed).toBe(false);
+  });
+
+  // ── /api/auth/me ─────────────────────────────────────────────────
+
+  it("GET /api/auth/me with valid JWT returns user info", async () => {
+    const jwt = await createOwnerJWT();
+    const resp = await fetch(`${baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${jwt}` },
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.sub).toBe("user-uuid-123");
+    expect(body.email).toBe("test@example.com");
+    expect(body.role).toBe("owner");
+    expect(body.authorizedRepos).toEqual(["acme/app", "acme/lib"]);
+  });
+
+  it("GET /api/auth/me without auth returns 401", async () => {
+    const resp = await fetch(`${baseUrl}/api/auth/me`);
+    expect(resp.status).toBe(401);
+  });
+
+  it("GET /api/auth/me with legacy secret returns legacy user", async () => {
+    const resp = await fetch(`${baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${TEST_LEGACY_SECRET}` },
+    });
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.sub).toBe("legacy");
+    expect(body.role).toBe("owner");
   });
 
   // ── Webhook forwarding ────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "jose": "^6.2.2",
     "kysely": "^0.28.16",
     "yaml": "^2.8.3"
   }

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,458 @@
+<!-- /autoplan restore point: /home/tapanc/.gstack/projects/chughtapan-zapbot/feat-issue-48-autoplan-restore-20260415-214452.md -->
+# Plan: Gateway Authentication with Supabase
+
+**Issue:** #48 — Gateway authentication with Supabase
+**Parent:** #44 — Migrate to github bot + auth + railway
+**Branch:** feat/issue-48
+**Status:** REVIEWED
+
+## Problem
+
+The gateway currently uses a shared `GATEWAY_SECRET` for all authentication. Every bridge operator uses the same Bearer token. There's no per-user identity, no authorization scoping, and no way to know WHO registered a bridge or controls a workflow. For a multi-user, multi-team orchestration system, this is a non-starter.
+
+## Goal
+
+Replace shared-secret auth with Supabase JWT-based authentication. Each user gets their own identity. Bridge registration, workflow access, and admin operations are scoped by role (owner vs member) and by org/repo.
+
+## What Exists Today
+
+### Gateway (Railway-deployed)
+- `gateway/src/handler.ts` — Pure fetch handler. `verifyAuth()` checks `Bearer ${GATEWAY_SECRET}`. Used by register/deregister endpoints.
+- `gateway/src/index.ts` — Server startup. Validates `GATEWAY_SECRET` on boot, exits if missing.
+- `gateway/src/registry.ts` — In-memory bridge registry. `registerBridge()`, `getBridge()`, `sweepStaleBridges()`. No auth awareness.
+- `gateway/.env.example` — Only has `GATEWAY_SECRET`.
+
+### Bridge Client (local)
+- `src/gateway/client.ts` — `GatewayClientConfig` with `{ gatewayUrl, secret }`. Sends `Authorization: Bearer ${secret}` on register/deregister/heartbeat.
+- `bin/webhook-bridge.ts` — Reads `ZAPBOT_GATEWAY_URL`, `ZAPBOT_GATEWAY_SECRET`, `ZAPBOT_BRIDGE_URL` from env.
+
+### Tests
+- `gateway/test/gateway-endpoints.test.ts` — 14 tests covering health, register, deregister, webhook forwarding. All use `TEST_SECRET` as the shared secret.
+- `test/gateway-client.test.ts` — 5 tests covering client register/deregister/heartbeat/setup.
+
+## Approach
+
+### JWT Verification (not Supabase client SDK)
+
+Use the `jose` library for direct JWT verification with `SUPABASE_JWT_SECRET`. This avoids a runtime dependency on `@supabase/supabase-js` in the gateway, keeps the gateway stateless, and is faster (no network calls to Supabase on each request).
+
+The gateway needs to:
+1. Verify the JWT signature (HS256)
+2. Check expiration AND max age (reject JWTs with `iat` > 1 hour old)
+3. Validate issuer and audience claims
+4. Extract claims (sub, email, role, authorized repos)
+
+### Access Control
+
+Two roles:
+- **owner** — can register/deregister bridges, view all workflows, manage users
+- **member** — can view workflows for authorized repos
+
+Authorization data lives in Supabase (the `authorized_users` table with RLS). The gateway doesn't query Supabase on every request. Instead, authorized repos/orgs are encoded as custom claims in the JWT (set via Supabase's `app_metadata` or a custom hook). The gateway verifies the JWT and reads claims locally.
+
+JWT claim structure:
+```json
+{
+  "sub": "user-uuid",
+  "email": "user@example.com",
+  "iss": "https://<project>.supabase.co/auth/v1",
+  "aud": "authenticated",
+  "app_metadata": {
+    "role": "owner",
+    "authorized_repos": ["org/repo1", "org/repo2"]
+  }
+}
+```
+
+**Scaling note:** For orgs with many repos, use `authorized_orgs` claim with wildcard matching (e.g., `"authorized_orgs": ["acme"]` matches any `acme/*` repo). Repo-level claims work fine for the current scale (<10 repos per user).
+
+### Backward Compatibility
+
+The bridge client currently uses `ZAPBOT_GATEWAY_SECRET`. During migration:
+- Gateway accepts BOTH old shared-secret auth AND new JWT auth
+- Legacy auth controlled by `LEGACY_AUTH_ENABLED` env var (defaults to `true`)
+- Legacy auth creates a synthetic `GatewayUser` with `{ sub: "legacy", role: "owner", authorizedRepos: ["*"] }`
+- Every legacy auth usage is logged with a deprecation warning
+- New env var: `ZAPBOT_GATEWAY_TOKEN` for JWT-based auth on the bridge side
+- **Sunset target:** Remove legacy auth support after all bridges migrate to JWT (target: 30 days after deploy)
+
+### Design Decisions
+
+**Webhook forwarding remains unauthenticated.** The `/api/webhooks/github` endpoint does NOT require auth at the gateway. GitHub webhook signature verification happens at the bridge level (`bin/webhook-bridge.ts:766`), not the gateway. The gateway is a stateless proxy that doesn't know per-repo webhook secrets. An attacker crafting payloads would fail at the bridge's HMAC verification.
+
+**Bridges use regular user JWTs, not service role tokens.** Service role tokens bypass all Supabase RLS, which defeats per-user auth. Bridges should authenticate as a specific user (the bot owner) with `owner` role. If the JWT expires, the bridge logs a warning on the next heartbeat but doesn't crash (existing `heartbeat()` error handling in `client.ts:119-125`).
+
+## Implementation Plan
+
+### Phase 1: Gateway JWT Middleware
+
+**Files:**
+- NEW: `gateway/src/auth.ts` — JWT verification module
+- MODIFY: `gateway/src/handler.ts` — Replace `verifyAuth` with JWT-aware auth
+- MODIFY: `gateway/src/index.ts` — Add Supabase env var validation
+- MODIFY: `gateway/.env.example` — Add Supabase env vars
+- MODIFY: `gateway/package.json` — Add `jose` dependency
+
+**`gateway/src/auth.ts`:**
+```typescript
+import { jwtVerify, type JWTPayload } from "jose";
+
+export interface GatewayUser {
+  sub: string;           // Supabase user ID (or "legacy" for shared-secret auth)
+  email?: string;
+  role: "owner" | "member";
+  authorizedRepos: string[];  // ["org/repo1", "org/repo2"] or ["*"] for legacy
+}
+
+export interface AuthConfig {
+  jwtSecret: string;              // SUPABASE_JWT_SECRET
+  jwtIssuer?: string;             // Expected JWT issuer (Supabase project URL)
+  legacySecret?: string;          // GATEWAY_SECRET (backward compat)
+  legacyEnabled: boolean;         // LEGACY_AUTH_ENABLED
+  maxAgeSeconds: number;          // Max JWT age (default: 3600 = 1 hour)
+}
+
+export type AuthResult =
+  | { ok: true; user: GatewayUser }
+  | { ok: false; error: AuthError };
+
+export interface AuthError {
+  type: string;           // e.g. "token_expired", "invalid_signature"
+  message: string;        // Human-readable description
+  fix: string;            // Actionable fix instruction
+}
+
+export async function verifyRequest(
+  req: Request,
+  config: AuthConfig,
+): Promise<AuthResult>;
+
+export function requireRole(
+  user: GatewayUser,
+  role: "owner" | "member",
+): boolean;
+
+export function requireRepoAccess(
+  user: GatewayUser,
+  repo: string,
+): boolean;
+```
+
+**Auth flow:**
+1. Extract `Authorization: Bearer <token>` header
+2. Try JWT verification first (jose `jwtVerify` with SUPABASE_JWT_SECRET)
+   - Validate signature (HS256)
+   - Check expiration (`exp`)
+   - Check max age (`iat` must be within `maxAgeSeconds`)
+   - Validate issuer (`iss`) and audience (`aud: "authenticated"`)
+   - Extract claims from `app_metadata`
+3. If JWT verification fails AND `legacyEnabled` is true, try legacy shared-secret check
+4. Legacy auth returns synthetic `GatewayUser { sub: "legacy", role: "owner", authorizedRepos: ["*"] }`
+5. Log auth results: success (sub, email, role) or failure (type, truncated token hash)
+6. NEVER log full JWT values
+
+**Error responses (structured):**
+
+| Error Type | HTTP | Message | Fix |
+|---|---|---|---|
+| `missing_token` | 401 | No Authorization header provided | Include `Authorization: Bearer <jwt>` header |
+| `invalid_token_format` | 401 | Authorization header must be `Bearer <token>` | Check header format |
+| `invalid_signature` | 401 | Token signature verification failed | Verify SUPABASE_JWT_SECRET matches your Supabase project |
+| `token_expired` | 401 | Token expired at {timestamp} | Refresh your Supabase JWT |
+| `token_too_old` | 401 | Token issued more than 1 hour ago | Obtain a fresh JWT |
+| `invalid_issuer` | 401 | Token issuer does not match expected | Check SUPABASE_URL configuration |
+| `missing_claims` | 401 | Token missing required claims: {list} | Set app_metadata.role and app_metadata.authorized_repos in Supabase |
+| `insufficient_role` | 403 | Operation requires {required} role, you have {actual} | Contact bot owner for role upgrade |
+| `repo_not_authorized` | 403 | Not authorized for repo {repo} | Add repo to your authorized_repos in Supabase |
+
+**`handler.ts` changes:**
+- Remove `verifyAuth()` and `parseAuthenticatedBody()`
+- `GatewayConfig` gets new `authConfig: AuthConfig` field (replaces `gatewaySecret: string`)
+- Register endpoint: verify auth, check `owner` role
+- Deregister endpoint: verify auth, check `owner` role
+- NEW: `GET /api/auth/me` endpoint: verify auth, return user info (for token validation)
+- `/healthz` and `/api/webhooks/github`: no auth (unchanged)
+
+### Phase 2: Bridge Client Updates
+
+**Files:**
+- MODIFY: `src/gateway/client.ts` — Support JWT token in addition to shared secret
+- MODIFY: `bin/webhook-bridge.ts` — Read `ZAPBOT_GATEWAY_TOKEN` env var
+
+**`GatewayClientConfig` changes:**
+```typescript
+export interface GatewayClientConfig {
+  gatewayUrl: string;
+  secret?: string;      // Legacy: ZAPBOT_GATEWAY_SECRET
+  token?: string;       // New: ZAPBOT_GATEWAY_TOKEN (Supabase JWT)
+}
+```
+
+Token selection: use `token` if set, fall back to `secret`. The `Authorization` header is `Bearer <value>` either way, so the wire format doesn't change.
+
+**`bin/webhook-bridge.ts` changes:**
+```typescript
+// Before
+const gatewaySecret = process.env.ZAPBOT_GATEWAY_SECRET;
+
+// After
+const gatewayToken = process.env.ZAPBOT_GATEWAY_TOKEN;
+const gatewaySecret = process.env.ZAPBOT_GATEWAY_SECRET;
+// ...
+const config = {
+  gatewayUrl,
+  token: gatewayToken,      // JWT takes precedence
+  secret: gatewaySecret,    // Legacy fallback
+};
+```
+
+### Phase 3: Environment & Config
+
+**Gateway env vars (new):**
+- `SUPABASE_JWT_SECRET` — Required for JWT verification. Gateway exits on startup if missing AND `GATEWAY_SECRET` is also missing (at least one auth method required).
+- `SUPABASE_URL` — Optional. Used to derive expected JWT issuer (`{SUPABASE_URL}/auth/v1`).
+- `LEGACY_AUTH_ENABLED` — Optional, defaults to `true`. Set to `false` to disable shared-secret auth.
+- `JWT_MAX_AGE_SECONDS` — Optional, defaults to `3600`. Maximum JWT age in seconds.
+
+**Bridge env vars (new):**
+- `ZAPBOT_GATEWAY_TOKEN` — Supabase JWT for bridge auth. Takes precedence over `ZAPBOT_GATEWAY_SECRET`.
+
+**Backward compatibility:**
+- `GATEWAY_SECRET` still works when `LEGACY_AUTH_ENABLED=true`
+- `ZAPBOT_GATEWAY_SECRET` still works on the bridge side
+- Gateway logs a deprecation warning on FIRST legacy auth usage per startup
+
+**Startup validation in `index.ts`:**
+```typescript
+const SUPABASE_JWT_SECRET = process.env.SUPABASE_JWT_SECRET || "";
+const GATEWAY_SECRET = process.env.GATEWAY_SECRET || "";
+const LEGACY_AUTH_ENABLED = process.env.LEGACY_AUTH_ENABLED !== "false";
+
+if (!SUPABASE_JWT_SECRET && !GATEWAY_SECRET) {
+  log("error", "Either SUPABASE_JWT_SECRET or GATEWAY_SECRET must be set.");
+  process.exit(1);
+}
+
+if (!SUPABASE_JWT_SECRET) {
+  log("warn", "SUPABASE_JWT_SECRET not set. Only legacy auth available.");
+}
+
+if (GATEWAY_SECRET && LEGACY_AUTH_ENABLED) {
+  log("warn", "Legacy auth enabled. Set LEGACY_AUTH_ENABLED=false after migrating bridges to JWT.");
+}
+```
+
+### Phase 4: Tests
+
+**Files:**
+- NEW: `gateway/test/auth.test.ts` — Unit tests for JWT verification
+- MODIFY: `gateway/test/gateway-endpoints.test.ts` — Add JWT auth tests
+- MODIFY: `test/gateway-client.test.ts` — Test token-based auth
+
+**Test JWT generation helper:**
+```typescript
+import { SignJWT } from "jose";
+
+const TEST_JWT_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+const encoder = new TextEncoder();
+
+async function createTestJWT(
+  claims: Record<string, unknown>,
+  options?: { expiresIn?: string; iat?: number }
+) {
+  const builder = new SignJWT(claims)
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer("https://test.supabase.co/auth/v1")
+    .setAudience("authenticated")
+    .setExpirationTime(options?.expiresIn || "1h");
+
+  if (options?.iat) {
+    builder.setIssuedAt(options.iat);
+  } else {
+    builder.setIssuedAt();
+  }
+
+  return builder.sign(encoder.encode(TEST_JWT_SECRET));
+}
+```
+
+**Test cases: `gateway/test/auth.test.ts` (19 tests)**
+See test plan artifact for full list. Key coverage:
+- JWT: valid owner, valid member, expired, invalid sig, wrong issuer, wrong audience, too old, missing claims
+- Legacy: success when enabled, rejected when disabled
+- Role checks: owner passes, member blocked for owner-only ops
+- Repo access: authorized passes, unauthorized blocked, owner bypasses
+
+**Test cases: `gateway/test/gateway-endpoints.test.ts` (10 new tests)**
+- Register/deregister with JWT owner (200), JWT member (403), legacy (200), no auth (401)
+- `/api/auth/me` with valid JWT, expired JWT
+- Existing unauthenticated endpoints remain accessible
+
+**Test cases: `test/gateway-client.test.ts` (4 new tests)**
+- Register with JWT token, register with legacy secret, token takes precedence, heartbeat with expired JWT
+
+### Phase 5: team-init Updates
+
+**Files:**
+- MODIFY: `bin/zapbot-team-init` — Prompt for gateway auth method during setup
+
+**Changes:**
+- Add question: "Gateway auth: (1) Supabase JWT token, (2) Shared secret (legacy)"
+- If JWT: write `ZAPBOT_GATEWAY_TOKEN=<token>` to .env
+- If shared secret: write `ZAPBOT_GATEWAY_SECRET=<secret>` to .env (existing behavior)
+
+## Quick Start
+
+### Gateway Setup
+```bash
+# 1. Set env vars on Railway
+SUPABASE_JWT_SECRET=your-jwt-secret-from-supabase-dashboard
+GATEWAY_SECRET=your-existing-shared-secret  # Keep for backward compat
+LEGACY_AUTH_ENABLED=true                     # Enable during migration
+
+# 2. Deploy
+railway up
+```
+
+### Bridge Setup
+```bash
+# In your bridge's .env:
+ZAPBOT_GATEWAY_URL=https://zapbot-gateway.up.railway.app
+ZAPBOT_GATEWAY_TOKEN=eyJhbGciOiJIUzI1NiIs...  # Your Supabase JWT
+
+# Or legacy (deprecated):
+# ZAPBOT_GATEWAY_SECRET=your-shared-secret
+```
+
+### Verify Token
+```bash
+# Test your JWT with the /api/auth/me endpoint
+curl -H "Authorization: Bearer $ZAPBOT_GATEWAY_TOKEN" \
+  https://zapbot-gateway.up.railway.app/api/auth/me
+
+# Expected response:
+# { "sub": "user-uuid", "email": "you@example.com", "role": "owner" }
+```
+
+### Register a Bridge
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $ZAPBOT_GATEWAY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"repo":"org/repo","bridgeUrl":"http://your-bridge:3000"}' \
+  https://zapbot-gateway.up.railway.app/api/bridges/register
+
+# Expected: { "ok": true, "repo": "org/repo", "registeredAt": 1234567890 }
+```
+
+## Out of Scope
+
+- Supabase project creation/configuration (external setup, Supabase dashboard)
+- `authorized_users` table schema and RLS policies (Supabase dashboard)
+- GitHub OAuth provider configuration (Supabase dashboard)
+- GitHub App installation tokens as auth mechanism (separate sub-issue per #44)
+- API key auth for CI/CD (future PR, auth module is extensible)
+- Rate limiting per user (future PR)
+- Multi-tenant data model (parent issue #44 concern)
+- Configurable JWT claim paths (defer until needed, `GatewayUser` interface is the extension point)
+
+## Dependencies
+
+- `jose` npm package (JWT verification, ~15KB, zero dependencies, well-maintained, standard)
+- Supabase project with JWT secret configured (external dependency)
+
+## Risks
+
+1. **JWT expiration during heartbeat** — Bridge JWT expires between heartbeats. Mitigation: bridges use regular user JWTs (not service role tokens). The existing `heartbeat()` catches errors and warns. Bridge operators should set JWT expiry > 1 hour.
+2. **Backward compatibility breakage** — Existing deployments use shared-secret auth. Mitigation: dual-mode auth with `LEGACY_AUTH_ENABLED` flag. Legacy creates synthetic `GatewayUser` so all code paths are uniform.
+3. **Custom claims dependency** — Relying on `app_metadata` for repo authorization couples to Supabase's JWT structure. Mitigation: abstract behind `GatewayUser` interface, easy to swap claim source.
+4. **Stale authorization in JWT claims** — If repo access is revoked in Supabase, the JWT still carries old claims until it expires. Mitigation: `maxAgeSeconds` check (default 1 hour) limits the window. For immediate revocation, deploy a blocklist (future PR).
+
+## Architecture Diagram
+
+```
+                    ┌─────────────────────┐
+                    │   GitHub Webhooks    │
+                    └──────────┬──────────┘
+                               │ POST /api/webhooks/github
+                               │ (no auth, signature verified at bridge)
+                               ▼
+┌──────────┐    ┌─────────────────────────────────┐
+│ Supabase │    │     Railway Gateway              │
+│  Auth    │    │  ┌─────────┐  ┌──────────────┐  │
+│ (issues  │    │  │ auth.ts │  │  handler.ts   │  │
+│  JWTs)   │    │  │ verify  │──│  route        │  │
+└──────────┘    │  │ JWT     │  │  dispatch     │  │
+                │  │ + legacy│  └──────┬───────┘  │
+                │  └─────────┘         │           │
+                │  ┌──────────────────┐│           │
+                │  │  registry.ts     ││           │
+                │  │  bridge map      │◄           │
+                │  └────────┬─────────┘            │
+                └───────────┼──────────────────────┘
+                            │ forward webhook
+                            ▼
+                ┌───────────────────────┐
+                │   Local Bridge        │
+                │   (webhook-bridge.ts) │
+                │   Auth: Bearer JWT    │
+                │   via client.ts       │
+                └───────────────────────┘
+```
+
+**Auth boundary:**
+- `/healthz` — No auth (public health check)
+- `/api/webhooks/github` — No auth (GitHub sig verification at bridge)
+- `/api/bridges/register` — JWT required, `owner` role required
+- `/api/bridges/register` (DELETE) — JWT required, `owner` role required
+- `/api/auth/me` — JWT required (any role)
+
+## Observability
+
+**Structured log lines:**
+- `auth.verify: success` — `{ sub, email, role, repo_count, method: "jwt" | "legacy" }`
+- `auth.verify: failed` — `{ type, method: "jwt" | "legacy", token_hash: first_8_chars }`
+- `auth.legacy: deprecation` — Logged once per startup when legacy auth is used
+- `auth.startup: config` — `{ jwt_enabled, legacy_enabled, max_age_s }`
+
+<!-- AUTONOMOUS DECISION LOG -->
+## Decision Audit Trail
+
+| # | Phase | Decision | Classification | Principle | Rationale | Rejected |
+|---|-------|----------|---------------|-----------|-----------|----------|
+| 1 | CEO | Approach A (jose) over B (Supabase SDK) and C (proxy auth) | Mechanical | P5, P3 | Simplest, fastest, zero external deps at request time | B (SDK weight), C (no repo authz) |
+| 2 | CEO | SELECTIVE EXPANSION mode | Mechanical | P6 | Feature enhancement on existing system | — |
+| 3 | CEO | Include audit logging of auth events | Mechanical | P1, P2 | Auth events MUST be logged, ~15 LOC, in blast radius | — |
+| 4 | CEO | Include /api/auth/me endpoint | Mechanical | P1 | Useful for DX, ~10 LOC, lets operators verify tokens | — |
+| 5 | CEO | Defer API key auth for CI/CD | Mechanical | P3 | Not needed for v1, auth module is extensible | — |
+| 6 | CEO | Defer rate limiting | Mechanical | P3 | Out of scope per issue | — |
+| 7 | CEO | Defer token refresh mechanism | Mechanical | P3 | Bridges use long-lived user tokens | — |
+| 8 | CEO | Accept Supabase as specified (not GitHub App tokens) | Taste | P6 | Parent issue #44 explicitly separates these. GatewayUser interface makes swap easy | GitHub App tokens |
+| 9 | Eng | Add max_age JWT check (1 hour) | Mechanical | P1 | Limits stale authorization window | — |
+| 10 | Eng | Add LEGACY_AUTH_ENABLED env var | Mechanical | P5, P1 | Explicit kill switch for legacy backdoor | — |
+| 11 | Eng | Synthetic GatewayUser for legacy auth | Mechanical | P5, P4 | Eliminates dual code paths, single type everywhere | Separate AuthResult variant |
+| 12 | Eng | Webhook path stays unauthenticated | Mechanical | P5 | Bridge verifies HMAC, gateway doesn't know secrets | Gateway-level HMAC check |
+| 13 | Eng | Add issuer/audience validation | Mechanical | P1 | jose accepts any valid JWT by default without these | — |
+| 14 | Eng | Add org-level claims doc | Taste | P3 | Document scaling path without implementing | Implement org claims now |
+| 15 | DX | Add Quick Start section | Mechanical | P1 | Zero guidance = critical DX gap | — |
+| 16 | DX | Add structured error responses | Mechanical | P1, P5 | Auth errors must be actionable | — |
+| 17 | DX | Keep existing env var names | Mechanical | P3 | Renaming breaks existing deployments | New naming scheme |
+| 18 | DX | Defer configurable claim paths | Mechanical | P5, P3 | Over-engineering, GatewayUser is the extension point | JWT_ROLE_CLAIM_PATH env var |
+
+## Cross-Phase Themes
+
+**Theme: Stale authorization claims** — Flagged in CEO (custom claims dependency) and Eng (JWT TOCTOU). High-confidence signal. Mitigated by max_age check and documented as a known limitation with blocklist as future work.
+
+**Theme: Legacy auth as security risk** — Flagged in CEO (backward compatibility) and Eng (permanent backdoor). Mitigated by LEGACY_AUTH_ENABLED kill switch and sunset target.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 1 | clean | 6 subagent findings, all resolved |
+| Codex Review | `codex exec` | Independent 2nd opinion | 0 | unavailable | Codex timed out in all phases |
+| Eng Review | `/plan-eng-review` | Architecture & tests | 1 | clean | 6 subagent findings, all resolved |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | skipped | No UI scope detected |
+| DX Review | `/plan-devex-review` | Developer experience | 1 | clean | 5 subagent findings, 4 resolved, 1 deferred |
+
+**VERDICT:** REVIEWED — 3 phases complete (CEO, Eng, DX). 17 findings total, 16 resolved, 1 deferred (configurable claim paths). Plan is ready for human review.

--- a/src/agents/cleanup.ts
+++ b/src/agents/cleanup.ts
@@ -1,0 +1,157 @@
+import { Kysely } from "kysely";
+import type { Database } from "../store/database.js";
+import { getSessionsForCleanup, markSessionCleaned, getAgentSessions } from "../store/queries.js";
+import { TERMINAL_STATES } from "../state-machine/states.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("cleanup");
+
+const KILL_TIMEOUT_MS = 10_000;
+
+/**
+ * Kill an AO session by name. Returns true if the kill succeeded (exit 0).
+ * Swallows errors and returns false on failure or timeout.
+ */
+async function killSession(sessionName: string): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["ao", "session", "kill", sessionName], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const timeoutPromise = new Promise<number>((resolve) =>
+      setTimeout(() => {
+        proc.kill();
+        resolve(-1);
+      }, KILL_TIMEOUT_MS)
+    );
+
+    const exitCode = await Promise.race([proc.exited, timeoutPromise]);
+
+    if (exitCode === 0) {
+      log.info(`Killed session ${sessionName}`, { session: sessionName });
+      return true;
+    }
+
+    const stderr = await new Response(proc.stderr).text().catch(() => "");
+    log.warn(`ao session kill ${sessionName} exited with code ${exitCode}: ${stderr.trim()}`, {
+      session: sessionName,
+      exitCode,
+    });
+    return false;
+  } catch (err) {
+    log.warn(`Failed to kill session ${sessionName}: ${err}`, { session: sessionName });
+    return false;
+  }
+}
+
+/**
+ * Find the AO session name for a given issue number by parsing `ao session ls` output.
+ * Looks for lines containing the branch pattern `feat/issue-{N}`.
+ */
+async function findSessionNameForIssue(issueNumber: number): Promise<string | null> {
+  const branch = `feat/issue-${issueNumber}`;
+
+  for (const cmd of [["ao", "session", "ls"], ["ao", "status"]]) {
+    try {
+      const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
+      const stdout = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) continue;
+
+      for (const line of stdout.split("\n")) {
+        if (line.includes(branch)) {
+          const match = line.match(/(zap-\d+)/);
+          if (match) return match[1];
+        }
+      }
+    } catch {
+      // Command failed, try next
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Clean up all agent sessions for a given workflow.
+ * Kills the AO session and marks the agent session as cleaned.
+ * Only marks cleaned_up_at on successful kill.
+ */
+export async function cleanupWorkflowSessions(
+  db: Kysely<Database>,
+  workflowId: string
+): Promise<void> {
+  const sessions = await getAgentSessions(db, workflowId);
+  const uncleaned = sessions.filter((s) => s.cleaned_up_at === null);
+
+  if (uncleaned.length === 0) return;
+
+  log.info(`Cleaning up ${uncleaned.length} session(s) for workflow ${workflowId}`, {
+    workflowId,
+    count: uncleaned.length,
+  });
+
+  for (const session of uncleaned) {
+    // Extract issue number from workflow ID (format: "wf-{issueNumber}")
+    const issueMatch = workflowId.match(/^wf-(\d+)/);
+    if (!issueMatch) {
+      log.warn(`Cannot parse issue number from workflow ${workflowId}`, { workflowId });
+      continue;
+    }
+
+    const issueNumber = parseInt(issueMatch[1], 10);
+    const sessionName = await findSessionNameForIssue(issueNumber);
+
+    if (!sessionName) {
+      // Session not found in AO — it may already be dead. Mark as cleaned.
+      log.info(`No AO session found for issue #${issueNumber}, marking as cleaned`, {
+        agentId: session.id,
+        issueNumber,
+      });
+      await markSessionCleaned(db, session.id);
+      continue;
+    }
+
+    const killed = await killSession(sessionName);
+    if (killed) {
+      await markSessionCleaned(db, session.id);
+    } else {
+      log.warn(`Kill failed for ${sessionName}, will retry on next sweep`, {
+        agentId: session.id,
+        session: sessionName,
+      });
+    }
+  }
+}
+
+/**
+ * Periodic sweep: find all agent sessions where the parent workflow is in a
+ * terminal state and the session hasn't been cleaned up yet.
+ */
+export async function cleanupStaleSessions(
+  db: Kysely<Database>
+): Promise<void> {
+  const terminalStatesList = Array.from(TERMINAL_STATES);
+  const stale = await getSessionsForCleanup(db, terminalStatesList);
+
+  if (stale.length === 0) return;
+
+  log.info(`Sweep found ${stale.length} stale session(s) to clean`, { count: stale.length });
+
+  // Group by workflow to avoid duplicate AO lookups
+  const byWorkflow = new Map<string, typeof stale>();
+  for (const session of stale) {
+    const list = byWorkflow.get(session.workflow_id) ?? [];
+    list.push(session);
+    byWorkflow.set(session.workflow_id, list);
+  }
+
+  for (const workflowId of byWorkflow.keys()) {
+    try {
+      await cleanupWorkflowSessions(db, workflowId);
+    } catch (err) {
+      log.error(`Cleanup failed for workflow ${workflowId}: ${err}`, { workflowId });
+    }
+  }
+}

--- a/src/agents/progress.ts
+++ b/src/agents/progress.ts
@@ -1,0 +1,262 @@
+import { Kysely } from "kysely";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import type { Database } from "../store/database.js";
+import { getActiveWorkflowsWithAgents, updateProgressCommentId } from "../store/queries.js";
+import { TERMINAL_STATES } from "../state-machine/states.js";
+import { toClaudeProjectPath } from "./spawner.js";
+import type { GitHubClient } from "../github/client.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("progress");
+
+// ── Task file types ─────────────────────────────────────────────
+
+export interface AgentTask {
+  id: string;
+  subject: string;
+  activeForm: string;
+  status: "pending" | "in_progress" | "completed";
+  blocks: string[];
+  blockedBy: string[];
+}
+
+function isValidTask(obj: unknown): obj is AgentTask {
+  if (typeof obj !== "object" || obj === null) return false;
+  const t = obj as Record<string, unknown>;
+  return (
+    typeof t.id === "string" &&
+    typeof t.subject === "string" &&
+    typeof t.status === "string" &&
+    ["pending", "in_progress", "completed"].includes(t.status as string)
+  );
+}
+
+// ── Task file reading ───────────────────────────────────────────
+
+/**
+ * Given a Claude session UUID, read all task files from ~/.claude/tasks/{UUID}/.
+ * Returns parsed tasks sorted by ID. Handles missing dirs and corrupt files.
+ */
+export async function readAgentTasks(sessionUUID: string): Promise<AgentTask[]> {
+  const taskDir = path.join(os.homedir(), ".claude", "tasks", sessionUUID);
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(taskDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const taskFiles = entries
+    .filter((e) => e.isFile() && /^\d+\.json$/.test(e.name))
+    .sort((a, b) => parseInt(a.name) - parseInt(b.name));
+
+  const tasks: AgentTask[] = [];
+  for (const file of taskFiles) {
+    try {
+      const content = await fs.promises.readFile(path.join(taskDir, file.name), "utf-8");
+      const parsed = JSON.parse(content);
+      if (isValidTask(parsed)) {
+        tasks.push({
+          id: parsed.id,
+          subject: parsed.subject,
+          activeForm: parsed.activeForm || "",
+          status: parsed.status,
+          blocks: Array.isArray(parsed.blocks) ? parsed.blocks : [],
+          blockedBy: Array.isArray(parsed.blockedBy) ? parsed.blockedBy : [],
+        });
+      } else {
+        log.warn(`Invalid task file ${file.name} in session ${sessionUUID}`);
+      }
+    } catch (err) {
+      log.warn(`Failed to read task file ${file.name} in session ${sessionUUID}: ${err}`);
+    }
+  }
+
+  return tasks;
+}
+
+/**
+ * Re-resolve the Claude session UUID from a worktree path.
+ * Used as a fallback when the stored claude_session_id is stale.
+ */
+export async function resolveClaudeSessionFromWorktree(worktreePath: string): Promise<string | null> {
+  const encoded = toClaudeProjectPath(worktreePath);
+  const projectDir = path.join(os.homedir(), ".claude", "projects", encoded);
+
+  try {
+    const entries = await fs.promises.readdir(projectDir, { withFileTypes: true });
+    const jsonlFiles = await Promise.all(
+      entries
+        .filter((e) => e.isFile() && e.name.endsWith(".jsonl") && !e.name.startsWith("agent-"))
+        .map(async (e) => {
+          const stat = await fs.promises.stat(path.join(projectDir, e.name));
+          return { name: e.name, mtimeMs: stat.mtimeMs };
+        })
+    );
+    jsonlFiles.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    if (jsonlFiles.length === 0) return null;
+    return jsonlFiles[0].name.replace(".jsonl", "");
+  } catch {
+    return null;
+  }
+}
+
+// ── Comment formatting ──────────────────────────────────────────
+
+export function formatProgressComment(role: string, tasks: AgentTask[]): string {
+  const lines: string[] = [`**${role}** agent progress`];
+
+  if (tasks.length === 0) {
+    lines.push("", "_Agent is working..._");
+    return lines.join("\n");
+  }
+
+  lines.push("");
+  for (const task of tasks) {
+    const checked = task.status === "completed" ? "x" : " ";
+    const suffix = task.status === "in_progress" ? " ← working" : "";
+    lines.push(`- [${checked}] ${task.subject}${suffix}`);
+  }
+
+  const completed = tasks.filter((t) => t.status === "completed").length;
+  lines.push("", `${completed}/${tasks.length} done`);
+
+  return lines.join("\n");
+}
+
+export function formatFinalComment(role: string, tasks: AgentTask[], outcome: string): string {
+  return formatProgressComment(role, tasks) + `\n\n**${outcome}**`;
+}
+
+// ── Polling loop ───────��────────────────────────────────────────
+
+/** In-memory cache of last-seen task state per workflow to avoid unnecessary API calls. */
+const lastTaskHash = new Map<string, string>();
+
+function hashTasks(tasks: AgentTask[]): string {
+  return tasks.map((t) => `${t.id}:${t.status}`).join(",");
+}
+
+/**
+ * One-time backfill: resolve worktree_path for running agents that have null values
+ * (spawned before the worktree tracking fix).
+ */
+async function backfillWorktreePaths(db: Kysely<Database>): Promise<void> {
+  const agents = await db
+    .selectFrom("agent_sessions")
+    .innerJoin("workflows", "workflows.id", "agent_sessions.workflow_id")
+    .select(["agent_sessions.id", "agent_sessions.workflow_id", "workflows.issue_number"])
+    .where("agent_sessions.status", "in", ["running", "spawning"])
+    .where("agent_sessions.worktree_path", "is", null)
+    .execute();
+
+  if (agents.length === 0) return;
+
+  log.info(`Backfilling worktree_path for ${agents.length} agent(s)`);
+
+  for (const agent of agents) {
+    const branch = `feat/issue-${agent.issue_number}`;
+    try {
+      const proc = Bun.spawn(["git", "worktree", "list", "--porcelain"], { stdout: "pipe", stderr: "pipe" });
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+      for (const block of stdout.split("\n\n")) {
+        if (!block.includes(`refs/heads/${branch}`)) continue;
+        const wtLine = block.split("\n").find((l) => l.startsWith("worktree "));
+        if (wtLine) {
+          const wtPath = wtLine.slice("worktree ".length);
+          await db
+            .updateTable("agent_sessions")
+            .set({ worktree_path: wtPath })
+            .where("id", "=", agent.id)
+            .execute();
+          log.info(`Backfilled worktree_path for ${agent.id}: ${wtPath}`, { agentId: agent.id });
+          break;
+        }
+      }
+    } catch (err) {
+      log.warn(`Failed to backfill worktree_path for ${agent.id}: ${err}`);
+    }
+  }
+}
+
+export function startProgressPoller(
+  db: Kysely<Database>,
+  gh: GitHubClient,
+  intervalMs = 60_000
+): { stop: () => void } {
+  let running = true;
+
+  async function poll(): Promise<void> {
+    try {
+      const terminalList = Array.from(TERMINAL_STATES);
+      const activeWorkflows = await getActiveWorkflowsWithAgents(db, terminalList);
+
+      for (const wf of activeWorkflows) {
+        try {
+          let sessionUUID = wf.claude_session_id;
+
+          // If no stored UUID, try to resolve from worktree path
+          if (!sessionUUID && wf.agent_id) {
+            // Look up worktree_path from the agent session
+            const agent = await db
+              .selectFrom("agent_sessions")
+              .select(["worktree_path"])
+              .where("id", "=", wf.agent_id)
+              .executeTakeFirst();
+            if (agent?.worktree_path) {
+              sessionUUID = await resolveClaudeSessionFromWorktree(agent.worktree_path);
+            }
+          }
+
+          if (!sessionUUID) continue;
+
+          const tasks = await readAgentTasks(sessionUUID);
+          const hash = hashTasks(tasks);
+          const prevHash = lastTaskHash.get(wf.id);
+
+          if (hash === prevHash) continue;
+          lastTaskHash.set(wf.id, hash);
+
+          const body = formatProgressComment(wf.agent_role, tasks);
+
+          if (wf.progress_comment_id) {
+            await gh.updateComment(wf.repo, wf.progress_comment_id, body);
+          } else {
+            const result = await gh.postComment(wf.repo, wf.issue_number, body);
+            await updateProgressCommentId(db, wf.id, result.id);
+          }
+
+          log.info(`Updated progress for ${wf.id}`, { tasks: tasks.length, issue: wf.issue_number });
+        } catch (err) {
+          log.warn(`Progress update failed for ${wf.id}: ${err}`);
+        }
+      }
+    } catch (err) {
+      log.error(`Progress poller error: ${err}`);
+    }
+  }
+
+  const interval = setInterval(() => {
+    if (running) poll();
+  }, intervalMs);
+
+  // Backfill worktree paths for old agents, then run first poll
+  const initialDelay = setTimeout(async () => {
+    if (!running) return;
+    await backfillWorktreePaths(db);
+    if (running) await poll();
+  }, 10_000);
+
+  return {
+    stop() {
+      running = false;
+      clearInterval(interval);
+      clearTimeout(initialDelay);
+      lastTaskHash.clear();
+    },
+  };
+}

--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -1,8 +1,9 @@
 import { Kysely } from "kysely";
 import * as fs from "fs";
 import * as path from "path";
+import * as os from "os";
 import type { Database } from "../store/database.js";
-import { createAgentSession, updateAgentStatus, getAgentSession, incrementRetryCount } from "../store/queries.js";
+import { createAgentSession, updateAgentStatus, getAgentSession, incrementRetryCount, updateAgentSessionFields } from "../store/queries.js";
 import { createLogger } from "../logger.js";
 
 const ZAPBOT_DIR = path.resolve(import.meta.dir, "../..");
@@ -60,6 +61,64 @@ async function findSessionForIssue(issueNumber: number): Promise<string | null> 
 
   log.warn(`Could not find AO session for ${branch}`, { issueNumber });
   return null;
+}
+
+/**
+ * Resolve the worktree path for a given issue by parsing `ao session ls` porcelain output
+ * or `git worktree list` for the branch pattern.
+ */
+async function resolveWorktreePath(issueNumber: number): Promise<string | null> {
+  const branch = `feat/issue-${issueNumber}`;
+  try {
+    const proc = Bun.spawn(["git", "worktree", "list", "--porcelain"], { stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    await proc.exited;
+    for (const block of stdout.split("\n\n")) {
+      if (!block.includes(`refs/heads/${branch}`)) continue;
+      const wtLine = block.split("\n").find((l) => l.startsWith("worktree "));
+      if (wtLine) return wtLine.slice("worktree ".length);
+    }
+  } catch (err) {
+    log.warn(`Failed to resolve worktree path for issue #${issueNumber}: ${err}`);
+  }
+  return null;
+}
+
+/**
+ * Encode a worktree path the same way Claude Code does for its project directory.
+ * Strips leading /, replaces / and . with -.
+ */
+export function toClaudeProjectPath(worktreePath: string): string {
+  return worktreePath
+    .replace(/\\/g, "/")
+    .replace(/:/g, "")
+    .replace(/[/.]/g, "-");
+}
+
+/**
+ * Given a worktree path, find the Claude Code session UUID by locating the
+ * latest .jsonl file in the Claude project directory.
+ */
+async function resolveClaudeSessionId(worktreePath: string): Promise<string | null> {
+  const encoded = toClaudeProjectPath(worktreePath);
+  const projectDir = path.join(os.homedir(), ".claude", "projects", encoded);
+
+  try {
+    const entries = await fs.promises.readdir(projectDir, { withFileTypes: true });
+    const jsonlFiles = await Promise.all(
+      entries
+        .filter((e) => e.isFile() && e.name.endsWith(".jsonl") && !e.name.startsWith("agent-"))
+        .map(async (e) => {
+          const stat = await fs.promises.stat(path.join(projectDir, e.name));
+          return { name: e.name, mtimeMs: stat.mtimeMs };
+        })
+    );
+    jsonlFiles.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    if (jsonlFiles.length === 0) return null;
+    return jsonlFiles[0].name.replace(".jsonl", "");
+  } catch {
+    return null;
+  }
 }
 
 function buildPrompt(ctx: SpawnContext): string {
@@ -177,6 +236,18 @@ export async function spawnAgent(
       if (code === 0) {
         await updateAgentStatus(db, agentId, "running");
         log.info(`Agent ${agentId} spawn process exited successfully`, { agentId });
+
+        // Resolve and store worktree path + Claude session UUID for progress tracking
+        const worktreePath = await resolveWorktreePath(ctx.issueNumber);
+        if (worktreePath) {
+          const fields: { worktree_path: string; claude_session_id?: string } = { worktree_path: worktreePath };
+          const sessionUUID = await resolveClaudeSessionId(worktreePath);
+          if (sessionUUID) {
+            fields.claude_session_id = sessionUUID;
+            log.info(`Resolved Claude session ${sessionUUID} for agent ${agentId}`, { agentId, worktreePath });
+          }
+          await updateAgentSessionFields(db, agentId, fields);
+        }
 
         // Re-deliver prompt after a delay to work around AO prompt delivery race.
         // AO pastes the prompt before Claude Code finishes loading, so it gets swallowed.

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -45,7 +45,13 @@ async function fetchWithRetry(
 
 export interface GatewayClientConfig {
   gatewayUrl: string;   // e.g. https://zapbot-gateway.up.railway.app
-  secret: string;       // GATEWAY_SECRET for Bearer auth
+  secret?: string;      // Legacy: ZAPBOT_GATEWAY_SECRET (deprecated)
+  token?: string;       // Supabase JWT: ZAPBOT_GATEWAY_TOKEN (preferred)
+}
+
+/** Returns the auth token to use — JWT token takes precedence over legacy secret. */
+function getAuthToken(config: GatewayClientConfig): string {
+  return config.token || config.secret || "";
 }
 
 /**
@@ -62,7 +68,7 @@ export async function registerBridge(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${config.secret}`,
+      Authorization: `Bearer ${getAuthToken(config)}`,
     },
     body: JSON.stringify({ repo, bridgeUrl }),
   });
@@ -89,7 +95,7 @@ export async function deregisterBridge(
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${config.secret}`,
+        Authorization: `Bearer ${getAuthToken(config)}`,
       },
       body: JSON.stringify({ repo }),
       signal: AbortSignal.timeout(5_000),

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -8,7 +8,8 @@ const API_BASE = "https://api.github.com";
 export interface GitHubClient {
   addLabel(repo: string, issueNumber: number, label: string): Promise<void>;
   removeLabel(repo: string, issueNumber: number, label: string): Promise<void>;
-  postComment(repo: string, issueNumber: number, body: string): Promise<void>;
+  postComment(repo: string, issueNumber: number, body: string): Promise<{ id: number }>;
+  updateComment(repo: string, commentId: number, body: string): Promise<void>;
   closeIssue(repo: string, issueNumber: number): Promise<void>;
   createIssue(repo: string, title: string, body: string, labels: string[]): Promise<string>;
   editIssue(repo: string, issueNumber: number, updates: Record<string, unknown>): Promise<void>;
@@ -94,8 +95,18 @@ function createRestClient(getToken: TokenProvider): GitHubClient {
 
     async postComment(repo, issueNumber, body) {
       log.debug(`Posting comment on #${issueNumber} via API`, { repo, issueNumber });
-      await authedFetch(`/repos/${repo}/issues/${issueNumber}/comments`, {
+      const resp = await authedFetch(`/repos/${repo}/issues/${issueNumber}/comments`, {
         method: "POST",
+        body: JSON.stringify({ body }),
+      });
+      const data = await resp.json() as { id: number };
+      return { id: data.id };
+    },
+
+    async updateComment(repo, commentId, body) {
+      log.debug(`Updating comment ${commentId} via API`, { repo, commentId });
+      await authedFetch(`/repos/${repo}/issues/comments/${commentId}`, {
+        method: "PATCH",
         body: JSON.stringify({ body }),
       });
     },
@@ -306,88 +317,20 @@ function createAppClient(appId: string, privateKey: string, installationId: stri
   return createRestClient(getToken);
 }
 
-// ── Legacy gh CLI client ────────────────────────────────────────────
+// ── Legacy client: resolves token from `gh auth token`, then uses REST ─────
 
 function createLegacyClient(): GitHubClient {
-  async function runGh(args: string[]): Promise<string> {
-    const proc = Bun.spawn(["gh", ...args], { stdout: "pipe", stderr: "pipe" });
+  async function resolveGhToken(): Promise<string> {
+    const proc = Bun.spawn(["gh", "auth", "token"], { stdout: "pipe", stderr: "pipe" });
     const output = await new Response(proc.stdout).text();
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      const errMsg = `gh ${args.join(" ")} → ${stderr.trim()}`;
-      log.error(`gh command failed: ${errMsg}`);
-      throw new Error(errMsg);
+      throw new Error("gh auth token failed — is `gh` authenticated?");
     }
     return output.trim();
   }
 
-  return {
-    async addLabel(repo, issueNumber, label) {
-      await runGh(["issue", "edit", String(issueNumber), "--repo", repo, "--add-label", label]);
-    },
-    async removeLabel(repo, issueNumber, label) {
-      await runGh(["issue", "edit", String(issueNumber), "--repo", repo, "--remove-label", label]);
-    },
-    async postComment(repo, issueNumber, body) {
-      await runGh(["issue", "comment", String(issueNumber), "--repo", repo, "--body", body]);
-    },
-    async closeIssue(repo, issueNumber) {
-      await runGh(["issue", "close", String(issueNumber), "--repo", repo]);
-    },
-    async getIssue(repo, issueNumber) {
-      const result = await runGh(["issue", "view", String(issueNumber), "--repo", repo, "--json", "state,body"]);
-      const data = JSON.parse(result) as { state: string; body: string };
-      return { state: data.state?.toLowerCase() === "closed" ? "closed" as const : "open" as const, body: data.body || "" };
-    },
-    async getIssueState(repo, issueNumber) {
-      return (await this.getIssue(repo, issueNumber)).state;
-    },
-    async getIssueBody(repo, issueNumber) {
-      return (await this.getIssue(repo, issueNumber)).body;
-    },
-    async createIssue(repo, title, body, labels) {
-      const args = ["issue", "create", "--repo", repo, "--title", title, "--body", body];
-      for (const l of labels) args.push("--label", l);
-      return runGh(args);
-    },
-    async editIssue(repo, issueNumber, updates) {
-      const args = ["issue", "edit", String(issueNumber), "--repo", repo];
-      if (updates.body) args.push("--body", String(updates.body));
-      if (updates.title) args.push("--title", String(updates.title));
-      await runGh(args);
-    },
-    async convertPrToDraft(repo, prNumber) {
-      await runGh(["pr", "ready", String(prNumber), "--repo", repo, "--undo"]);
-    },
-    async listWebhooks(repo) {
-      const output = await runGh(["api", `repos/${repo}/hooks`]);
-      return JSON.parse(output || "[]");
-    },
-    async createWebhook(repo, config) {
-      const output = await runGh([
-        "api", `repos/${repo}/hooks`, "--method", "POST",
-        "-f", `config[url]=${config.url}`,
-        "-f", `config[content_type]=${config.content_type}`,
-        "-f", `config[secret]=${config.secret}`,
-        ...config.events.flatMap((e) => ["-F", `events[]=${e}`]),
-        "-F", `active=${config.active}`,
-        "--jq", ".id",
-      ]);
-      return parseInt(output, 10);
-    },
-    async updateWebhook(repo, hookId, config) {
-      const args = ["api", `repos/${repo}/hooks/${hookId}`, "--method", "PATCH"];
-      if (config.url) args.push("-f", `config[url]=${config.url}`);
-      if (config.content_type) args.push("-f", `config[content_type]=${config.content_type}`);
-      if (config.secret) args.push("-f", `config[secret]=${config.secret}`);
-      if (config.active !== undefined) args.push("-F", `active=${config.active}`);
-      await runGh(args);
-    },
-    async deactivateWebhook(repo, hookId) {
-      await runGh(["api", `repos/${repo}/hooks/${hookId}`, "--method", "PATCH", "-F", "active=false"]);
-    },
-  };
+  return createRestClient(resolveGhToken);
 }
 
 // ── Factory ─────────────────────────────────────────────────────────

--- a/src/store/database.ts
+++ b/src/store/database.ts
@@ -19,6 +19,7 @@ export interface WorkflowTable {
   intent: string;
   draft_review_cycles: number;
   dependencies: string | null; // JSON-encoded number[] — use serializeDeps/deserializeDeps
+  progress_comment_id: number | null;
   created_at: number;
   updated_at: number;
 }
@@ -40,6 +41,7 @@ export interface AgentSessionTable {
   workflow_id: string;
   role: string; // "triage" | "planner" | "implementer" | "qe" | "investigator"
   worktree_path: string | null;
+  claude_session_id: string | null;
   pr_number: number | null;
   status: string; // "spawning" | "running" | "completed" | "failed" | "timeout"
   retry_count: number;
@@ -47,6 +49,7 @@ export interface AgentSessionTable {
   last_heartbeat: number;
   spawned_at: number;
   completed_at: number | null;
+  cleaned_up_at: number | null;
 }
 
 export interface TransitionTable {

--- a/src/store/migrations.ts
+++ b/src/store/migrations.ts
@@ -129,4 +129,17 @@ const migrations: Migration[] = [
       await sql`ALTER TABLE workflows ADD COLUMN dependencies TEXT DEFAULT NULL`.execute(db);
     },
   },
+  {
+    name: "004_add_cleanup_columns",
+    up: async (db: Kysely<Database>) => {
+      await sql`ALTER TABLE agent_sessions ADD COLUMN cleaned_up_at INTEGER DEFAULT NULL`.execute(db);
+    },
+  },
+  {
+    name: "005_add_progress_columns",
+    up: async (db: Kysely<Database>) => {
+      await sql`ALTER TABLE workflows ADD COLUMN progress_comment_id INTEGER DEFAULT NULL`.execute(db);
+      await sql`ALTER TABLE agent_sessions ADD COLUMN claude_session_id TEXT DEFAULT NULL`.execute(db);
+    },
+  },
 ];

--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -1,13 +1,15 @@
 import { Kysely, sql } from "kysely";
 import type { Database, WorkflowTable, AgentSessionTable, TransitionTable } from "./database.js";
 
-type WorkflowInsert = Omit<WorkflowTable, "created_at" | "updated_at" | "draft_review_cycles" | "dependencies"> & {
+type WorkflowInsert = Omit<WorkflowTable, "created_at" | "updated_at" | "draft_review_cycles" | "dependencies" | "progress_comment_id"> & {
   draft_review_cycles?: number;
   dependencies?: string | null;
+  progress_comment_id?: number | null;
 };
-type AgentInsert = Omit<AgentSessionTable, "status" | "retry_count" | "max_retries" | "last_heartbeat" | "spawned_at" | "completed_at"> & {
+type AgentInsert = Omit<AgentSessionTable, "status" | "retry_count" | "max_retries" | "last_heartbeat" | "spawned_at" | "completed_at" | "claude_session_id"> & {
   status?: string;
   max_retries?: number;
+  claude_session_id?: string | null;
 };
 type TransitionInsert = Omit<TransitionTable, "created_at">;
 
@@ -182,6 +184,81 @@ export async function getStaleAgents(
     .selectAll()
     .where("status", "in", ["spawning", "running"])
     .where("last_heartbeat", "<", cutoff)
+    .execute();
+}
+
+// ── Progress ────────────────────────────────────────────────────
+
+export async function updateProgressCommentId(
+  db: Kysely<Database>,
+  workflowId: string,
+  commentId: number
+): Promise<void> {
+  await db
+    .updateTable("workflows")
+    .set({ progress_comment_id: commentId })
+    .where("id", "=", workflowId)
+    .execute();
+}
+
+export async function updateAgentSessionFields(
+  db: Kysely<Database>,
+  agentId: string,
+  fields: { worktree_path?: string; claude_session_id?: string }
+): Promise<void> {
+  await db
+    .updateTable("agent_sessions")
+    .set(fields)
+    .where("id", "=", agentId)
+    .execute();
+}
+
+/**
+ * Get active (non-terminal) workflows that have at least one running agent session.
+ * Returns the workflow joined with the latest running agent's claude_session_id.
+ */
+export async function getActiveWorkflowsWithAgents(
+  db: Kysely<Database>,
+  terminalStates: string[]
+): Promise<Array<WorkflowTable & { agent_role: string; claude_session_id: string | null; agent_id: string }>> {
+  return db
+    .selectFrom("workflows")
+    .innerJoin("agent_sessions", "agent_sessions.workflow_id", "workflows.id")
+    .selectAll("workflows")
+    .select(["agent_sessions.role as agent_role", "agent_sessions.claude_session_id", "agent_sessions.id as agent_id"])
+    .where("workflows.state", "not in", terminalStates)
+    .where("agent_sessions.status", "in", ["running", "spawning"])
+    .execute();
+}
+
+// ── Cleanup ─────────────────────────────────────────────────────
+
+/**
+ * Find agent sessions eligible for cleanup: parent workflow is in a terminal
+ * state and the session has not been cleaned up yet.
+ */
+export async function getSessionsForCleanup(
+  db: Kysely<Database>,
+  terminalStates: string[]
+): Promise<AgentSessionTable[]> {
+  return db
+    .selectFrom("agent_sessions")
+    .innerJoin("workflows", "workflows.id", "agent_sessions.workflow_id")
+    .selectAll("agent_sessions")
+    .where("workflows.state", "in", terminalStates)
+    .where("agent_sessions.cleaned_up_at", "is", null)
+    .execute();
+}
+
+export async function markSessionCleaned(
+  db: Kysely<Database>,
+  agentId: string
+): Promise<void> {
+  const now = Math.floor(Date.now() / 1000);
+  await db
+    .updateTable("agent_sessions")
+    .set({ cleaned_up_at: now })
+    .where("id", "=", agentId)
     .execute();
 }
 

--- a/templates/agent-rules-implementer.md
+++ b/templates/agent-rules-implementer.md
@@ -57,3 +57,5 @@ These skills should be used **during** implementation, not just at the end:
 - If tests fail: use /investigate, not trial-and-error
 - If CI fails after pushing: read the failure, fix it, push again
 - If the plan is ambiguous: implement the simpler interpretation
+
+Frequently update your task list using TaskCreate/TaskUpdate. Your progress is broadcast to users on GitHub.

--- a/templates/agent-rules-investigator.md
+++ b/templates/agent-rules-investigator.md
@@ -2,6 +2,15 @@
 
 You are an investigator agent. Your job is to diagnose bugs and write minimal reproduction tests. You do NOT fix bugs — only find root causes and prove them with tests.
 
+## Task list (required)
+
+Maintain a task list so progress is visible to the team on GitHub.
+Before starting work, create tasks for each major step using TaskCreate.
+Mark each task in_progress when you start it and completed when done.
+Keep tasks updated as you go — this is how humans track your progress.
+
+## Workflow
+
 1. Read the issue body for the bug report or verification failure
 2. **Use `/investigate`** as your primary tool — systematic root cause investigation with the Iron Law: no fixes without root cause
 3. Write a minimal test to reproduce the issue, in this priority order:
@@ -36,3 +45,5 @@ During investigation:
 1. Use `/investigate` for systematic root cause analysis
 2. If you need to understand code flow, read the relevant source files
 3. Do NOT use trial-and-error — find the root cause first
+
+Frequently update your task list using TaskCreate/TaskUpdate. Your progress is broadcast to users on GitHub.

--- a/templates/agent-rules-planner.md
+++ b/templates/agent-rules-planner.md
@@ -30,3 +30,5 @@ a sub-issue using gstack's planning and review skills.
 ## Commit style:
 - Use conventional commits (feat:, fix:, chore:)
 - Reference the issue number in the commit message: "feat: ... (closes #N)"
+
+Frequently update your task list using TaskCreate/TaskUpdate. Your progress is broadcast to users on GitHub.

--- a/templates/agent-rules-qe.md
+++ b/templates/agent-rules-qe.md
@@ -2,6 +2,8 @@
 
 You are a QE (quality engineering) agent. Your job is to verify code quality and ship.
 
+## Workflow
+
 1. You are spawned when a draft PR is marked "Ready for review"
 2. Run `/qa` to systematically test the application — this produces a structured health score and catches bugs that unit tests miss
 3. Run `/review` to check code quality and structural issues
@@ -29,3 +31,5 @@ During verification:
 4. Run /document-release to verify documentation accuracy
 5. If verification fails and root cause is unclear, use /investigate
 6. Do NOT guess at fixes — find the root cause first
+
+Frequently update your task list using TaskCreate/TaskUpdate. Your progress is broadcast to users on GitHub.

--- a/templates/agent-rules-triage.md
+++ b/templates/agent-rules-triage.md
@@ -40,3 +40,5 @@ asks for 10 features, create 10 sub-issues (or more), not 3 "simplified" ones.
 ## Commit style:
 - Use conventional commits (feat:, fix:, chore:)
 - Reference the issue number in the commit message: "feat: ... (closes #N)"
+
+Frequently update your task list using TaskCreate/TaskUpdate. Your progress is broadcast to users on GitHub.

--- a/test/cleanup.test.ts
+++ b/test/cleanup.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Kysely } from "kysely";
+import { initDatabase, type Database } from "../src/store/database.js";
+import {
+  upsertWorkflow,
+  createAgentSession,
+  getAgentSession,
+  getSessionsForCleanup,
+  markSessionCleaned,
+  updateWorkflowState,
+} from "../src/store/queries.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+let db: Kysely<Database>;
+let dbPath: string;
+
+beforeEach(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `zapbot-cleanup-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+  db = await initDatabase(dbPath);
+});
+
+afterEach(async () => {
+  await db.destroy();
+  try { fs.unlinkSync(dbPath); } catch {}
+  try { fs.unlinkSync(dbPath + "-wal"); } catch {}
+  try { fs.unlinkSync(dbPath + "-shm"); } catch {}
+});
+
+async function createWorkflow(id: string, issueNumber: number, state: string): Promise<void> {
+  await upsertWorkflow(db, {
+    id,
+    issue_number: issueNumber,
+    repo: "owner/repo",
+    state,
+    level: "sub",
+    parent_workflow_id: null,
+    author: "tester",
+    intent: "test",
+  });
+}
+
+async function createAgent(id: string, workflowId: string, status = "running"): Promise<void> {
+  await createAgentSession(db, {
+    id,
+    workflow_id: workflowId,
+    role: "implementer",
+    worktree_path: null,
+    pr_number: null,
+  });
+  if (status !== "spawning") {
+    await db
+      .updateTable("agent_sessions")
+      .set({ status })
+      .where("id", "=", id)
+      .execute();
+  }
+}
+
+describe("cleanup queries", () => {
+  it("getSessionsForCleanup returns sessions in terminal workflow states", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-done-1", "wf-done", "completed");
+
+    await createWorkflow("wf-active", 2, "IMPLEMENTING");
+    await createAgent("agent-active-1", "wf-active", "running");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].id).toBe("agent-done-1");
+  });
+
+  it("getSessionsForCleanup excludes already-cleaned sessions", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-cleaned", "wf-done", "completed");
+    await markSessionCleaned(db, "agent-cleaned");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("markSessionCleaned sets cleaned_up_at timestamp", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-mark", "wf-done", "completed");
+
+    const before = await getAgentSession(db, "agent-mark");
+    expect(before!.cleaned_up_at).toBeNull();
+
+    await markSessionCleaned(db, "agent-mark");
+
+    const after = await getAgentSession(db, "agent-mark");
+    expect(after!.cleaned_up_at).not.toBeNull();
+    expect(after!.cleaned_up_at).toBeGreaterThan(0);
+  });
+
+  it("markSessionCleaned is idempotent", async () => {
+    await createWorkflow("wf-done", 1, "DONE");
+    await createAgent("agent-idem", "wf-done", "completed");
+
+    await markSessionCleaned(db, "agent-idem");
+    const first = await getAgentSession(db, "agent-idem");
+
+    await markSessionCleaned(db, "agent-idem");
+    const second = await getAgentSession(db, "agent-idem");
+
+    // Both calls set a timestamp; the second just overwrites with a new one
+    expect(first!.cleaned_up_at).not.toBeNull();
+    expect(second!.cleaned_up_at).not.toBeNull();
+  });
+
+  it("getSessionsForCleanup handles ABANDONED state", async () => {
+    await createWorkflow("wf-abandon", 3, "ABANDONED");
+    await createAgent("agent-abandon", "wf-abandon", "failed");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].id).toBe("agent-abandon");
+  });
+
+  it("getSessionsForCleanup handles COMPLETED parent state", async () => {
+    await upsertWorkflow(db, {
+      id: "wf-parent",
+      issue_number: 10,
+      repo: "owner/repo",
+      state: "COMPLETED",
+      level: "parent",
+      parent_workflow_id: null,
+      author: "tester",
+      intent: "parent",
+    });
+    await createAgent("agent-parent", "wf-parent", "timeout");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(1);
+    expect(stale[0].id).toBe("agent-parent");
+  });
+
+  it("getSessionsForCleanup returns multiple sessions for one workflow", async () => {
+    await createWorkflow("wf-multi", 5, "DONE");
+    await createAgent("agent-impl", "wf-multi", "completed");
+    await createAgent("agent-qe", "wf-multi", "completed");
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(2);
+    const ids = stale.map((s) => s.id).sort();
+    expect(ids).toEqual(["agent-impl", "agent-qe"]);
+  });
+
+  it("non-terminal workflows are never returned", async () => {
+    const nonTerminal = ["PLANNING", "REVIEW", "IMPLEMENTING", "DRAFT_REVIEW", "VERIFYING", "TRIAGE", "TRIAGED"];
+    for (let i = 0; i < nonTerminal.length; i++) {
+      await createWorkflow(`wf-nt-${i}`, 100 + i, nonTerminal[i]);
+      await createAgent(`agent-nt-${i}`, `wf-nt-${i}`, "running");
+    }
+
+    const stale = await getSessionsForCleanup(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(stale).toHaveLength(0);
+  });
+});

--- a/test/e2e-parent-completion.test.ts
+++ b/test/e2e-parent-completion.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Kysely } from "kysely";
+import { initDatabase, type Database } from "../src/store/database.js";
+import {
+  getWorkflow,
+  upsertWorkflow,
+  updateWorkflowState,
+  getSubWorkflows,
+  addTransition,
+  getTransitionHistory,
+  withTransaction,
+} from "../src/store/queries.js";
+import { apply } from "../src/state-machine/engine.js";
+import { TERMINAL_STATES, ParentState, SubState } from "../src/state-machine/states.js";
+import type { Workflow } from "../src/state-machine/transitions.js";
+import type { SideEffect } from "../src/state-machine/effects.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+let db: Kysely<Database>;
+let dbPath: string;
+
+const REPO = "test-owner/test-repo";
+
+beforeEach(async () => {
+  dbPath = path.join(os.tmpdir(), `zapbot-e2e-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  db = await initDatabase(dbPath);
+});
+
+afterEach(async () => {
+  await db.destroy();
+  try { fs.unlinkSync(dbPath); } catch {}
+  try { fs.unlinkSync(dbPath + "-wal"); } catch {}
+  try { fs.unlinkSync(dbPath + "-shm"); } catch {}
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Replicate checkParentCompletion logic from bin/webhook-bridge.ts (lines 263-307).
+ *  Returns the side effects that would be executed, or null if no transition occurred. */
+async function checkParentCompletion(
+  database: Kysely<Database>,
+  parentWorkflowId: string,
+): Promise<SideEffect[] | null> {
+  const result = await withTransaction(database, async (trx) => {
+    const parent = await getWorkflow(trx, parentWorkflowId);
+    if (!parent || TERMINAL_STATES.has(parent.state)) return null;
+
+    const subs = await getSubWorkflows(trx, parentWorkflowId);
+    const allTerminal = subs.length > 0 && subs.every((s) => TERMINAL_STATES.has(s.state));
+
+    if (!allTerminal) return null;
+
+    const parentWf: Workflow = {
+      id: parent.id,
+      issueNumber: parent.issue_number,
+      state: parent.state,
+      level: parent.level as "parent" | "sub",
+      parentWorkflowId: parent.parent_workflow_id,
+      draftReviewCycles: parent.draft_review_cycles,
+    };
+    const applyResult = apply(parentWf, { type: "all_subs_done", triggeredBy: "system" });
+    if (!applyResult) return null;
+
+    await updateWorkflowState(trx, parent.id, applyResult.newState);
+    await addTransition(trx, {
+      id: `t-${crypto.randomUUID()}`,
+      workflow_id: parent.id,
+      from_state: applyResult.transition.from,
+      to_state: applyResult.transition.to,
+      event_type: applyResult.transition.event,
+      triggered_by: applyResult.transition.triggeredBy,
+      metadata: null,
+      github_delivery_id: null,
+    });
+
+    return applyResult;
+  });
+
+  return result?.sideEffects ?? null;
+}
+
+async function insertParent(issueNumber: number, state: string): Promise<string> {
+  const id = `wf-test-${issueNumber}`;
+  await upsertWorkflow(db, {
+    id,
+    issue_number: issueNumber,
+    repo: REPO,
+    state,
+    level: "parent",
+    parent_workflow_id: null,
+    author: "test-author",
+    intent: "parent issue",
+  });
+  return id;
+}
+
+async function insertSub(
+  issueNumber: number,
+  parentId: string,
+  state: string,
+): Promise<string> {
+  const id = `wf-test-${issueNumber}`;
+  await upsertWorkflow(db, {
+    id,
+    issue_number: issueNumber,
+    repo: REPO,
+    state,
+    level: "sub",
+    parent_workflow_id: parentId,
+    author: "test-author",
+    intent: `sub-issue ${issueNumber}`,
+  });
+  return id;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("E2E: parent completes when all triage sub-issues reach terminal state", () => {
+  it("parent stays in TRIAGED while children are in-progress", async () => {
+    const parentId = await insertParent(100, ParentState.TRIAGED);
+    await insertSub(101, parentId, SubState.DONE);
+    await insertSub(102, parentId, SubState.IMPLEMENTING); // not terminal
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).toBeNull();
+
+    const parent = await getWorkflow(db, parentId);
+    expect(parent!.state).toBe(ParentState.TRIAGED);
+  });
+
+  it("parent transitions to COMPLETED when all children are DONE", async () => {
+    const parentId = await insertParent(200, ParentState.TRIAGED);
+    await insertSub(201, parentId, SubState.DONE);
+    await insertSub(202, parentId, SubState.DONE);
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).not.toBeNull();
+
+    const parent = await getWorkflow(db, parentId);
+    expect(parent!.state).toBe(ParentState.COMPLETED);
+
+    // Verify close_issue side effect is produced
+    expect(effects!.some((e) => e.type === "close_issue" && e.issueNumber === 200)).toBe(true);
+  });
+
+  it("parent GitHub issue is closed (close_issue effect produced)", async () => {
+    const parentId = await insertParent(300, ParentState.TRIAGED);
+    await insertSub(301, parentId, SubState.DONE);
+    await insertSub(302, parentId, SubState.DONE);
+    await insertSub(303, parentId, SubState.DONE);
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).not.toBeNull();
+
+    const closeEffects = effects!.filter((e) => e.type === "close_issue");
+    expect(closeEffects).toHaveLength(1);
+    expect(closeEffects[0]).toEqual({ type: "close_issue", issueNumber: 300 });
+
+    // Verify triaged label is removed
+    expect(effects!.some((e) => e.type === "remove_label" && e.label === "triaged")).toBe(true);
+
+    // Verify transition is recorded in history
+    const history = await getTransitionHistory(db, parentId);
+    expect(history.some((t) => t.from_state === "TRIAGED" && t.to_state === "COMPLETED")).toBe(true);
+  });
+
+  it("handles mixed terminal states (DONE + ABANDONED)", async () => {
+    const parentId = await insertParent(400, ParentState.TRIAGED);
+    await insertSub(401, parentId, SubState.DONE);
+    await insertSub(402, parentId, SubState.ABANDONED);
+    await insertSub(403, parentId, SubState.DONE);
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).not.toBeNull();
+
+    const parent = await getWorkflow(db, parentId);
+    expect(parent!.state).toBe(ParentState.COMPLETED);
+
+    expect(effects!.some((e) => e.type === "close_issue" && e.issueNumber === 400)).toBe(true);
+  });
+
+  it("does not complete when some children are in non-terminal states", async () => {
+    const parentId = await insertParent(500, ParentState.TRIAGED);
+    await insertSub(501, parentId, SubState.DONE);
+    await insertSub(502, parentId, SubState.VERIFYING);
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).toBeNull();
+
+    const parent = await getWorkflow(db, parentId);
+    expect(parent!.state).toBe(ParentState.TRIAGED);
+
+    // Now move the remaining sub to terminal
+    await updateWorkflowState(db, "wf-test-502", SubState.DONE);
+
+    const effects2 = await checkParentCompletion(db, parentId);
+    expect(effects2).not.toBeNull();
+
+    const parent2 = await getWorkflow(db, parentId);
+    expect(parent2!.state).toBe(ParentState.COMPLETED);
+  });
+
+  it("does not complete when parent has no sub-issues", async () => {
+    const parentId = await insertParent(600, ParentState.TRIAGED);
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).toBeNull();
+
+    const parent = await getWorkflow(db, parentId);
+    expect(parent!.state).toBe(ParentState.TRIAGED);
+  });
+
+  it("skips already-completed parent", async () => {
+    const parentId = await insertParent(700, ParentState.COMPLETED);
+    await insertSub(701, parentId, SubState.DONE);
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).toBeNull();
+
+    const parent = await getWorkflow(db, parentId);
+    expect(parent!.state).toBe(ParentState.COMPLETED);
+  });
+
+  it("skips already-abandoned parent", async () => {
+    const parentId = await insertParent(800, ParentState.ABANDONED);
+    await insertSub(801, parentId, SubState.DONE);
+
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).toBeNull();
+
+    const parent = await getWorkflow(db, parentId);
+    expect(parent!.state).toBe(ParentState.ABANDONED);
+  });
+
+  it("records exactly one all_subs_done transition", async () => {
+    const parentId = await insertParent(900, ParentState.TRIAGED);
+    await insertSub(901, parentId, SubState.DONE);
+    await insertSub(902, parentId, SubState.ABANDONED);
+
+    await checkParentCompletion(db, parentId);
+
+    const history = await getTransitionHistory(db, parentId);
+    const allSubsDoneTransitions = history.filter((t) => t.event_type === "all_subs_done");
+    expect(allSubsDoneTransitions).toHaveLength(1);
+    expect(allSubsDoneTransitions[0].from_state).toBe("TRIAGED");
+    expect(allSubsDoneTransitions[0].to_state).toBe("COMPLETED");
+    expect(allSubsDoneTransitions[0].triggered_by).toBe("system");
+  });
+
+  it("second call is a no-op after parent already completed", async () => {
+    const parentId = await insertParent(1000, ParentState.TRIAGED);
+    await insertSub(1001, parentId, SubState.DONE);
+    await insertSub(1002, parentId, SubState.DONE);
+
+    // First call completes the parent
+    const effects1 = await checkParentCompletion(db, parentId);
+    expect(effects1).not.toBeNull();
+
+    // Second call is a no-op (parent already COMPLETED)
+    const effects2 = await checkParentCompletion(db, parentId);
+    expect(effects2).toBeNull();
+
+    // Only one transition recorded
+    const history = await getTransitionHistory(db, parentId);
+    const completionTransitions = history.filter((t) => t.to_state === "COMPLETED");
+    expect(completionTransitions).toHaveLength(1);
+  });
+
+  it("simulates full lifecycle: subs transition one by one, parent completes at the end", async () => {
+    const parentId = await insertParent(1100, ParentState.TRIAGED);
+    const sub1Id = await insertSub(1101, parentId, SubState.IMPLEMENTING);
+    const sub2Id = await insertSub(1102, parentId, SubState.PLANNING);
+
+    // Both subs in-progress: parent stays TRIAGED
+    expect(await checkParentCompletion(db, parentId)).toBeNull();
+
+    // Sub 1 reaches DONE
+    await updateWorkflowState(db, sub1Id, SubState.DONE);
+    expect(await checkParentCompletion(db, parentId)).toBeNull();
+    expect((await getWorkflow(db, parentId))!.state).toBe(ParentState.TRIAGED);
+
+    // Sub 2 reaches ABANDONED
+    await updateWorkflowState(db, sub2Id, SubState.ABANDONED);
+    const effects = await checkParentCompletion(db, parentId);
+    expect(effects).not.toBeNull();
+    expect((await getWorkflow(db, parentId))!.state).toBe(ParentState.COMPLETED);
+
+    // Verify the completion comment
+    expect(effects!.some((e) =>
+      e.type === "post_comment" && e.body.includes("All sub-issues are complete")
+    )).toBe(true);
+  });
+});

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { SignJWT } from "jose";
 import {
   registerBridge,
   deregisterBridge,
@@ -9,6 +10,7 @@ import {
 } from "../src/gateway/client.js";
 import { createFetchHandler } from "../gateway/src/handler.js";
 import { clearRegistry, getBridge } from "../gateway/src/registry.js";
+import { resetLegacyDeprecationFlag, type AuthConfig } from "../gateway/src/auth.js";
 
 /**
  * Tests for the gateway client module (src/gateway/client.ts).
@@ -17,20 +19,48 @@ import { clearRegistry, getBridge } from "../gateway/src/registry.js";
  * and heartbeat end-to-end without mocking HTTP.
  */
 
-const GATEWAY_SECRET = "test-secret-abc123";
+const LEGACY_SECRET = "test-secret-abc123";
+const JWT_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
+const JWT_ISSUER = "https://test.supabase.co/auth/v1";
+const encoder = new TextEncoder();
+
+const authConfig: AuthConfig = {
+  jwtSecret: JWT_SECRET,
+  jwtIssuer: JWT_ISSUER,
+  legacySecret: LEGACY_SECRET,
+  legacyEnabled: true,
+  maxAgeSeconds: 3600,
+};
+
+async function createOwnerJWT(): Promise<string> {
+  return new SignJWT({
+    sub: "user-uuid-123",
+    email: "test@example.com",
+    app_metadata: {
+      role: "owner",
+      authorized_repos: ["owner/repo", "owner/repo-a", "owner/repo-b", "owner/a", "owner/b"],
+    },
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuer(JWT_ISSUER)
+    .setAudience("authenticated")
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(encoder.encode(JWT_SECRET));
+}
 
 let gatewayServer: ReturnType<typeof Bun.serve>;
 let gatewayUrl: string;
-let config: GatewayClientConfig;
+let legacyConfig: GatewayClientConfig;
 
 beforeAll(() => {
   const handler = createFetchHandler({
-    gatewaySecret: GATEWAY_SECRET,
+    authConfig,
     forwardTimeoutMs: 5000,
   });
   gatewayServer = Bun.serve({ port: 0, fetch: handler });
   gatewayUrl = `http://localhost:${gatewayServer.port}`;
-  config = { gatewayUrl, secret: GATEWAY_SECRET };
+  legacyConfig = { gatewayUrl, secret: LEGACY_SECRET };
 });
 
 afterAll(() => {
@@ -39,6 +69,7 @@ afterAll(() => {
 
 beforeEach(() => {
   clearRegistry();
+  resetLegacyDeprecationFlag();
 });
 
 afterEach(() => {
@@ -47,17 +78,34 @@ afterEach(() => {
 
 describe("gateway client", () => {
   describe("registerBridge", () => {
-    it("registers a bridge with the gateway", async () => {
-      await registerBridge(config, "owner/repo", "http://localhost:3000");
+    it("registers a bridge with legacy secret", async () => {
+      await registerBridge(legacyConfig, "owner/repo", "http://localhost:3000");
       const bridge = getBridge("owner/repo");
       expect(bridge).toBeDefined();
       expect(bridge!.bridgeUrl).toBe("http://localhost:3000");
       expect(bridge!.active).toBe(true);
     });
 
+    it("registers a bridge with JWT token", async () => {
+      const jwt = await createOwnerJWT();
+      const jwtConfig: GatewayClientConfig = { gatewayUrl, token: jwt };
+      await registerBridge(jwtConfig, "owner/repo", "http://localhost:3000");
+      const bridge = getBridge("owner/repo");
+      expect(bridge).toBeDefined();
+      expect(bridge!.bridgeUrl).toBe("http://localhost:3000");
+    });
+
+    it("JWT token takes precedence over legacy secret", async () => {
+      const jwt = await createOwnerJWT();
+      const config: GatewayClientConfig = { gatewayUrl, token: jwt, secret: "wrong-secret" };
+      // Should succeed because JWT is used, not the wrong legacy secret
+      await registerBridge(config, "owner/repo", "http://localhost:3000");
+      expect(getBridge("owner/repo")).toBeDefined();
+    });
+
     it("registers multiple repos", async () => {
-      await registerBridge(config, "owner/repo-a", "http://localhost:3000");
-      await registerBridge(config, "owner/repo-b", "http://localhost:3000");
+      await registerBridge(legacyConfig, "owner/repo-a", "http://localhost:3000");
+      await registerBridge(legacyConfig, "owner/repo-b", "http://localhost:3000");
       expect(getBridge("owner/repo-a")).toBeDefined();
       expect(getBridge("owner/repo-b")).toBeDefined();
     });
@@ -71,27 +119,27 @@ describe("gateway client", () => {
 
   describe("deregisterBridge", () => {
     it("removes a bridge from the gateway", async () => {
-      await registerBridge(config, "owner/repo", "http://localhost:3000");
+      await registerBridge(legacyConfig, "owner/repo", "http://localhost:3000");
       expect(getBridge("owner/repo")).toBeDefined();
 
-      await deregisterBridge(config, "owner/repo");
+      await deregisterBridge(legacyConfig, "owner/repo");
       expect(getBridge("owner/repo")).toBeUndefined();
     });
 
     it("does not throw for non-existent repo", async () => {
       // Deregistering a repo that doesn't exist should not throw
-      await deregisterBridge(config, "owner/nonexistent");
+      await deregisterBridge(legacyConfig, "owner/nonexistent");
     });
   });
 
   describe("heartbeat", () => {
     it("re-registers to update lastSeen", async () => {
-      await registerBridge(config, "owner/repo", "http://localhost:3000");
+      await registerBridge(legacyConfig, "owner/repo", "http://localhost:3000");
       const firstSeen = getBridge("owner/repo")!.lastSeen;
 
       // Small delay to ensure timestamp differs
       await new Promise((r) => setTimeout(r, 10));
-      await heartbeat(config, "owner/repo", "http://localhost:3000");
+      await heartbeat(legacyConfig, "owner/repo", "http://localhost:3000");
 
       const secondSeen = getBridge("owner/repo")!.lastSeen;
       expect(secondSeen).toBeGreaterThanOrEqual(firstSeen);
@@ -105,11 +153,24 @@ describe("gateway client", () => {
       // Should not have registered
       expect(getBridge("owner/repo")).toBeUndefined();
     });
+
+    it("works with JWT token", async () => {
+      const jwt = await createOwnerJWT();
+      const jwtConfig: GatewayClientConfig = { gatewayUrl, token: jwt };
+      await registerBridge(jwtConfig, "owner/repo", "http://localhost:3000");
+      const firstSeen = getBridge("owner/repo")!.lastSeen;
+
+      await new Promise((r) => setTimeout(r, 10));
+      await heartbeat(jwtConfig, "owner/repo", "http://localhost:3000");
+
+      const secondSeen = getBridge("owner/repo")!.lastSeen;
+      expect(secondSeen).toBeGreaterThanOrEqual(firstSeen);
+    });
   });
 
   describe("setupGateway", () => {
     it("registers all repos and returns cleanup function", async () => {
-      const cleanup = await setupGateway(config, ["owner/a", "owner/b"], "http://localhost:3000");
+      const cleanup = await setupGateway(legacyConfig, ["owner/a", "owner/b"], "http://localhost:3000");
 
       expect(getBridge("owner/a")).toBeDefined();
       expect(getBridge("owner/b")).toBeDefined();

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Kysely } from "kysely";
+import { initDatabase, type Database } from "../src/store/database.js";
+import {
+  upsertWorkflow,
+  createAgentSession,
+  updateAgentStatus,
+  updateProgressCommentId,
+  updateAgentSessionFields,
+  getActiveWorkflowsWithAgents,
+  getWorkflow,
+  getAgentSession,
+} from "../src/store/queries.js";
+import {
+  readAgentTasks,
+  formatProgressComment,
+  formatFinalComment,
+  type AgentTask,
+} from "../src/agents/progress.js";
+import { toClaudeProjectPath } from "../src/agents/spawner.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+let db: Kysely<Database>;
+let dbPath: string;
+
+beforeEach(async () => {
+  dbPath = path.join(
+    os.tmpdir(),
+    `zapbot-progress-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+  );
+  db = await initDatabase(dbPath);
+});
+
+afterEach(async () => {
+  await db.destroy();
+  try { fs.unlinkSync(dbPath); } catch {}
+  try { fs.unlinkSync(dbPath + "-wal"); } catch {}
+  try { fs.unlinkSync(dbPath + "-shm"); } catch {}
+});
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+async function createWorkflow(id: string, issueNumber: number, state: string): Promise<void> {
+  await upsertWorkflow(db, {
+    id,
+    issue_number: issueNumber,
+    repo: "owner/repo",
+    state,
+    level: "sub",
+    parent_workflow_id: null,
+    author: "tester",
+    intent: "test",
+  });
+}
+
+async function createAgent(
+  id: string,
+  workflowId: string,
+  status = "running",
+  sessionId: string | null = null
+): Promise<void> {
+  await createAgentSession(db, {
+    id,
+    workflow_id: workflowId,
+    role: "implementer",
+    worktree_path: null,
+    pr_number: null,
+    claude_session_id: sessionId,
+  });
+  if (status !== "spawning") {
+    await db
+      .updateTable("agent_sessions")
+      .set({ status })
+      .where("id", "=", id)
+      .execute();
+  }
+}
+
+function makeTempTaskDir(sessionUUID: string): string {
+  const dir = path.join(os.tmpdir(), `claude-tasks-test-${Date.now()}`, sessionUUID);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ── Task file reading ────────────────────────────────────────────
+
+describe("readAgentTasks", () => {
+  it("returns empty array for nonexistent directory", async () => {
+    const tasks = await readAgentTasks("nonexistent-uuid-12345");
+    expect(tasks).toEqual([]);
+  });
+
+  it("reads valid task files sorted by ID", async () => {
+    const uuid = `test-session-${Date.now()}`;
+    const taskDir = path.join(os.homedir(), ".claude", "tasks", uuid);
+    fs.mkdirSync(taskDir, { recursive: true });
+
+    try {
+      fs.writeFileSync(path.join(taskDir, "2.json"), JSON.stringify({
+        id: "2",
+        subject: "Create PR",
+        activeForm: "Creating PR",
+        status: "pending",
+        blocks: [],
+        blockedBy: ["1"],
+      }));
+      fs.writeFileSync(path.join(taskDir, "1.json"), JSON.stringify({
+        id: "1",
+        subject: "Write tests",
+        activeForm: "Writing tests",
+        status: "completed",
+        blocks: ["2"],
+        blockedBy: [],
+      }));
+
+      const tasks = await readAgentTasks(uuid);
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].id).toBe("1");
+      expect(tasks[0].status).toBe("completed");
+      expect(tasks[1].id).toBe("2");
+      expect(tasks[1].status).toBe("pending");
+    } finally {
+      fs.rmSync(taskDir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips corrupt files gracefully", async () => {
+    const uuid = `test-corrupt-${Date.now()}`;
+    const taskDir = path.join(os.homedir(), ".claude", "tasks", uuid);
+    fs.mkdirSync(taskDir, { recursive: true });
+
+    try {
+      fs.writeFileSync(path.join(taskDir, "1.json"), JSON.stringify({
+        id: "1", subject: "Valid task", activeForm: "", status: "in_progress", blocks: [], blockedBy: [],
+      }));
+      fs.writeFileSync(path.join(taskDir, "2.json"), "not json at all");
+      fs.writeFileSync(path.join(taskDir, "3.json"), JSON.stringify({ missing: "fields" }));
+
+      const tasks = await readAgentTasks(uuid);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe("1");
+    } finally {
+      fs.rmSync(taskDir, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-numeric filenames", async () => {
+    const uuid = `test-ignore-${Date.now()}`;
+    const taskDir = path.join(os.homedir(), ".claude", "tasks", uuid);
+    fs.mkdirSync(taskDir, { recursive: true });
+
+    try {
+      fs.writeFileSync(path.join(taskDir, "1.json"), JSON.stringify({
+        id: "1", subject: "Task", activeForm: "", status: "pending", blocks: [], blockedBy: [],
+      }));
+      fs.writeFileSync(path.join(taskDir, "metadata.json"), JSON.stringify({ version: 1 }));
+      fs.writeFileSync(path.join(taskDir, "readme.txt"), "hello");
+
+      const tasks = await readAgentTasks(uuid);
+      expect(tasks).toHaveLength(1);
+    } finally {
+      fs.rmSync(taskDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── Comment formatting ───────────────────────────────────────────
+
+describe("formatProgressComment", () => {
+  it("formats a task list with checkboxes", () => {
+    const tasks: AgentTask[] = [
+      { id: "1", subject: "Analyze codebase", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+      { id: "2", subject: "Create sub-issues", activeForm: "", status: "in_progress", blocks: [], blockedBy: [] },
+      { id: "3", subject: "Post summary", activeForm: "", status: "pending", blocks: [], blockedBy: [] },
+    ];
+    const comment = formatProgressComment("implementer", tasks);
+
+    expect(comment).toContain("- [x] Analyze codebase");
+    expect(comment).toContain("- [ ] Create sub-issues ← working");
+    expect(comment).toContain("- [ ] Post summary");
+    expect(comment).not.toContain("Post summary ← working");
+    expect(comment).toContain("1/3 done");
+    expect(comment).toContain("**implementer** agent progress");
+  });
+
+  it("formats a comment with no tasks", () => {
+    const comment = formatProgressComment("triage", []);
+    expect(comment).toContain("Agent is working...");
+    expect(comment).toContain("**triage** agent progress");
+  });
+});
+
+describe("formatFinalComment", () => {
+  it("includes outcome in the comment", () => {
+    const tasks: AgentTask[] = [
+      { id: "1", subject: "Task", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+    ];
+    const comment = formatFinalComment("implementer", tasks, "Workflow complete");
+    expect(comment).toContain("**Workflow complete**");
+    expect(comment).toContain("- [x] Task");
+  });
+});
+
+// ── toClaudeProjectPath encoding ─────────────────────────────────
+
+describe("toClaudeProjectPath", () => {
+  it("encodes a Unix path correctly", () => {
+    expect(toClaudeProjectPath("/home/user/.worktrees/zapbot/zap-1")).toBe(
+      "-home-user--worktrees-zapbot-zap-1"
+    );
+  });
+
+  it("handles paths with dots", () => {
+    expect(toClaudeProjectPath("/home/user/my.project")).toBe(
+      "-home-user-my-project"
+    );
+  });
+
+  it("replaces leading slash with dash (matching Claude Code encoding)", () => {
+    const result = toClaudeProjectPath("/foo/bar");
+    expect(result).toBe("-foo-bar");
+  });
+});
+
+// ── Query helpers ────────────────────────────────────────────────
+
+describe("progress queries", () => {
+  it("updateProgressCommentId stores the comment ID", async () => {
+    await createWorkflow("wf-10", 10, "IMPLEMENTING");
+    await updateProgressCommentId(db, "wf-10", 42);
+
+    const wf = await getWorkflow(db, "wf-10");
+    expect(wf!.progress_comment_id).toBe(42);
+  });
+
+  it("updateAgentSessionFields stores worktree_path and claude_session_id", async () => {
+    await createWorkflow("wf-11", 11, "IMPLEMENTING");
+    await createAgent("agent-11", "wf-11", "running");
+
+    await updateAgentSessionFields(db, "agent-11", {
+      worktree_path: "/tmp/wt/zap-1",
+      claude_session_id: "uuid-abc-123",
+    });
+
+    const session = await getAgentSession(db, "agent-11");
+    expect(session!.worktree_path).toBe("/tmp/wt/zap-1");
+    expect(session!.claude_session_id).toBe("uuid-abc-123");
+  });
+
+  it("getActiveWorkflowsWithAgents returns active workflows with running agents", async () => {
+    await createWorkflow("wf-active", 20, "IMPLEMENTING");
+    await createAgent("agent-active", "wf-active", "running", "session-uuid");
+
+    await createWorkflow("wf-done", 21, "DONE");
+    await createAgent("agent-done", "wf-done", "completed");
+
+    await createWorkflow("wf-noagent", 22, "IMPLEMENTING");
+    await createAgent("agent-failed", "wf-noagent", "failed");
+
+    const active = await getActiveWorkflowsWithAgents(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe("wf-active");
+    expect(active[0].agent_role).toBe("implementer");
+    expect(active[0].claude_session_id).toBe("session-uuid");
+  });
+
+  it("getActiveWorkflowsWithAgents includes spawning agents", async () => {
+    await createWorkflow("wf-spawn", 30, "TRIAGE");
+    await createAgentSession(db, {
+      id: "agent-spawn",
+      workflow_id: "wf-spawn",
+      role: "triage",
+      worktree_path: null,
+      pr_number: null,
+    });
+    // Agent is in default "spawning" status
+
+    const active = await getActiveWorkflowsWithAgents(db, ["DONE", "ABANDONED", "COMPLETED"]);
+    expect(active).toHaveLength(1);
+    expect(active[0].agent_id).toBe("agent-spawn");
+  });
+
+  it("migration 005 creates the new columns", async () => {
+    // Verify the columns exist by inserting and reading
+    await createWorkflow("wf-mig", 40, "PLANNING");
+    const wf = await getWorkflow(db, "wf-mig");
+    expect(wf!.progress_comment_id).toBeNull();
+
+    await createAgent("agent-mig", "wf-mig", "running");
+    const session = await getAgentSession(db, "agent-mig");
+    expect(session!.claude_session_id).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #48

- **JWT auth for gateway**: New `gateway/src/auth.ts` module using `jose` library for Supabase JWT verification (HS256, issuer/audience validation, max-age check)
- **Backward-compatible**: Legacy shared-secret auth preserved behind `LEGACY_AUTH_ENABLED` env var with deprecation warnings. Gateway accepts both JWT and legacy tokens during migration
- **Bridge client updated**: `GatewayClientConfig` now supports `token` (JWT) alongside `secret` (legacy). `ZAPBOT_GATEWAY_TOKEN` env var takes precedence over `ZAPBOT_GATEWAY_SECRET`
- **New `/api/auth/me` endpoint**: Lets operators verify their JWT tokens against the gateway
- **Role-based access control**: `owner` role required for bridge register/deregister. `member` role can view workflows for authorized repos
- **74 gateway tests**: Unit tests for JWT verification, role checks, repo access, legacy fallback. Integration tests for all endpoints with both auth methods

### New env vars

**Gateway (Railway):**
- `SUPABASE_JWT_SECRET` — JWT verification secret
- `SUPABASE_URL` — (optional) validates JWT issuer claim
- `LEGACY_AUTH_ENABLED` — (default: true) set to false after migration
- `JWT_MAX_AGE_SECONDS` — (default: 3600) max JWT age

**Bridge (local):**
- `ZAPBOT_GATEWAY_TOKEN` — Supabase JWT (preferred over `ZAPBOT_GATEWAY_SECRET`)

## Test plan

- [x] All 74 gateway tests pass (auth unit tests, endpoint integration tests, client tests)
- [x] Full project test suite: 533 pass, 1 pre-existing failure (plannotator network timeout)
- [ ] Deploy to Railway with `SUPABASE_JWT_SECRET` + `GATEWAY_SECRET` and verify dual-mode auth
- [ ] Register a bridge using JWT token via `/api/auth/me` and `/api/bridges/register`
- [ ] Verify legacy secret still works during migration period
- [ ] Set `LEGACY_AUTH_ENABLED=false` and verify legacy auth is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)