### PR TITLE
fix: reject @mention commands when permission check fails

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -507,7 +507,12 @@ async function handleMentionCommand(
       return { status: 200, body: "insufficient permissions" };
     }
   } catch (err) {
-    log.warn(`Permission check failed for ${triggeredBy}, proceeding anyway: ${err}`);
+    log.error(`Permission check failed for ${triggeredBy}, rejecting command: ${err}`);
+    await executeSideEffects([{
+      type: "post_comment", issueNumber,
+      body: `Sorry @${triggeredBy}, I couldn't verify your permissions right now. Please try again in a moment.`,
+    }], repo);
+    return { status: 200, body: "permission check failed" };
   }
 
   const cmdLower = command.toLowerCase().trim();


### PR DESCRIPTION
## Summary

Closes #73

- **Hardened the permission check** in `handleMentionCommand()` (`bin/webhook-bridge.ts:509-516`) to reject commands when `getUserPermission()` throws (network error, rate limit, etc.), instead of silently proceeding without verified permissions
- Changed `log.warn` → `log.error` and added an early return with a user-friendly comment explaining the temporary failure

## What changed

**Before:** The catch block logged a warning and fell through, allowing the command to execute without a permission check.

**After:** The catch block logs an error, posts a comment telling the user to retry, and returns immediately — no command is executed.

## Test plan

- [x] All 1168 existing tests pass (0 failures)
- [x] No files changed outside the plan's scope (1 file, ~5 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)