### PR TITLE
feat: bot token injection + loose mention transitions

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -612,13 +612,42 @@ async function handleMentionCommand(
 
   // ── implement this ────────────────────────────────────────────────
   if (cmdLower === "implement this" || cmdLower === "implement") {
-    const wfRow = await getWorkflowByIssue(db, issueNumber, repo);
+    let wfRow = await getWorkflowByIssue(db, issueNumber, repo);
     if (!wfRow) {
-      await executeSideEffects([{
-        type: "post_comment", issueNumber,
-        body: `No workflow found. Use \`@${BOT_USERNAME} plan this\` first.`,
-      }], repo);
-      return { status: 200, body: "no workflow" };
+      // Create workflow on the fly and spawn implementer
+      try {
+        await gh.assignIssue(repo, issueNumber, [BOT_USERNAME]);
+      } catch (err) {
+        log.warn(`Failed to auto-assign bot to #${issueNumber}: ${err}`);
+      }
+      const intent = `Implementation triggered by @${triggeredBy}`;
+      const wfId = makeWorkflowId(repo, issueNumber);
+      await upsertWorkflow(db, {
+        id: wfId,
+        issue_number: issueNumber,
+        repo,
+        state: "IMPLEMENTING",
+        level: "sub",
+        parent_workflow_id: null,
+        author: triggeredBy,
+        intent,
+      });
+      await addTransition(db, {
+        id: `t-${crypto.randomUUID()}`,
+        workflow_id: wfId,
+        from_state: "NEW",
+        to_state: "IMPLEMENTING",
+        event_type: "mention:implement",
+        triggered_by: triggeredBy,
+        metadata: JSON.stringify({ command, commentId }),
+        github_delivery_id: deliveryId,
+      });
+      await executeSideEffects([
+        { type: "spawn_agent", role: "implementer", issueNumber },
+        { type: "post_comment", issueNumber,
+          body: `Spawning **implementer** agent per @${triggeredBy}'s request.` },
+      ], repo);
+      return { status: 200, body: "implementer spawned (new workflow)" };
     }
 
     log.info(`Spawning implementer for #${issueNumber} via mention`, { issueNumber });
@@ -649,13 +678,42 @@ async function handleMentionCommand(
 
   // ── verify this ──────────────────────────────────────────────────
   if (cmdLower === "verify this" || cmdLower === "verify") {
-    const wfRow = await getWorkflowByIssue(db, issueNumber, repo);
+    let wfRow = await getWorkflowByIssue(db, issueNumber, repo);
     if (!wfRow) {
-      await executeSideEffects([{
-        type: "post_comment", issueNumber,
-        body: `No workflow found. Use \`@${BOT_USERNAME} plan this\` first.`,
-      }], repo);
-      return { status: 200, body: "no workflow" };
+      // Create workflow on the fly and spawn QE
+      try {
+        await gh.assignIssue(repo, issueNumber, [BOT_USERNAME]);
+      } catch (err) {
+        log.warn(`Failed to auto-assign bot to #${issueNumber}: ${err}`);
+      }
+      const intent = `Verification triggered by @${triggeredBy}`;
+      const wfId = makeWorkflowId(repo, issueNumber);
+      await upsertWorkflow(db, {
+        id: wfId,
+        issue_number: issueNumber,
+        repo,
+        state: "VERIFYING",
+        level: "sub",
+        parent_workflow_id: null,
+        author: triggeredBy,
+        intent,
+      });
+      await addTransition(db, {
+        id: `t-${crypto.randomUUID()}`,
+        workflow_id: wfId,
+        from_state: "NEW",
+        to_state: "VERIFYING",
+        event_type: "mention:verify",
+        triggered_by: triggeredBy,
+        metadata: JSON.stringify({ command, commentId }),
+        github_delivery_id: deliveryId,
+      });
+      await executeSideEffects([
+        { type: "spawn_agent", role: "qe", issueNumber },
+        { type: "post_comment", issueNumber,
+          body: `Spawning **QE** agent per @${triggeredBy}'s request.` },
+      ], repo);
+      return { status: 200, body: "qe spawned (new workflow)" };
     }
 
     log.info(`Spawning QE for #${issueNumber} via mention`, { issueNumber });

--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -6,6 +6,7 @@ import type { Database } from "../store/database.js";
 import { createAgentSession, updateAgentStatus, getAgentSession, incrementRetryCount, updateAgentSessionFields } from "../store/queries.js";
 import { createLogger } from "../logger.js";
 import { findSessionForIssue } from "./session-lookup.js";
+import { getInstallationToken } from "../github/client.js";
 
 const ZAPBOT_DIR = path.resolve(import.meta.dir, "../..");
 
@@ -184,11 +185,16 @@ export async function spawnAgent(
 
     // Build env for ao spawn: it needs AO_CONFIG_PATH to find the yaml,
     // and AO_PROJECT_ID to select the right project in multi-repo setups.
+    // GH_TOKEN makes gh CLI and git operations run as the bot, not the user.
     const spawnEnv: Record<string, string | undefined> = {
       ...process.env,
       ZAPBOT_AGENT_ID: agentId,
       ZAPBOT_AGENT_ROLE: ctx.role,
     };
+    const botToken = await getInstallationToken();
+    if (botToken) {
+      spawnEnv.GH_TOKEN = botToken;
+    }
     if (process.env.ZAPBOT_CONFIG) {
       spawnEnv.AO_CONFIG_PATH = process.env.ZAPBOT_CONFIG;
     }

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -195,6 +195,28 @@ function wrapOctokit(octokit: Octokit): GitHubClient {
   };
 }
 
+// ── Installation token for agent sessions ──────────────────────────
+
+let _authInstance: ReturnType<typeof createAppAuth> | null = null;
+
+/**
+ * Get a fresh GitHub App installation token. Agents use this as GH_TOKEN
+ * so gh CLI and git operations run as the bot, not the user.
+ * Returns null if not using GitHub App auth (PAT mode).
+ */
+export async function getInstallationToken(): Promise<string | null> {
+  if (!_authInstance) {
+    const appId = process.env.GITHUB_APP_ID;
+    if (!appId) return null;
+    const privateKey = loadPrivateKey();
+    const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+    if (!installationId) return null;
+    _authInstance = createAppAuth({ appId, privateKey, installationId });
+  }
+  const auth = await _authInstance({ type: "installation" });
+  return auth.token;
+}
+
 // ── Factory ─────────────────────────────────────────────────────────
 
 export function createGitHubClient(): GitHubClient {


### PR DESCRIPTION
## Summary

- **Bot token injection**: agents now run as `zapbot-ai[bot]` instead of the user. `getInstallationToken()` generates GitHub App tokens, spawner sets `GH_TOKEN` in the agent's tmux env.
- **Loose transitions**: `@zapbot implement this` and `@zapbot verify this` create workflows on the fly instead of requiring `plan this` first. Same pattern as `investigate this`.

## Test plan

- [x] 584 tests pass, 0 fail
- [x] Verified agents post comments as bot (issue #73, #74)
- [x] Verified `implement this` on issue with no workflow creates one

🤖 Generated with [Claude Code](https://claude.com/claude-code)