### PR TITLE
fix: sort progress task list by status (closes #81)

### DIFF
--- a/src/agents/progress.ts
+++ b/src/agents/progress.ts
@@ -106,6 +106,17 @@ export async function resolveClaudeSessionFromWorktree(worktreePath: string): Pr
 
 // ── Comment formatting ──────────────────────────────────────────
 
+const STATUS_ORDER: Record<AgentTask["status"], number> = {
+  completed: 0,
+  in_progress: 1,
+  pending: 2,
+};
+
+/** Sort tasks: completed first, then in_progress, then pending. Stable sort preserves creation order within each group. */
+export function sortTasksByStatus(tasks: AgentTask[]): AgentTask[] {
+  return [...tasks].sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+}
+
 export function formatProgressComment(role: string, tasks: AgentTask[]): string {
   const lines: string[] = [`**${role}** agent progress`];
 
@@ -114,8 +125,10 @@ export function formatProgressComment(role: string, tasks: AgentTask[]): string 
     return lines.join("\n");
   }
 
+  const sorted = sortTasksByStatus(tasks);
+
   lines.push("");
-  for (const task of tasks) {
+  for (const task of sorted) {
     const checked = task.status === "completed" ? "x" : " ";
     const suffix = task.status === "in_progress" ? " ← working" : "";
     lines.push(`- [${checked}] ${task.subject}${suffix}`);

--- a/test/progress.test.ts
+++ b/test/progress.test.ts
@@ -15,6 +15,7 @@ import {
   readAgentTasks,
   formatProgressComment,
   formatFinalComment,
+  sortTasksByStatus,
   type AgentTask,
 } from "../src/agents/progress.js";
 import { toClaudeProjectPath } from "../src/agents/spawner.js";
@@ -189,6 +190,69 @@ describe("formatProgressComment", () => {
     const comment = formatProgressComment("triage", []);
     expect(comment).toContain("Agent is working...");
     expect(comment).toContain("**triage** agent progress");
+  });
+});
+
+describe("sortTasksByStatus", () => {
+  it("sorts completed first, then in_progress, then pending", () => {
+    const tasks: AgentTask[] = [
+      { id: "1", subject: "Run tests", activeForm: "", status: "pending", blocks: [], blockedBy: [] },
+      { id: "2", subject: "Update handler.ts", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+      { id: "3", subject: "Update endpoints.test.ts", activeForm: "", status: "in_progress", blocks: [], blockedBy: [] },
+      { id: "4", subject: "Rewrite auth.test.ts", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+      { id: "5", subject: "Update index.ts", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+      { id: "6", subject: "Remove jose", activeForm: "", status: "pending", blocks: [], blockedBy: [] },
+      { id: "7", subject: "Rewrite auth.ts", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+    ];
+    const sorted = sortTasksByStatus(tasks);
+    expect(sorted.map((t) => t.status)).toEqual([
+      "completed", "completed", "completed", "completed",
+      "in_progress",
+      "pending", "pending",
+    ]);
+    // Preserve creation order within each group
+    expect(sorted.filter((t) => t.status === "completed").map((t) => t.id)).toEqual(["2", "4", "5", "7"]);
+    expect(sorted.filter((t) => t.status === "pending").map((t) => t.id)).toEqual(["1", "6"]);
+  });
+
+  it("preserves order when already sorted", () => {
+    const tasks: AgentTask[] = [
+      { id: "1", subject: "A", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+      { id: "2", subject: "B", activeForm: "", status: "in_progress", blocks: [], blockedBy: [] },
+      { id: "3", subject: "C", activeForm: "", status: "pending", blocks: [], blockedBy: [] },
+    ];
+    const sorted = sortTasksByStatus(tasks);
+    expect(sorted.map((t) => t.id)).toEqual(["1", "2", "3"]);
+  });
+
+  it("does not mutate the original array", () => {
+    const tasks: AgentTask[] = [
+      { id: "1", subject: "A", activeForm: "", status: "pending", blocks: [], blockedBy: [] },
+      { id: "2", subject: "B", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+    ];
+    sortTasksByStatus(tasks);
+    expect(tasks[0].id).toBe("1");
+    expect(tasks[1].id).toBe("2");
+  });
+});
+
+describe("formatProgressComment with out-of-order tasks", () => {
+  it("renders completed tasks first in the progress comment", () => {
+    const tasks: AgentTask[] = [
+      { id: "1", subject: "Run tests", activeForm: "", status: "pending", blocks: [], blockedBy: [] },
+      { id: "2", subject: "Update handler.ts", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+      { id: "3", subject: "Update endpoints.test.ts", activeForm: "", status: "in_progress", blocks: [], blockedBy: [] },
+      { id: "4", subject: "Rewrite auth.ts", activeForm: "", status: "completed", blocks: [], blockedBy: [] },
+    ];
+    const comment = formatProgressComment("implementer", tasks);
+    const lines = comment.split("\n").filter((l) => l.startsWith("- ["));
+
+    // Completed first, then in_progress, then pending
+    expect(lines[0]).toBe("- [x] Update handler.ts");
+    expect(lines[1]).toBe("- [x] Rewrite auth.ts");
+    expect(lines[2]).toBe("- [ ] Update endpoints.test.ts ← working");
+    expect(lines[3]).toBe("- [ ] Run tests");
+    expect(comment).toContain("2/4 done");
   });
 });
 


### PR DESCRIPTION
## Summary
- Sorts the progress comment task list: completed tasks first, then in-progress, then pending
- Preserves creation order within each status group (stable sort)
- Adds `sortTasksByStatus` helper to `src/agents/progress.ts` and uses it in `formatProgressComment`
- Adds tests for sorting logic, immutability, and end-to-end comment formatting

Closes #81

## Test plan
- [x] All 34 progress tests pass (`bun test test/progress.test.ts`)
- [x] New `sortTasksByStatus` tests cover the exact scenario from the issue (scattered completions)
- [x] Existing `formatProgressComment` tests still pass (tasks already in correct order are unchanged)
- [x] Verified sort does not mutate the original array

🤖 Generated with [Claude Code](https://claude.com/claude-code)