### PR TITLE
feat: replace Supabase JWT with GitHub API token verification

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "@octokit/auth-app": "^8.2.0",
         "@octokit/rest": "^22.0.1",
-        "jose": "^6.2.2",
         "kysely": "^0.28.16",
         "yaml": "^2.8.3",
       },
@@ -210,8 +209,6 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 

--- a/gateway/.env.example
+++ b/gateway/.env.example
@@ -1,20 +1,7 @@
-# Supabase JWT secret for token verification.
-# Required unless GATEWAY_SECRET is set (at least one auth method needed).
-# SUPABASE_JWT_SECRET=your-jwt-secret-from-supabase-dashboard
-
-# Supabase project URL (optional). Used to validate JWT issuer claim.
-# SUPABASE_URL=https://your-project.supabase.co
-
-# Legacy shared secret for bridge registration authentication (deprecated).
-# Bridges must send this as Bearer token when registering/deregistering.
-# Migrate to Supabase JWT and set LEGACY_AUTH_ENABLED=false.
+# Shared secret for bridge authentication.
+# Required. Bridges send this as Bearer token when registering/deregistering.
+# For GitHub App setups, bridges can also use a GitHub App installation token.
 GATEWAY_SECRET=change-me-to-a-random-secret
-
-# Set to "false" to disable legacy shared-secret auth after migrating to JWT.
-# LEGACY_AUTH_ENABLED=true
-
-# Maximum JWT age in seconds. Tokens issued longer ago are rejected.
-# JWT_MAX_AGE_SECONDS=3600
 
 # Port the gateway listens on. Railway sets this automatically.
 # PORT=8080

--- a/gateway/bun.lock
+++ b/gateway/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "zapbot-gateway",
-      "dependencies": {
-        "jose": "^6.2.2",
-      },
       "devDependencies": {
         "bun-types": "^1.3.12",
         "typescript": "^6.0.2",
@@ -166,8 +163,6 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -12,8 +12,5 @@
     "bun-types": "^1.3.12",
     "typescript": "^6.0.2",
     "vitest": "^3.2.4"
-  },
-  "dependencies": {
-    "jose": "^6.2.2"
   }
 }

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -1,28 +1,23 @@
 /**
- * Gateway authentication — JWT verification with legacy shared-secret fallback.
+ * Gateway authentication — GitHub API token verification with shared-secret fallback.
  *
- * Uses the `jose` library for direct JWT verification with SUPABASE_JWT_SECRET.
- * No Supabase client SDK dependency — the gateway stays stateless.
+ * Two auth methods:
+ * 1. GitHub App installation token — verified by calling the GitHub API
+ * 2. Shared secret (GATEWAY_SECRET) — simple PAT-mode for setups without a GitHub App
  */
 
-import { jwtVerify, errors as joseErrors } from "jose";
 import { timingSafeEqual } from "crypto";
 
 // ── Types ──────────────────────────────────────────────────────────
 
-export interface GatewayUser {
-  sub: string;            // Supabase user ID (or "legacy" for shared-secret auth)
-  email?: string;
-  role: "owner" | "member";
-  authorizedRepos: string[];  // ["org/repo1", "org/repo2"] or ["*"] for legacy
+export interface AuthResult {
+  valid: boolean;
+  repos: string[];        // ["org/repo1", "org/repo2"] or ["*"] for shared-secret
+  source: "github" | "shared-secret";
 }
 
 export interface AuthConfig {
-  jwtSecret: string;              // SUPABASE_JWT_SECRET
-  jwtIssuer?: string;             // Expected JWT issuer (Supabase project URL + /auth/v1)
-  legacySecret?: string;          // GATEWAY_SECRET (backward compat)
-  legacyEnabled: boolean;         // LEGACY_AUTH_ENABLED
-  maxAgeSeconds: number;          // Max JWT age (default: 3600 = 1 hour)
+  gatewaySecret?: string; // GATEWAY_SECRET for shared-secret auth
 }
 
 export interface AuthError {
@@ -31,202 +26,151 @@ export interface AuthError {
   fix: string;
 }
 
-export type AuthResult =
-  | { ok: true; user: GatewayUser }
+export type AuthOutcome =
+  | { ok: true; result: AuthResult }
   | { ok: false; error: AuthError };
 
 // ── Helpers ────────────────────────────────────────────────────────
 
 const encoder = new TextEncoder();
 
-/** Track whether we've logged the legacy deprecation warning this startup. */
-let legacyDeprecationLogged = false;
-
-/** Reset the deprecation flag — exposed for tests. */
-export function resetLegacyDeprecationFlag(): void {
-  legacyDeprecationLogged = false;
-}
-
-function authError(type: string, message: string, fix: string): AuthResult {
+function authError(type: string, message: string, fix: string): AuthOutcome {
   return { ok: false, error: { type, message, fix } };
 }
 
-// ── JWT verification ───────────────────────────────────────────────
+// ── GitHub token cache ─────────────────────────────────────────────
 
-interface SupabaseJwtPayload {
-  sub?: string;
-  email?: string;
-  iss?: string;
-  aud?: string | string[];
-  exp?: number;
-  iat?: number;
-  app_metadata?: {
-    role?: string;
-    authorized_repos?: string[];
-  };
+interface CacheEntry {
+  result: AuthResult;
+  expiresAt: number;
 }
 
-async function verifyJwt(
+const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const tokenCache = new Map<string, CacheEntry>();
+
+/** Clear the token cache — exposed for tests. */
+export function clearTokenCache(): void {
+  tokenCache.clear();
+}
+
+/** Get current cache size — exposed for tests. */
+export function getTokenCacheSize(): number {
+  return tokenCache.size;
+}
+
+// ── GitHub token verification ──────────────────────────────────────
+
+/**
+ * Verify a GitHub App installation token by calling the GitHub API.
+ *
+ * Calls `GET https://api.github.com/installation/repositories` with the token.
+ * - 200 = valid installation token; extract repo list
+ * - 401 = invalid/expired token; reject
+ *
+ * Results are cached for 5 minutes to avoid hitting GitHub API on every heartbeat.
+ */
+export async function verifyGitHubToken(
   token: string,
-  config: AuthConfig,
-): Promise<AuthResult> {
-  const secret = encoder.encode(config.jwtSecret);
+): Promise<AuthOutcome> {
+  // Check cache first
+  const cached = tokenCache.get(token);
+  if (cached && cached.expiresAt > Date.now()) {
+    return { ok: true, result: cached.result };
+  }
 
-  let payload: SupabaseJwtPayload;
+  // Evict expired entry if present
+  if (cached) {
+    tokenCache.delete(token);
+  }
+
   try {
-    const result = await jwtVerify(token, secret, {
-      algorithms: ["HS256"],
-      ...(config.jwtIssuer ? { issuer: config.jwtIssuer } : {}),
-      audience: "authenticated",
+    const resp = await globalThis.fetch(
+      "https://api.github.com/installation/repositories",
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: "application/vnd.github+json",
+          "x-github-api-version": "2022-11-28",
+          "user-agent": "zapbot-gateway",
+        },
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+
+    if (resp.status === 401) {
+      return authError(
+        "invalid_token",
+        "GitHub token is invalid or expired.",
+        "Ensure you are sending a valid GitHub App installation token.",
+      );
+    }
+
+    if (!resp.ok) {
+      return authError(
+        "github_api_error",
+        `GitHub API returned ${resp.status}.`,
+        "Check GitHub API status and try again.",
+      );
+    }
+
+    const body = (await resp.json()) as {
+      repositories?: Array<{ full_name: string }>;
+    };
+
+    const repos = (body.repositories || []).map((r) => r.full_name);
+
+    const result: AuthResult = {
+      valid: true,
+      repos,
+      source: "github",
+    };
+
+    // Cache the successful result
+    tokenCache.set(token, {
+      result,
+      expiresAt: Date.now() + TOKEN_CACHE_TTL_MS,
     });
-    payload = result.payload as SupabaseJwtPayload;
-  } catch (err) {
-    if (err instanceof joseErrors.JWTExpired) {
-      return authError(
-        "token_expired",
-        `Token expired at ${err.payload?.exp ? new Date((err.payload.exp as number) * 1000).toISOString() : "unknown"}`,
-        "Refresh your Supabase JWT.",
-      );
-    }
-    if (err instanceof joseErrors.JWSSignatureVerificationFailed) {
-      return authError(
-        "invalid_signature",
-        "Token signature verification failed.",
-        "Verify SUPABASE_JWT_SECRET matches your Supabase project.",
-      );
-    }
-    if (err instanceof joseErrors.JWTClaimValidationFailed) {
-      const claim = err.claim || "unknown";
-      if (claim === "iss") {
-        return authError(
-          "invalid_issuer",
-          "Token issuer does not match expected.",
-          "Check SUPABASE_URL configuration.",
-        );
-      }
-      if (claim === "aud") {
-        return authError(
-          "invalid_audience",
-          "Token audience does not match expected.",
-          'Ensure your Supabase JWT has audience "authenticated".',
-        );
-      }
-      return authError(
-        "invalid_claims",
-        `JWT claim validation failed: ${claim}`,
-        "Check your Supabase JWT configuration.",
-      );
-    }
-    return authError(
-      "invalid_token",
-      "Token verification failed.",
-      "Ensure you are sending a valid Supabase JWT.",
-    );
-  }
 
-  // Check max age (iat must be within maxAgeSeconds)
-  if (payload.iat === undefined || payload.iat === null) {
+    return { ok: true, result };
+  } catch {
     return authError(
-      "missing_claims",
-      "Token missing required claim: iat",
-      "Ensure your Supabase JWT includes an issued-at (iat) claim.",
+      "github_api_error",
+      "Failed to reach GitHub API for token verification.",
+      "Check network connectivity and try again.",
     );
   }
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  const age = nowSeconds - payload.iat;
-  if (age > config.maxAgeSeconds) {
-    return authError(
-      "token_too_old",
-      `Token issued more than ${config.maxAgeSeconds} seconds ago.`,
-      "Obtain a fresh JWT.",
-    );
-  }
-
-  // Extract and validate claims
-  if (!payload.sub) {
-    return authError(
-      "missing_claims",
-      "Token missing required claim: sub",
-      "Ensure your Supabase JWT includes a subject claim.",
-    );
-  }
-
-  const appMeta = payload.app_metadata;
-  const role = appMeta?.role;
-  if (role !== "owner" && role !== "member") {
-    return authError(
-      "missing_claims",
-      "Token missing required claim: app_metadata.role (must be 'owner' or 'member')",
-      "Set app_metadata.role in Supabase.",
-    );
-  }
-
-  const authorizedRepos = appMeta?.authorized_repos;
-  if (!Array.isArray(authorizedRepos) || authorizedRepos.length === 0) {
-    return authError(
-      "missing_claims",
-      "Token missing required claim: app_metadata.authorized_repos",
-      "Set app_metadata.authorized_repos in Supabase.",
-    );
-  }
-
-  return {
-    ok: true,
-    user: {
-      sub: payload.sub,
-      email: payload.email,
-      role,
-      authorizedRepos,
-    },
-  };
 }
 
-// ── Legacy shared-secret verification ──────────────────────────────
+// ── Shared-secret verification ─────────────────────────────────────
 
-function verifyLegacy(token: string, config: AuthConfig): AuthResult {
-  if (!config.legacyEnabled) {
-    return authError(
-      "invalid_token",
-      "Legacy shared-secret auth is disabled.",
-      "Use a Supabase JWT for authentication.",
-    );
-  }
-  if (!config.legacySecret) {
-    return authError(
-      "invalid_token",
-      "Token verification failed.",
-      "Ensure you are sending a valid Supabase JWT.",
-    );
-  }
-
+/**
+ * Verify a shared secret (GATEWAY_SECRET).
+ * Simple alternative for setups without a GitHub App.
+ */
+export function verifySharedSecret(
+  token: string,
+  secret: string,
+): AuthOutcome {
   const tokenBuf = encoder.encode(token);
-  const secretBuf = encoder.encode(config.legacySecret);
+  const secretBuf = encoder.encode(secret);
   const secretsMatch =
     tokenBuf.length === secretBuf.length &&
     timingSafeEqual(tokenBuf, secretBuf);
+
   if (!secretsMatch) {
     return authError(
       "invalid_token",
       "Token verification failed.",
-      "Check your GATEWAY_SECRET or use a valid Supabase JWT.",
+      "Check your GATEWAY_SECRET or use a valid GitHub App installation token.",
     );
-  }
-
-  // Log deprecation warning once per startup
-  if (!legacyDeprecationLogged) {
-    console.warn(
-      "[gateway] DEPRECATION: Legacy shared-secret auth used. Migrate to Supabase JWT. " +
-      "Set LEGACY_AUTH_ENABLED=false after migrating all bridges.",
-    );
-    legacyDeprecationLogged = true;
   }
 
   return {
     ok: true,
-    user: {
-      sub: "legacy",
-      role: "owner",
-      authorizedRepos: ["*"],
+    result: {
+      valid: true,
+      repos: ["*"],
+      source: "shared-secret",
     },
   };
 }
@@ -238,20 +182,20 @@ function verifyLegacy(token: string, config: AuthConfig): AuthResult {
  *
  * Flow:
  * 1. Extract Bearer token from Authorization header
- * 2. Try JWT verification first
- * 3. If JWT fails and legacy auth is enabled, try shared-secret check
- * 4. Return GatewayUser on success, structured AuthError on failure
+ * 2. Try shared-secret check first (fast, no network)
+ * 3. If not a shared secret, try GitHub token verification
+ * 4. Return AuthResult on success, structured AuthError on failure
  */
 export async function verifyRequest(
   req: Request,
   config: AuthConfig,
-): Promise<AuthResult> {
+): Promise<AuthOutcome> {
   const authHeader = req.headers.get("authorization");
   if (!authHeader) {
     return authError(
       "missing_token",
       "No Authorization header provided.",
-      "Include `Authorization: Bearer <jwt>` header.",
+      "Include `Authorization: Bearer <token>` header.",
     );
   }
 
@@ -266,55 +210,26 @@ export async function verifyRequest(
 
   const token = parts[1];
 
-  // Try JWT verification first (if jwtSecret is configured)
-  if (config.jwtSecret) {
-    const jwtResult = await verifyJwt(token, config);
-    if (jwtResult.ok) {
-      return jwtResult;
+  // Try shared-secret first (fast, no network call)
+  if (config.gatewaySecret) {
+    const secretResult = verifySharedSecret(token, config.gatewaySecret);
+    if (secretResult.ok) {
+      return secretResult;
     }
-
-    // JWT failed — try legacy if enabled
-    if (config.legacyEnabled && config.legacySecret) {
-      const legacyResult = verifyLegacy(token, config);
-      if (legacyResult.ok) {
-        return legacyResult;
-      }
-    }
-
-    // Return the JWT error (more informative than legacy error)
-    return jwtResult;
   }
 
-  // No JWT secret configured — only legacy auth available
-  return verifyLegacy(token, config);
+  // Try GitHub token verification
+  return verifyGitHubToken(token);
 }
 
 /**
- * Check if a user has the required role.
- * Owners satisfy both "owner" and "member" requirements.
- */
-export function requireRole(
-  user: GatewayUser,
-  role: "owner" | "member",
-): boolean {
-  if (role === "member") return true; // Both owner and member satisfy "member"
-  return user.role === "owner";
-}
-
-/**
- * Check if a user is authorized for a specific repo.
- * Wildcard "*" (used by legacy auth) matches any repo.
+ * Check if an auth result authorizes access to a specific repo.
+ * Wildcard "*" (used by shared-secret auth) matches any repo.
  */
 export function requireRepoAccess(
-  user: GatewayUser,
+  result: AuthResult,
   repo: string,
 ): boolean {
-  if (user.authorizedRepos.includes("*")) return true;
-  if (user.authorizedRepos.includes(repo)) return true;
-
-  // Check org-level wildcard: if user has "org" authorized, it matches "org/any-repo"
-  const repoOrg = repo.split("/")[0];
-  if (repoOrg && user.authorizedRepos.includes(repoOrg)) return true;
-
-  return false;
+  if (result.repos.includes("*")) return true;
+  return result.repos.includes(repo);
 }

--- a/gateway/src/handler.ts
+++ b/gateway/src/handler.ts
@@ -13,10 +13,9 @@ import {
 } from "./registry.js";
 import {
   verifyRequest,
-  requireRole,
   requireRepoAccess,
   type AuthConfig,
-  type GatewayUser,
+  type AuthResult,
   type AuthError,
 } from "./auth.js";
 
@@ -27,7 +26,7 @@ function errorResponse(status: number, type: string, message: string, extra?: Re
 }
 
 function authErrorResponse(error: AuthError): Response {
-  const status = error.type === "insufficient_role" || error.type === "repo_not_authorized" ? 403 : 401;
+  const status = error.type === "repo_not_authorized" ? 403 : 401;
   return Response.json(
     { error: { type: error.type, message: error.message, fix: error.fix, status } },
     { status },
@@ -78,10 +77,6 @@ export function createFetchHandler(config: GatewayConfig) {
       return handleBridgeDeregister(req, authConfig);
     }
 
-    if (pathname === "/api/auth/me" && req.method === "GET") {
-      return handleAuthMe(req, authConfig);
-    }
-
     return errorResponse(404, "not_found", "Resource not found.");
   };
 }
@@ -91,22 +86,13 @@ export function createFetchHandler(config: GatewayConfig) {
 async function authenticateRequest(
   req: Request,
   authConfig: AuthConfig,
-  requiredRole?: "owner" | "member",
-): Promise<GatewayUser | Response> {
-  const result = await verifyRequest(req, authConfig);
-  if (!result.ok) {
-    return authErrorResponse(result.error);
+): Promise<AuthResult | Response> {
+  const outcome = await verifyRequest(req, authConfig);
+  if (!outcome.ok) {
+    return authErrorResponse(outcome.error);
   }
 
-  if (requiredRole && !requireRole(result.user, requiredRole)) {
-    return authErrorResponse({
-      type: "insufficient_role",
-      message: `Operation requires ${requiredRole} role, you have ${result.user.role}.`,
-      fix: "Contact bot owner for role upgrade.",
-    });
-  }
-
-  return result.user;
+  return outcome.result;
 }
 
 // ── Request handlers ────────────────────────────────────────────────
@@ -158,8 +144,8 @@ async function handleWebhookForward(req: Request, timeoutMs: number): Promise<Re
 }
 
 async function handleBridgeRegister(req: Request, authConfig: AuthConfig): Promise<Response> {
-  const userOrResp = await authenticateRequest(req, authConfig, "owner");
-  if (userOrResp instanceof Response) return userOrResp;
+  const authOrResp = await authenticateRequest(req, authConfig);
+  if (authOrResp instanceof Response) return authOrResp;
 
   let body: any;
   try {
@@ -176,11 +162,11 @@ async function handleBridgeRegister(req: Request, authConfig: AuthConfig): Promi
     return errorResponse(400, "invalid_request", "Missing or invalid 'bridgeUrl' field.");
   }
 
-  if (!requireRepoAccess(userOrResp, repo)) {
+  if (!requireRepoAccess(authOrResp, repo)) {
     return authErrorResponse({
       type: "repo_not_authorized",
       message: `Not authorized for repo ${repo}.`,
-      fix: "Add repo to your authorized_repos in Supabase.",
+      fix: "Ensure the GitHub App is installed on this repository.",
     });
   }
 
@@ -189,8 +175,8 @@ async function handleBridgeRegister(req: Request, authConfig: AuthConfig): Promi
 }
 
 async function handleBridgeDeregister(req: Request, authConfig: AuthConfig): Promise<Response> {
-  const userOrResp = await authenticateRequest(req, authConfig, "owner");
-  if (userOrResp instanceof Response) return userOrResp;
+  const authOrResp = await authenticateRequest(req, authConfig);
+  if (authOrResp instanceof Response) return authOrResp;
 
   let body: any;
   try {
@@ -204,26 +190,14 @@ async function handleBridgeDeregister(req: Request, authConfig: AuthConfig): Pro
     return errorResponse(400, "invalid_request", "Missing or invalid 'repo' field.");
   }
 
-  if (!requireRepoAccess(userOrResp, repo)) {
+  if (!requireRepoAccess(authOrResp, repo)) {
     return authErrorResponse({
       type: "repo_not_authorized",
       message: `Not authorized for repo ${repo}.`,
-      fix: "Add repo to your authorized_repos in Supabase.",
+      fix: "Ensure the GitHub App is installed on this repository.",
     });
   }
 
   const removed = deregisterBridge(repo);
   return Response.json({ ok: true, removed });
-}
-
-async function handleAuthMe(req: Request, authConfig: AuthConfig): Promise<Response> {
-  const userOrResp = await authenticateRequest(req, authConfig);
-  if (userOrResp instanceof Response) return userOrResp;
-
-  return Response.json({
-    sub: userOrResp.sub,
-    email: userOrResp.email,
-    role: userOrResp.role,
-    authorizedRepos: userOrResp.authorizedRepos,
-  });
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -16,11 +16,7 @@ import type { AuthConfig } from "./auth.js";
 // ── Config ──────────────────────────────────────────────────────────
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
-const SUPABASE_JWT_SECRET = process.env.SUPABASE_JWT_SECRET || "";
-const SUPABASE_URL = process.env.SUPABASE_URL || "";
 const GATEWAY_SECRET = process.env.GATEWAY_SECRET || "";
-const LEGACY_AUTH_ENABLED = process.env.LEGACY_AUTH_ENABLED !== "false";
-const JWT_MAX_AGE_SECONDS = parseInt(process.env.JWT_MAX_AGE_SECONDS || "3600", 10) || 3600;
 const LIVENESS_INTERVAL_MS = parseInt(process.env.LIVENESS_INTERVAL_MS || "30000", 10);
 const STALE_TIMEOUT_MS = parseInt(process.env.STALE_TIMEOUT_MS || "600000", 10);
 const FORWARD_TIMEOUT_MS = parseInt(process.env.FORWARD_TIMEOUT_MS || "30000", 10);
@@ -40,33 +36,20 @@ function log(level: string, message: string, kv: Record<string, unknown> = {}): 
 
 // ── Startup validation ──────────────────────────────────────────────
 
-if (!SUPABASE_JWT_SECRET && !GATEWAY_SECRET) {
-  log("error", "Either SUPABASE_JWT_SECRET or GATEWAY_SECRET must be set.");
+if (!GATEWAY_SECRET) {
+  log("error", "GATEWAY_SECRET must be set.");
   process.exit(1);
 }
 
-if (!SUPABASE_JWT_SECRET) {
-  log("warn", "SUPABASE_JWT_SECRET not set. Only legacy auth available.");
-}
-
-if (GATEWAY_SECRET && LEGACY_AUTH_ENABLED) {
-  log("warn", "Legacy auth enabled. Set LEGACY_AUTH_ENABLED=false after migrating bridges to JWT.");
-}
-
 log("info", "Auth config", {
-  jwt_enabled: !!SUPABASE_JWT_SECRET,
-  legacy_enabled: LEGACY_AUTH_ENABLED && !!GATEWAY_SECRET,
-  max_age_s: JWT_MAX_AGE_SECONDS,
+  shared_secret: "enabled",
+  github_token_verification: "enabled (per-request)",
 });
 
 // ── Auth config ────────────────────────────────────────────────────
 
 const authConfig: AuthConfig = {
-  jwtSecret: SUPABASE_JWT_SECRET,
-  jwtIssuer: SUPABASE_URL ? `${SUPABASE_URL}/auth/v1` : undefined,
-  legacySecret: GATEWAY_SECRET || undefined,
-  legacyEnabled: LEGACY_AUTH_ENABLED,
-  maxAgeSeconds: JWT_MAX_AGE_SECONDS,
+  gatewaySecret: GATEWAY_SECRET,
 };
 
 // ── Server ──────────────────────────────────────────────────────────

--- a/gateway/test/auth.test.ts
+++ b/gateway/test/auth.test.ts
@@ -1,60 +1,31 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { SignJWT } from "jose";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
+  verifyGitHubToken,
+  verifySharedSecret,
   verifyRequest,
-  requireRole,
   requireRepoAccess,
-  resetLegacyDeprecationFlag,
+  clearTokenCache,
+  getTokenCacheSize,
   type AuthConfig,
-  type GatewayUser,
+  type AuthResult,
 } from "../src/auth.js";
 
 // ── Test helpers ───────────────────────────────────────────────────
 
-const TEST_JWT_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
-const TEST_LEGACY_SECRET = "test-legacy-secret";
-const TEST_ISSUER = "https://test.supabase.co/auth/v1";
-const encoder = new TextEncoder();
+const TEST_GATEWAY_SECRET = "test-gateway-secret";
+
+const MOCK_REPOS_RESPONSE = {
+  repositories: [
+    { full_name: "acme/app" },
+    { full_name: "acme/lib" },
+  ],
+};
 
 function defaultConfig(overrides?: Partial<AuthConfig>): AuthConfig {
   return {
-    jwtSecret: TEST_JWT_SECRET,
-    jwtIssuer: TEST_ISSUER,
-    legacySecret: TEST_LEGACY_SECRET,
-    legacyEnabled: true,
-    maxAgeSeconds: 3600,
+    gatewaySecret: TEST_GATEWAY_SECRET,
     ...overrides,
   };
-}
-
-async function createTestJWT(
-  claims: Record<string, unknown> = {},
-  options?: { expiresIn?: string; iat?: number; skipIat?: boolean; secret?: string; issuer?: string; audience?: string },
-): Promise<string> {
-  const secret = options?.secret || TEST_JWT_SECRET;
-  const builder = new SignJWT({
-    sub: "user-uuid-123",
-    email: "test@example.com",
-    app_metadata: {
-      role: "owner",
-      authorized_repos: ["acme/app", "acme/lib"],
-    },
-    ...claims,
-  })
-    .setProtectedHeader({ alg: "HS256" })
-    .setIssuer(options?.issuer ?? TEST_ISSUER)
-    .setAudience(options?.audience ?? "authenticated")
-    .setExpirationTime(options?.expiresIn || "1h");
-
-  if (options?.skipIat) {
-    // Don't set iat at all
-  } else if (options?.iat !== undefined) {
-    builder.setIssuedAt(options.iat);
-  } else {
-    builder.setIssuedAt();
-  }
-
-  return builder.sign(encoder.encode(secret));
 }
 
 function makeRequest(token?: string): Request {
@@ -65,15 +36,177 @@ function makeRequest(token?: string): Request {
   return new Request("http://localhost/test", { headers });
 }
 
-// ── Tests ──────────────────────────────────────────────────────────
+// ── Setup ─────────────────────────────────────────────────────────
+
+const originalFetch = globalThis.fetch;
 
 beforeEach(() => {
-  resetLegacyDeprecationFlag();
+  clearTokenCache();
 });
 
-describe("verifyRequest", () => {
-  // ── Missing/malformed auth header ────────────────────────────────
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
 
+// ── verifyGitHubToken ─────────────────────────────────────────────
+
+describe("verifyGitHubToken", () => {
+  it("accepts a valid installation token (200 with repo list)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      Response.json(MOCK_REPOS_RESPONSE, { status: 200 }),
+    );
+
+    const result = await verifyGitHubToken("ghs_validtoken123");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.valid).toBe(true);
+      expect(result.result.source).toBe("github");
+      expect(result.result.repos).toEqual(["acme/app", "acme/lib"]);
+    }
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/installation/repositories",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer ghs_validtoken123",
+        }),
+      }),
+    );
+  });
+
+  it("rejects an expired/invalid token (401)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 }),
+    );
+
+    const result = await verifyGitHubToken("ghs_expired");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_token");
+      expect(result.error.message).toContain("invalid or expired");
+    }
+  });
+
+  it("handles GitHub API errors (non-200, non-401)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("Internal Server Error", { status: 500 }),
+    );
+
+    const result = await verifyGitHubToken("ghs_sometoken");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("github_api_error");
+      expect(result.error.message).toContain("500");
+    }
+  });
+
+  it("handles network failure (GitHub API down)", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const result = await verifyGitHubToken("ghs_sometoken");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("github_api_error");
+      expect(result.error.message).toContain("Failed to reach GitHub API");
+    }
+  });
+
+  it("caches valid tokens (no API call on second request within 5min)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      Response.json(MOCK_REPOS_RESPONSE, { status: 200 }),
+    );
+    globalThis.fetch = mockFetch;
+
+    // First call — hits API
+    const result1 = await verifyGitHubToken("ghs_cached");
+    expect(result1.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second call — should use cache
+    const result2 = await verifyGitHubToken("ghs_cached");
+    expect(result2.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // NOT called again
+
+    if (result2.ok) {
+      expect(result2.result.repos).toEqual(["acme/app", "acme/lib"]);
+    }
+  });
+
+  it("does not cache invalid tokens", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 }),
+    );
+    globalThis.fetch = mockFetch;
+
+    await verifyGitHubToken("ghs_invalid");
+    await verifyGitHubToken("ghs_invalid");
+
+    // Should call API both times since failures aren't cached
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts expired cache entries", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      Response.json(MOCK_REPOS_RESPONSE, { status: 200 }),
+    );
+    globalThis.fetch = mockFetch;
+
+    // First call — caches the result
+    await verifyGitHubToken("ghs_expiring");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(getTokenCacheSize()).toBe(1);
+
+    // Manually expire the cache entry by clearing and re-adding with past expiry
+    clearTokenCache();
+
+    // Next call — cache is empty, so API is called again
+    await verifyGitHubToken("ghs_expiring");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles empty repositories list", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      Response.json({ repositories: [] }, { status: 200 }),
+    );
+
+    const result = await verifyGitHubToken("ghs_norepos");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.repos).toEqual([]);
+    }
+  });
+});
+
+// ── verifySharedSecret ────────────────────────────────────────────
+
+describe("verifySharedSecret", () => {
+  it("accepts matching secret", () => {
+    const result = verifySharedSecret(TEST_GATEWAY_SECRET, TEST_GATEWAY_SECRET);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.source).toBe("shared-secret");
+      expect(result.result.repos).toEqual(["*"]);
+    }
+  });
+
+  it("rejects wrong secret", () => {
+    const result = verifySharedSecret("wrong-secret", TEST_GATEWAY_SECRET);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_token");
+    }
+  });
+
+  it("rejects empty token", () => {
+    const result = verifySharedSecret("", TEST_GATEWAY_SECRET);
+    expect(result.ok).toBe(false);
+  });
+});
+
+// ── verifyRequest ─────────────────────────────────────────────────
+
+describe("verifyRequest", () => {
   it("returns missing_token when no Authorization header", async () => {
     const result = await verifyRequest(makeRequest(), defaultConfig());
     expect(result.ok).toBe(false);
@@ -98,245 +231,74 @@ describe("verifyRequest", () => {
     }
   });
 
-  // ── Valid JWT ────────────────────────────────────────────────────
+  it("accepts shared secret (fast path, no GitHub API call)", async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
 
-  it("accepts a valid owner JWT", async () => {
-    const jwt = await createTestJWT();
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.user.sub).toBe("user-uuid-123");
-      expect(result.user.email).toBe("test@example.com");
-      expect(result.user.role).toBe("owner");
-      expect(result.user.authorizedRepos).toEqual(["acme/app", "acme/lib"]);
-    }
-  });
-
-  it("accepts a valid member JWT", async () => {
-    const jwt = await createTestJWT({
-      app_metadata: { role: "member", authorized_repos: ["acme/app"] },
-    });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.user.role).toBe("member");
-    }
-  });
-
-  // ── Expired JWT ──────────────────────────────────────────────────
-
-  it("rejects an expired JWT", async () => {
-    const jwt = await createTestJWT({}, { expiresIn: "-1h" });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("token_expired");
-    }
-  });
-
-  // ── Invalid signature ────────────────────────────────────────────
-
-  it("rejects a JWT signed with wrong secret", async () => {
-    const jwt = await createTestJWT({}, { secret: "wrong-secret-that-is-at-least-32-chars!" });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("invalid_signature");
-    }
-  });
-
-  // ── Wrong issuer ─────────────────────────────────────────────────
-
-  it("rejects a JWT with wrong issuer", async () => {
-    const jwt = await createTestJWT({}, { issuer: "https://wrong.supabase.co/auth/v1" });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("invalid_issuer");
-    }
-  });
-
-  // ── Wrong audience ───────────────────────────────────────────────
-
-  it("rejects a JWT with wrong audience", async () => {
-    const jwt = await createTestJWT({}, { audience: "wrong-audience" });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("invalid_audience");
-    }
-  });
-
-  // ── Token too old ────────────────────────────────────────────────
-
-  it("rejects a JWT that is too old (iat check)", async () => {
-    const twoHoursAgo = Math.floor(Date.now() / 1000) - 7200;
-    const jwt = await createTestJWT({}, { iat: twoHoursAgo });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("token_too_old");
-    }
-  });
-
-  // ── Missing iat ─────────────────────────────────────────────────
-
-  it("rejects a JWT without iat claim", async () => {
-    const jwt = await createTestJWT({}, { skipIat: true });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("missing_claims");
-      expect(result.error.message).toContain("iat");
-    }
-  });
-
-  // ── Missing claims ───────────────────────────────────────────────
-
-  it("rejects JWT without sub claim", async () => {
-    const jwt = await createTestJWT({ sub: undefined });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("missing_claims");
-      expect(result.error.message).toContain("sub");
-    }
-  });
-
-  it("rejects JWT without app_metadata.role", async () => {
-    const jwt = await createTestJWT({
-      app_metadata: { authorized_repos: ["acme/app"] },
-    });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("missing_claims");
-      expect(result.error.message).toContain("role");
-    }
-  });
-
-  it("rejects JWT without app_metadata.authorized_repos", async () => {
-    const jwt = await createTestJWT({
-      app_metadata: { role: "owner" },
-    });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("missing_claims");
-      expect(result.error.message).toContain("authorized_repos");
-    }
-  });
-
-  it("rejects JWT with empty authorized_repos array", async () => {
-    const jwt = await createTestJWT({
-      app_metadata: { role: "owner", authorized_repos: [] },
-    });
-    const result = await verifyRequest(makeRequest(`Bearer ${jwt}`), defaultConfig());
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.type).toBe("missing_claims");
-    }
-  });
-
-  // ── Legacy auth ──────────────────────────────────────────────────
-
-  it("accepts legacy secret when enabled", async () => {
     const result = await verifyRequest(
-      makeRequest(`Bearer ${TEST_LEGACY_SECRET}`),
+      makeRequest(`Bearer ${TEST_GATEWAY_SECRET}`),
       defaultConfig(),
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.user.sub).toBe("legacy");
-      expect(result.user.role).toBe("owner");
-      expect(result.user.authorizedRepos).toEqual(["*"]);
+      expect(result.result.source).toBe("shared-secret");
+      expect(result.result.repos).toEqual(["*"]);
     }
+    // Should NOT have called GitHub API
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("rejects wrong legacy secret", async () => {
+  it("falls through to GitHub token when shared secret doesn't match", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      Response.json(MOCK_REPOS_RESPONSE, { status: 200 }),
+    );
+
     const result = await verifyRequest(
-      makeRequest("Bearer wrong-secret"),
+      makeRequest("Bearer ghs_sometoken"),
       defaultConfig(),
-    );
-    expect(result.ok).toBe(false);
-  });
-
-  it("rejects legacy secret when disabled", async () => {
-    const result = await verifyRequest(
-      makeRequest(`Bearer ${TEST_LEGACY_SECRET}`),
-      defaultConfig({ legacyEnabled: false }),
-    );
-    expect(result.ok).toBe(false);
-  });
-
-  it("accepts legacy secret when jwtSecret is empty", async () => {
-    const result = await verifyRequest(
-      makeRequest(`Bearer ${TEST_LEGACY_SECRET}`),
-      defaultConfig({ jwtSecret: "" }),
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.user.sub).toBe("legacy");
+      expect(result.result.source).toBe("github");
     }
   });
 
-  // ── Issuer not configured ────────────────────────────────────────
+  it("works without gatewaySecret configured (GitHub-only mode)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      Response.json(MOCK_REPOS_RESPONSE, { status: 200 }),
+    );
 
-  it("accepts JWT when jwtIssuer is not configured (skip issuer check)", async () => {
-    const jwt = await createTestJWT({}, { issuer: "https://any-issuer.supabase.co/auth/v1" });
     const result = await verifyRequest(
-      makeRequest(`Bearer ${jwt}`),
-      defaultConfig({ jwtIssuer: undefined }),
+      makeRequest("Bearer ghs_sometoken"),
+      defaultConfig({ gatewaySecret: undefined }),
     );
     expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.source).toBe("github");
+    }
   });
 });
 
-// ── Role checks ────────────────────────────────────────────────────
-
-describe("requireRole", () => {
-  const owner: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme/app"] };
-  const member: GatewayUser = { sub: "u2", role: "member", authorizedRepos: ["acme/app"] };
-
-  it("owner satisfies owner requirement", () => {
-    expect(requireRole(owner, "owner")).toBe(true);
-  });
-
-  it("owner satisfies member requirement", () => {
-    expect(requireRole(owner, "member")).toBe(true);
-  });
-
-  it("member satisfies member requirement", () => {
-    expect(requireRole(member, "member")).toBe(true);
-  });
-
-  it("member does not satisfy owner requirement", () => {
-    expect(requireRole(member, "owner")).toBe(false);
-  });
-});
-
-// ── Repo access checks ────────────────────────────────────────────
+// ── requireRepoAccess ─────────────────────────────────────────────
 
 describe("requireRepoAccess", () => {
   it("allows access to authorized repo", () => {
-    const user: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme/app"] };
-    expect(requireRepoAccess(user, "acme/app")).toBe(true);
+    const result: AuthResult = { valid: true, repos: ["acme/app", "acme/lib"], source: "github" };
+    expect(requireRepoAccess(result, "acme/app")).toBe(true);
   });
 
   it("denies access to unauthorized repo", () => {
-    const user: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme/app"] };
-    expect(requireRepoAccess(user, "other/repo")).toBe(false);
+    const result: AuthResult = { valid: true, repos: ["acme/app"], source: "github" };
+    expect(requireRepoAccess(result, "other/repo")).toBe(false);
   });
 
-  it("wildcard * allows access to any repo", () => {
-    const user: GatewayUser = { sub: "legacy", role: "owner", authorizedRepos: ["*"] };
-    expect(requireRepoAccess(user, "any/repo")).toBe(true);
+  it("wildcard * allows access to any repo (shared-secret)", () => {
+    const result: AuthResult = { valid: true, repos: ["*"], source: "shared-secret" };
+    expect(requireRepoAccess(result, "any/repo")).toBe(true);
   });
 
-  it("org-level access allows any repo in that org", () => {
-    const user: GatewayUser = { sub: "u1", role: "owner", authorizedRepos: ["acme"] };
-    expect(requireRepoAccess(user, "acme/app")).toBe(true);
-    expect(requireRepoAccess(user, "acme/lib")).toBe(true);
-    expect(requireRepoAccess(user, "other/repo")).toBe(false);
+  it("denies access when repo list is empty", () => {
+    const result: AuthResult = { valid: true, repos: [], source: "github" };
+    expect(requireRepoAccess(result, "acme/app")).toBe(false);
   });
 });

--- a/gateway/test/gateway-endpoints.test.ts
+++ b/gateway/test/gateway-endpoints.test.ts
@@ -1,8 +1,7 @@
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
-import { SignJWT } from "jose";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
 import { clearRegistry, registerBridge, getBridge } from "../src/registry.js";
 import { createFetchHandler } from "../src/handler.js";
-import { resetLegacyDeprecationFlag, type AuthConfig } from "../src/auth.js";
+import { clearTokenCache, type AuthConfig } from "../src/auth.js";
 
 /**
  * Integration tests for the gateway HTTP endpoints.
@@ -12,57 +11,52 @@ import { resetLegacyDeprecationFlag, type AuthConfig } from "../src/auth.js";
  * and startup validation that would interfere with tests).
  */
 
-const TEST_LEGACY_SECRET = "test-gateway-secret";
-const TEST_JWT_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
-const TEST_ISSUER = "https://test.supabase.co/auth/v1";
-const encoder = new TextEncoder();
+const TEST_GATEWAY_SECRET = "test-gateway-secret";
+const TEST_GITHUB_TOKEN = "ghs_test_installation_token";
 
-const authConfig: AuthConfig = {
-  jwtSecret: TEST_JWT_SECRET,
-  jwtIssuer: TEST_ISSUER,
-  legacySecret: TEST_LEGACY_SECRET,
-  legacyEnabled: true,
-  maxAgeSeconds: 3600,
+const MOCK_REPOS_RESPONSE = {
+  repositories: [
+    { full_name: "acme/app" },
+    { full_name: "acme/lib" },
+  ],
 };
 
-async function createOwnerJWT(): Promise<string> {
-  return new SignJWT({
-    sub: "user-uuid-123",
-    email: "test@example.com",
-    app_metadata: {
-      role: "owner",
-      authorized_repos: ["acme/app", "acme/lib"],
-    },
-  })
-    .setProtectedHeader({ alg: "HS256" })
-    .setIssuer(TEST_ISSUER)
-    .setAudience("authenticated")
-    .setIssuedAt()
-    .setExpirationTime("1h")
-    .sign(encoder.encode(TEST_JWT_SECRET));
-}
-
-async function createMemberJWT(): Promise<string> {
-  return new SignJWT({
-    sub: "member-uuid-456",
-    email: "member@example.com",
-    app_metadata: {
-      role: "member",
-      authorized_repos: ["acme/app"],
-    },
-  })
-    .setProtectedHeader({ alg: "HS256" })
-    .setIssuer(TEST_ISSUER)
-    .setAudience("authenticated")
-    .setIssuedAt()
-    .setExpirationTime("1h")
-    .sign(encoder.encode(TEST_JWT_SECRET));
-}
+const authConfig: AuthConfig = {
+  gatewaySecret: TEST_GATEWAY_SECRET,
+};
 
 let server: ReturnType<typeof Bun.serve>;
 let baseUrl: string;
 let mockBridge: ReturnType<typeof Bun.serve>;
 let mockBridgeUrl: string;
+
+const originalFetch = globalThis.fetch;
+
+/**
+ * Wrap globalThis.fetch so that:
+ * - Calls to api.github.com return mocked responses
+ * - All other calls (localhost test servers) pass through to real fetch
+ */
+function installFetchMock() {
+  const mockFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.includes("api.github.com")) {
+      // Check the auth header to decide the response
+      const headers = init?.headers as Record<string, string> | undefined;
+      const authHeader =
+        (headers && headers["authorization"]) ||
+        (input instanceof Request ? input.headers.get("authorization") : undefined);
+
+      if (authHeader === `Bearer ${TEST_GITHUB_TOKEN}`) {
+        return Response.json(MOCK_REPOS_RESPONSE, { status: 200 });
+      }
+      return new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
+    }
+    // Pass through to real fetch for localhost calls
+    return originalFetch(input, init);
+  });
+  globalThis.fetch = mockFn as typeof globalThis.fetch;
+}
 
 beforeAll(() => {
   // Start a mock bridge that echoes back a success response
@@ -99,7 +93,13 @@ afterAll(() => {
 
 beforeEach(() => {
   clearRegistry();
-  resetLegacyDeprecationFlag();
+  clearTokenCache();
+  installFetchMock();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
 });
 
 // ── Tests ───────────────────────────────────────────────────────────
@@ -108,7 +108,7 @@ describe("gateway endpoints", () => {
   // ── Health check ──────────────────────────────────────────────────
 
   it("GET /healthz returns 200 with status and bridge counts", async () => {
-    const resp = await fetch(`${baseUrl}/healthz`);
+    const resp = await originalFetch(`${baseUrl}/healthz`);
     expect(resp.status).toBe(200);
     const body = await resp.json();
     expect(body.status).toBe("ok");
@@ -118,7 +118,7 @@ describe("gateway endpoints", () => {
 
   it("GET /healthz reflects registered bridges", async () => {
     registerBridge("acme/app", mockBridgeUrl);
-    const resp = await fetch(`${baseUrl}/healthz`);
+    const resp = await originalFetch(`${baseUrl}/healthz`);
     const body = await resp.json();
     expect(body.bridges.total).toBe(1);
     expect(body.bridges.active).toBe(1);
@@ -127,7 +127,7 @@ describe("gateway endpoints", () => {
   // ── Bridge registration ───────────────────────────────────────────
 
   it("POST /api/bridges/register without auth returns 401", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: JSON.stringify({ repo: "acme/app", bridgeUrl: mockBridgeUrl }),
       headers: { "content-type": "application/json" },
@@ -137,13 +137,13 @@ describe("gateway endpoints", () => {
     expect(body.error.type).toBe("missing_token");
   });
 
-  it("POST /api/bridges/register with legacy auth registers bridge", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+  it("POST /api/bridges/register with shared secret registers bridge", async () => {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: JSON.stringify({ repo: "acme/app", bridgeUrl: mockBridgeUrl }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
+        authorization: `Bearer ${TEST_GATEWAY_SECRET}`,
       },
     });
     expect(resp.status).toBe(200);
@@ -153,14 +153,13 @@ describe("gateway endpoints", () => {
     expect(body.bridgeUrl).toBeUndefined(); // bridge URLs must not leak
   });
 
-  it("POST /api/bridges/register with JWT owner registers bridge", async () => {
-    const jwt = await createOwnerJWT();
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+  it("POST /api/bridges/register with GitHub token registers bridge", async () => {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: JSON.stringify({ repo: "acme/app", bridgeUrl: mockBridgeUrl }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${jwt}`,
+        authorization: `Bearer ${TEST_GITHUB_TOKEN}`,
       },
     });
     expect(resp.status).toBe(200);
@@ -169,28 +168,27 @@ describe("gateway endpoints", () => {
     expect(body.repo).toBe("acme/app");
   });
 
-  it("POST /api/bridges/register with JWT member returns 403", async () => {
-    const jwt = await createMemberJWT();
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+  it("POST /api/bridges/register with GitHub token for unauthorized repo returns 403", async () => {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
-      body: JSON.stringify({ repo: "acme/app", bridgeUrl: mockBridgeUrl }),
+      body: JSON.stringify({ repo: "other/repo", bridgeUrl: mockBridgeUrl }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${jwt}`,
+        authorization: `Bearer ${TEST_GITHUB_TOKEN}`,
       },
     });
     expect(resp.status).toBe(403);
     const body = await resp.json();
-    expect(body.error.type).toBe("insufficient_role");
+    expect(body.error.type).toBe("repo_not_authorized");
   });
 
   it("POST /api/bridges/register with missing repo returns 400", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: JSON.stringify({ bridgeUrl: mockBridgeUrl }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
+        authorization: `Bearer ${TEST_GATEWAY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
@@ -199,24 +197,24 @@ describe("gateway endpoints", () => {
   });
 
   it("POST /api/bridges/register with missing bridgeUrl returns 400", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: JSON.stringify({ repo: "acme/app" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
+        authorization: `Bearer ${TEST_GATEWAY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
   });
 
   it("POST /api/bridges/register with invalid JSON returns 400", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "POST",
       body: "not json{{{",
       headers: {
         "content-type": "text/plain",
-        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
+        authorization: `Bearer ${TEST_GATEWAY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
@@ -225,7 +223,7 @@ describe("gateway endpoints", () => {
   // ── Bridge deregistration ─────────────────────────────────────────
 
   it("DELETE /api/bridges/register without auth returns 401", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "DELETE",
       body: JSON.stringify({ repo: "acme/app" }),
       headers: { "content-type": "application/json" },
@@ -233,14 +231,14 @@ describe("gateway endpoints", () => {
     expect(resp.status).toBe(401);
   });
 
-  it("DELETE /api/bridges/register removes a registered bridge", async () => {
+  it("DELETE /api/bridges/register with shared secret removes a bridge", async () => {
     registerBridge("acme/app", mockBridgeUrl);
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "DELETE",
       body: JSON.stringify({ repo: "acme/app" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
+        authorization: `Bearer ${TEST_GATEWAY_SECRET}`,
       },
     });
     expect(resp.status).toBe(200);
@@ -250,15 +248,14 @@ describe("gateway endpoints", () => {
     expect(getBridge("acme/app")).toBeUndefined();
   });
 
-  it("DELETE /api/bridges/register with JWT owner succeeds", async () => {
+  it("DELETE /api/bridges/register with GitHub token succeeds", async () => {
     registerBridge("acme/app", mockBridgeUrl);
-    const jwt = await createOwnerJWT();
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "DELETE",
       body: JSON.stringify({ repo: "acme/app" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${jwt}`,
+        authorization: `Bearer ${TEST_GITHUB_TOKEN}`,
       },
     });
     expect(resp.status).toBe(200);
@@ -268,24 +265,24 @@ describe("gateway endpoints", () => {
   });
 
   it("DELETE /api/bridges/register with missing repo returns 400", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "DELETE",
       body: JSON.stringify({}),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
+        authorization: `Bearer ${TEST_GATEWAY_SECRET}`,
       },
     });
     expect(resp.status).toBe(400);
   });
 
   it("DELETE /api/bridges/register for unknown repo returns removed=false", async () => {
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
       method: "DELETE",
       body: JSON.stringify({ repo: "unknown/repo" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${TEST_LEGACY_SECRET}`,
+        authorization: `Bearer ${TEST_GATEWAY_SECRET}`,
       },
     });
     expect(resp.status).toBe(200);
@@ -293,14 +290,14 @@ describe("gateway endpoints", () => {
     expect(body.removed).toBe(false);
   });
 
-  it("POST /api/bridges/register with JWT owner for unauthorized repo returns 403", async () => {
-    const jwt = await createOwnerJWT(); // authorized for acme/app, acme/lib
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
-      method: "POST",
-      body: JSON.stringify({ repo: "other/repo", bridgeUrl: mockBridgeUrl }),
+  it("DELETE /api/bridges/register with GitHub token for unauthorized repo returns 403", async () => {
+    registerBridge("other/repo", mockBridgeUrl);
+    const resp = await originalFetch(`${baseUrl}/api/bridges/register`, {
+      method: "DELETE",
+      body: JSON.stringify({ repo: "other/repo" }),
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${jwt}`,
+        authorization: `Bearer ${TEST_GITHUB_TOKEN}`,
       },
     });
     expect(resp.status).toBe(403);
@@ -308,57 +305,11 @@ describe("gateway endpoints", () => {
     expect(body.error.type).toBe("repo_not_authorized");
   });
 
-  it("DELETE /api/bridges/register with JWT member returns 403", async () => {
-    registerBridge("acme/app", mockBridgeUrl);
-    const jwt = await createMemberJWT();
-    const resp = await fetch(`${baseUrl}/api/bridges/register`, {
-      method: "DELETE",
-      body: JSON.stringify({ repo: "acme/app" }),
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${jwt}`,
-      },
-    });
-    expect(resp.status).toBe(403);
-    const body = await resp.json();
-    expect(body.error.type).toBe("insufficient_role");
-  });
-
-  // ── /api/auth/me ─────────────────────────────────────────────────
-
-  it("GET /api/auth/me with valid JWT returns user info", async () => {
-    const jwt = await createOwnerJWT();
-    const resp = await fetch(`${baseUrl}/api/auth/me`, {
-      headers: { authorization: `Bearer ${jwt}` },
-    });
-    expect(resp.status).toBe(200);
-    const body = await resp.json();
-    expect(body.sub).toBe("user-uuid-123");
-    expect(body.email).toBe("test@example.com");
-    expect(body.role).toBe("owner");
-    expect(body.authorizedRepos).toEqual(["acme/app", "acme/lib"]);
-  });
-
-  it("GET /api/auth/me without auth returns 401", async () => {
-    const resp = await fetch(`${baseUrl}/api/auth/me`);
-    expect(resp.status).toBe(401);
-  });
-
-  it("GET /api/auth/me with legacy secret returns legacy user", async () => {
-    const resp = await fetch(`${baseUrl}/api/auth/me`, {
-      headers: { authorization: `Bearer ${TEST_LEGACY_SECRET}` },
-    });
-    expect(resp.status).toBe(200);
-    const body = await resp.json();
-    expect(body.sub).toBe("legacy");
-    expect(body.role).toBe("owner");
-  });
-
   // ── Webhook forwarding ────────────────────────────────────────────
 
   it("POST /api/webhooks/github with no registered bridge returns 502", async () => {
     const payload = JSON.stringify({ repository: { full_name: "acme/app" } });
-    const resp = await fetch(`${baseUrl}/api/webhooks/github`, {
+    const resp = await originalFetch(`${baseUrl}/api/webhooks/github`, {
       method: "POST",
       body: payload,
       headers: { "content-type": "application/json" },
@@ -369,7 +320,7 @@ describe("gateway endpoints", () => {
   });
 
   it("POST /api/webhooks/github with invalid JSON returns 400", async () => {
-    const resp = await fetch(`${baseUrl}/api/webhooks/github`, {
+    const resp = await originalFetch(`${baseUrl}/api/webhooks/github`, {
       method: "POST",
       body: "not json{{{",
       headers: { "content-type": "text/plain" },
@@ -380,7 +331,7 @@ describe("gateway endpoints", () => {
   });
 
   it("POST /api/webhooks/github with missing repo in payload returns 400", async () => {
-    const resp = await fetch(`${baseUrl}/api/webhooks/github`, {
+    const resp = await originalFetch(`${baseUrl}/api/webhooks/github`, {
       method: "POST",
       body: JSON.stringify({ action: "opened" }),
       headers: { "content-type": "application/json" },
@@ -393,7 +344,7 @@ describe("gateway endpoints", () => {
   it("POST /api/webhooks/github forwards to registered bridge", async () => {
     registerBridge("acme/app", mockBridgeUrl);
     const payload = JSON.stringify({ repository: { full_name: "acme/app" }, action: "opened" });
-    const resp = await fetch(`${baseUrl}/api/webhooks/github`, {
+    const resp = await originalFetch(`${baseUrl}/api/webhooks/github`, {
       method: "POST",
       body: payload,
       headers: {
@@ -412,7 +363,7 @@ describe("gateway endpoints", () => {
   it("POST /api/webhooks/github to unreachable bridge returns 502", async () => {
     registerBridge("acme/app", "http://localhost:1");
     const payload = JSON.stringify({ repository: { full_name: "acme/app" } });
-    const resp = await fetch(`${baseUrl}/api/webhooks/github`, {
+    const resp = await originalFetch(`${baseUrl}/api/webhooks/github`, {
       method: "POST",
       body: payload,
       headers: { "content-type": "application/json" },
@@ -422,17 +373,26 @@ describe("gateway endpoints", () => {
     expect(body.error.type).toBe("bridge_error");
   });
 
+  // ── /api/auth/me removed ──────────────────────────────────────────
+
+  it("GET /api/auth/me returns 404 (endpoint removed)", async () => {
+    const resp = await originalFetch(`${baseUrl}/api/auth/me`, {
+      headers: { authorization: `Bearer ${TEST_GATEWAY_SECRET}` },
+    });
+    expect(resp.status).toBe(404);
+  });
+
   // ── Method mismatch ────────────────────────────────────────────────
 
   it("GET /api/webhooks/github returns 404", async () => {
-    const resp = await fetch(`${baseUrl}/api/webhooks/github`);
+    const resp = await originalFetch(`${baseUrl}/api/webhooks/github`);
     expect(resp.status).toBe(404);
   });
 
   // ── 404 ───────────────────────────────────────────────────────────
 
   it("unknown endpoint returns 404", async () => {
-    const resp = await fetch(`${baseUrl}/not/a/real/endpoint`);
+    const resp = await originalFetch(`${baseUrl}/not/a/real/endpoint`);
     expect(resp.status).toBe(404);
     const body = await resp.json();
     expect(body.error.type).toBe("not_found");

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
-    "jose": "^6.2.2",
     "kysely": "^0.28.16",
     "yaml": "^2.8.3"
   }

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -46,7 +46,7 @@ async function fetchWithRetry(
 export interface GatewayClientConfig {
   gatewayUrl: string;
   secret?: string;      // ZAPBOT_GATEWAY_SECRET (shared secret)
-  token?: string;       // ZAPBOT_GATEWAY_TOKEN (Supabase JWT)
+  token?: string;       // GitHub App installation token
 }
 
 function getAuthToken(config: GatewayClientConfig): string {

--- a/test/gateway-client.test.ts
+++ b/test/gateway-client.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
-import { SignJWT } from "jose";
 import {
   registerBridge,
   deregisterBridge,
@@ -10,48 +9,62 @@ import {
 } from "../src/gateway/client.js";
 import { createFetchHandler } from "../gateway/src/handler.js";
 import { clearRegistry, getBridge } from "../gateway/src/registry.js";
-import { resetLegacyDeprecationFlag, type AuthConfig } from "../gateway/src/auth.js";
+import { clearTokenCache, type AuthConfig } from "../gateway/src/auth.js";
 
 /**
  * Tests for the gateway client module (src/gateway/client.ts).
  *
  * Spins up a real gateway handler so we test registration, deregistration,
  * and heartbeat end-to-end without mocking HTTP.
+ *
+ * Uses a fetch mock to intercept GitHub API calls while letting
+ * localhost requests pass through to the real test servers.
  */
 
-const LEGACY_SECRET = "test-secret-abc123";
-const JWT_SECRET = "test-jwt-secret-at-least-32-chars-long!!";
-const JWT_ISSUER = "https://test.supabase.co/auth/v1";
-const encoder = new TextEncoder();
+const SHARED_SECRET = "test-secret-abc123";
+const GITHUB_TOKEN = "ghs_test_installation_token";
 
-const authConfig: AuthConfig = {
-  jwtSecret: JWT_SECRET,
-  jwtIssuer: JWT_ISSUER,
-  legacySecret: LEGACY_SECRET,
-  legacyEnabled: true,
-  maxAgeSeconds: 3600,
+const MOCK_REPOS_RESPONSE = {
+  repositories: [
+    { full_name: "owner/repo" },
+    { full_name: "owner/repo-a" },
+    { full_name: "owner/repo-b" },
+    { full_name: "owner/a" },
+    { full_name: "owner/b" },
+  ],
 };
 
-async function createOwnerJWT(): Promise<string> {
-  return new SignJWT({
-    sub: "user-uuid-123",
-    email: "test@example.com",
-    app_metadata: {
-      role: "owner",
-      authorized_repos: ["owner/repo", "owner/repo-a", "owner/repo-b", "owner/a", "owner/b"],
-    },
-  })
-    .setProtectedHeader({ alg: "HS256" })
-    .setIssuer(JWT_ISSUER)
-    .setAudience("authenticated")
-    .setIssuedAt()
-    .setExpirationTime("1h")
-    .sign(encoder.encode(JWT_SECRET));
+const authConfig: AuthConfig = {
+  gatewaySecret: SHARED_SECRET,
+};
+
+const originalFetch = globalThis.fetch;
+
+/**
+ * Install a fetch mock that intercepts GitHub API calls and passes
+ * through all other requests to the real fetch implementation.
+ */
+function installFetchMock() {
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.includes("api.github.com")) {
+      const headers = init?.headers as Record<string, string> | undefined;
+      const authHeader =
+        (headers && (headers["Authorization"] || headers["authorization"])) ||
+        (input instanceof Request ? input.headers.get("authorization") : undefined);
+
+      if (authHeader === `Bearer ${GITHUB_TOKEN}`) {
+        return Response.json(MOCK_REPOS_RESPONSE, { status: 200 });
+      }
+      return new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
+    }
+    return originalFetch(input, init);
+  }) as typeof globalThis.fetch;
 }
 
 let gatewayServer: ReturnType<typeof Bun.serve>;
 let gatewayUrl: string;
-let legacyConfig: GatewayClientConfig;
+let sharedSecretConfig: GatewayClientConfig;
 
 beforeAll(() => {
   const handler = createFetchHandler({
@@ -60,7 +73,7 @@ beforeAll(() => {
   });
   gatewayServer = Bun.serve({ port: 0, fetch: handler });
   gatewayUrl = `http://localhost:${gatewayServer.port}`;
-  legacyConfig = { gatewayUrl, secret: LEGACY_SECRET };
+  sharedSecretConfig = { gatewayUrl, secret: SHARED_SECRET };
 });
 
 afterAll(() => {
@@ -69,43 +82,43 @@ afterAll(() => {
 
 beforeEach(() => {
   clearRegistry();
-  resetLegacyDeprecationFlag();
+  clearTokenCache();
+  installFetchMock();
 });
 
 afterEach(() => {
   stopHeartbeats();
+  globalThis.fetch = originalFetch;
 });
 
 describe("gateway client", () => {
   describe("registerBridge", () => {
-    it("registers a bridge with legacy secret", async () => {
-      await registerBridge(legacyConfig, "owner/repo", "http://localhost:3000");
+    it("registers a bridge with shared secret", async () => {
+      await registerBridge(sharedSecretConfig, "owner/repo", "http://localhost:3000");
       const bridge = getBridge("owner/repo");
       expect(bridge).toBeDefined();
       expect(bridge!.bridgeUrl).toBe("http://localhost:3000");
       expect(bridge!.active).toBe(true);
     });
 
-    it("registers a bridge with JWT token", async () => {
-      const jwt = await createOwnerJWT();
-      const jwtConfig: GatewayClientConfig = { gatewayUrl, token: jwt };
-      await registerBridge(jwtConfig, "owner/repo", "http://localhost:3000");
+    it("registers a bridge with GitHub token", async () => {
+      const githubConfig: GatewayClientConfig = { gatewayUrl, token: GITHUB_TOKEN };
+      await registerBridge(githubConfig, "owner/repo", "http://localhost:3000");
       const bridge = getBridge("owner/repo");
       expect(bridge).toBeDefined();
       expect(bridge!.bridgeUrl).toBe("http://localhost:3000");
     });
 
-    it("JWT token takes precedence over legacy secret", async () => {
-      const jwt = await createOwnerJWT();
-      const config: GatewayClientConfig = { gatewayUrl, token: jwt, secret: "wrong-secret" };
-      // Should succeed because JWT is used, not the wrong legacy secret
+    it("token takes precedence over secret", async () => {
+      const config: GatewayClientConfig = { gatewayUrl, token: GITHUB_TOKEN, secret: "wrong-secret" };
+      // Should succeed because token is used, not the wrong secret
       await registerBridge(config, "owner/repo", "http://localhost:3000");
       expect(getBridge("owner/repo")).toBeDefined();
     });
 
     it("registers multiple repos", async () => {
-      await registerBridge(legacyConfig, "owner/repo-a", "http://localhost:3000");
-      await registerBridge(legacyConfig, "owner/repo-b", "http://localhost:3000");
+      await registerBridge(sharedSecretConfig, "owner/repo-a", "http://localhost:3000");
+      await registerBridge(sharedSecretConfig, "owner/repo-b", "http://localhost:3000");
       expect(getBridge("owner/repo-a")).toBeDefined();
       expect(getBridge("owner/repo-b")).toBeDefined();
     });
@@ -119,27 +132,27 @@ describe("gateway client", () => {
 
   describe("deregisterBridge", () => {
     it("removes a bridge from the gateway", async () => {
-      await registerBridge(legacyConfig, "owner/repo", "http://localhost:3000");
+      await registerBridge(sharedSecretConfig, "owner/repo", "http://localhost:3000");
       expect(getBridge("owner/repo")).toBeDefined();
 
-      await deregisterBridge(legacyConfig, "owner/repo");
+      await deregisterBridge(sharedSecretConfig, "owner/repo");
       expect(getBridge("owner/repo")).toBeUndefined();
     });
 
     it("does not throw for non-existent repo", async () => {
       // Deregistering a repo that doesn't exist should not throw
-      await deregisterBridge(legacyConfig, "owner/nonexistent");
+      await deregisterBridge(sharedSecretConfig, "owner/nonexistent");
     });
   });
 
   describe("heartbeat", () => {
     it("re-registers to update lastSeen", async () => {
-      await registerBridge(legacyConfig, "owner/repo", "http://localhost:3000");
+      await registerBridge(sharedSecretConfig, "owner/repo", "http://localhost:3000");
       const firstSeen = getBridge("owner/repo")!.lastSeen;
 
       // Small delay to ensure timestamp differs
       await new Promise((r) => setTimeout(r, 10));
-      await heartbeat(legacyConfig, "owner/repo", "http://localhost:3000");
+      await heartbeat(sharedSecretConfig, "owner/repo", "http://localhost:3000");
 
       const secondSeen = getBridge("owner/repo")!.lastSeen;
       expect(secondSeen).toBeGreaterThanOrEqual(firstSeen);
@@ -154,14 +167,13 @@ describe("gateway client", () => {
       expect(getBridge("owner/repo")).toBeUndefined();
     });
 
-    it("works with JWT token", async () => {
-      const jwt = await createOwnerJWT();
-      const jwtConfig: GatewayClientConfig = { gatewayUrl, token: jwt };
-      await registerBridge(jwtConfig, "owner/repo", "http://localhost:3000");
+    it("works with GitHub token", async () => {
+      const githubConfig: GatewayClientConfig = { gatewayUrl, token: GITHUB_TOKEN };
+      await registerBridge(githubConfig, "owner/repo", "http://localhost:3000");
       const firstSeen = getBridge("owner/repo")!.lastSeen;
 
       await new Promise((r) => setTimeout(r, 10));
-      await heartbeat(jwtConfig, "owner/repo", "http://localhost:3000");
+      await heartbeat(githubConfig, "owner/repo", "http://localhost:3000");
 
       const secondSeen = getBridge("owner/repo")!.lastSeen;
       expect(secondSeen).toBeGreaterThanOrEqual(firstSeen);
@@ -170,7 +182,7 @@ describe("gateway client", () => {
 
   describe("setupGateway", () => {
     it("registers all repos and returns cleanup function", async () => {
-      const cleanup = await setupGateway(legacyConfig, ["owner/a", "owner/b"], "http://localhost:3000");
+      const cleanup = await setupGateway(sharedSecretConfig, ["owner/a", "owner/b"], "http://localhost:3000");
 
       expect(getBridge("owner/a")).toBeDefined();
       expect(getBridge("owner/b")).toBeDefined();


### PR DESCRIPTION
## Summary

Closes #74

- Replace Supabase JWT verification in the gateway with GitHub App installation token verification via the GitHub API (`GET /installation/repositories`)
- Keep `GATEWAY_SECRET` shared-secret as a simple alternative for setups without a GitHub App
- Add 5-minute in-memory TTL cache to avoid hitting GitHub API on every heartbeat
- Remove `/api/auth/me` endpoint (no longer meaningful without user identity)
- Remove `jose` dependency from both gateway and root package.json
- Remove all Supabase env vars (`SUPABASE_JWT_SECRET`, `SUPABASE_URL`, `JWT_MAX_AGE_SECONDS`, `LEGACY_AUTH_ENABLED`)

### Files changed

| File | Change |
|------|--------|
| `gateway/src/auth.ts` | Gut and rewrite: `verifyGitHubToken()` with TTL cache, `verifySharedSecret()`, new `AuthResult`/`AuthOutcome` types |
| `gateway/src/handler.ts` | Use new auth flow, remove `/api/auth/me`, remove role checks, update error messages |
| `gateway/src/index.ts` | Remove Supabase env vars, require `GATEWAY_SECRET`, simplify startup |
| `gateway/test/auth.test.ts` | Rewrite with mocked `fetch` for GitHub API |
| `gateway/test/gateway-endpoints.test.ts` | Update for new auth, remove `/api/auth/me` tests |
| `gateway/package.json` | Remove `jose` dependency |
| `gateway/.env.example` | Remove Supabase references |
| `src/gateway/client.ts` | Update comment (Supabase JWT → GitHub App token) |
| `test/gateway-client.test.ts` | Replace JWT tests with GitHub token tests using fetch mock |
| `package.json` | Remove `jose` from root dependencies |

## Test plan

- [x] Gateway unit tests pass (`bun test` in gateway/): 57 pass
- [x] Gateway client integration tests pass (`bun test test/gateway-client.test.ts`): 22 pass
- [x] Valid GitHub token accepted (200 with repo list)
- [x] Invalid/expired GitHub token rejected (401)
- [x] Repo not in installation rejected (403)
- [x] GitHub API down handled gracefully
- [x] Token cache hit verified (no API call on second request)
- [x] Shared secret fallback works
- [x] `/api/auth/me` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)