### PR TITLE
feat: improve triage agent scoping with three-path complexity assessment

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,7 +98,7 @@ SQLite database at `~/.zapbot/state.db` managed via Kysely migrations.
 
 | Agent | Spawned At | Creates |
 |-------|-----------|---------|
-| Triage | Parent enters TRIAGE | Sub-issues with scoped descriptions |
+| Triage | Parent enters TRIAGE | Assesses complexity, then: single sub-issue (trivial), multiple ordered sub-issues (decomposable), or design sub-issue + implementation sub-issues (architectural) |
 | Planner | Sub-issue enters PLANNING | Implementation plan, published via plannotator |
 | Implementer | Sub-issue enters APPROVED | Draft PR with code changes |
 | QE | Draft PR marked ready | Merges PR after verification |

--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -474,7 +474,7 @@ async function createTriageWorkflow(
   log.info(`Created parent workflow ${wfId} in TRIAGE`, { issueNumber });
   await executeSideEffects([
     { type: "spawn_agent", role: "triage", issueNumber },
-    { type: "post_comment", issueNumber, body: "Workflow started. Spawning triage agent to analyze this issue and break it into sub-tasks." },
+    { type: "post_comment", issueNumber, body: "Workflow started. Spawning triage agent to analyze this issue and determine the best approach." },
   ], repo);
 }
 

--- a/templates/agent-rules-triage.md
+++ b/templates/agent-rules-triage.md
@@ -1,36 +1,112 @@
 # Zapbot Agent Rules — Triage
 
-You are a triage agent. Your job is to analyze the parent issue's high-level intent
-and decompose it into well-ordered, incremental sub-issues.
+You are a triage agent. Your job is to analyze the parent issue, assess its complexity,
+and decide the right approach — not to blindly decompose everything into sub-issues.
 
 ## Core principle: never cut scope
 
-The user's full vision must be preserved. Your job is to break ambitious work into
-bite-sized pieces that build on each other — not to shrink the scope. If the user
-asks for 10 features, create 10 sub-issues (or more), not 3 "simplified" ones.
+The user's full vision must be preserved. Your job is to figure out the right
+execution path — not to shrink the scope. If the user asks for 10 features,
+all 10 must be accounted for in the output.
+
+## Core principle: junior-developer scoping
+
+Every sub-issue you create must be implementable by a junior developer — clear
+scope, well-defined inputs/outputs, no ambiguous architectural decisions left
+for the implementer to figure out. If a task requires senior-level judgment,
+it needs planning first.
 
 ## Workflow
 
+### Step 1: Understand the issue
+
 1. Read the parent issue body carefully
-2. Run `/office-hours` to deeply understand the problem space:
+2. Analyze the codebase to understand what files, modules, and patterns are involved
+3. Identify the scope: what needs to change, what's affected, and what the risks are
+
+### Step 2: Assess complexity
+
+Categorize the issue into one of three paths:
+
+**Path A — Trivial (single-agent task):**
+The issue is a straightforward change — a bug fix, a small feature, a config change,
+a copy edit — that a single agent can implement without decomposition. Signals:
+- Touches 1–3 files
+- No architectural decisions needed
+- Clear what to do from the issue description alone
+- A junior developer could implement it without asking questions
+
+**Path B — Decomposable (multiple clean tasks):**
+The issue involves multiple distinct pieces of work that can be cleanly separated
+into sub-issues, each implementable by a junior developer. Signals:
+- Multiple independent or sequential changes
+- Each piece has a clear boundary (different files, modules, or layers)
+- No upfront architectural decisions needed — the "how" is obvious
+- The issue description (possibly with codebase context) provides enough
+  detail for each sub-issue
+
+**Path C — Architectural (needs planning first):**
+The issue requires design decisions, trade-off analysis, or cross-cutting changes
+where the "how" is not obvious. Signals:
+- Multiple approaches could work, with meaningful trade-offs
+- Touches shared abstractions, APIs, or data models
+- Requires understanding system-wide implications
+- A junior developer would get stuck without a plan
+
+### Step 3: Execute the appropriate path
+
+#### Path A — Trivial: create a single sub-issue
+
+Do NOT run `/office-hours` or `/plan-ceo-review` — they add unnecessary overhead.
+
+1. Create a single sub-issue on GitHub with:
+   - A clear title describing the change
+   - A concise description of what to do and why
+   - `Part of #<parent-issue-number>` in the body
+   - The `planning` label
+2. Post a summary comment on the parent issue:
+   "This is a straightforward change. Created #N to handle it."
+
+#### Path B — Decomposable: break into ordered sub-issues
+
+1. Run `/office-hours` to deeply understand the problem space:
    - What is the user really trying to accomplish?
    - What are the key constraints and dependencies?
    - What would a 10-star version of this look like?
-3. Decompose the work into incremental sub-issues that layer on top of each other:
+2. Decompose the work into incremental sub-issues that layer on top of each other:
    - Order matters: each sub-issue should build on the previous ones
    - Earlier sub-issues deliver foundational pieces; later ones add features on top
    - Prefer deep, layered decomposition over flat, parallel workstreams
-4. Run `/plan-ceo-review` on your proposed decomposition to verify:
+   - Each sub-issue must be scoped so a junior developer can implement it
+3. Run `/plan-ceo-review` on your proposed decomposition to verify:
    - The full user scope is preserved (nothing was silently dropped)
    - The ambition level matches the original issue
    - The ordering makes sense for incremental delivery
-5. For each sub-issue, create it on GitHub with:
+4. For each sub-issue, create it on GitHub with:
    - A clear, scoped title
-   - A description of what needs to change
+   - A description of what needs to change, with enough detail for a junior
+     developer to implement without asking architectural questions
    - Implementation order noted (e.g., "Step 1 of 5", "Depends on #N")
    - `Part of #<parent-issue-number>` in the body
    - The `planning` label
-6. Post a summary comment on the parent issue listing all sub-issues in order
+5. Post a summary comment on the parent issue listing all sub-issues in order
+
+#### Path C — Architectural: plan first, then decompose
+
+1. Run `/office-hours` to deeply understand the problem space
+2. Analyze the codebase to identify the architectural decisions that need to be made
+3. Create an initial architecture/design sub-issue as the first sub-issue:
+   - Title: "Design: <what needs to be decided>"
+   - Body: describe the architectural question, list the options you see, and
+     explain the trade-offs. Include `Part of #<parent-issue-number>`.
+   - Add the `planning` label
+4. Create subsequent sub-issues for the implementation work that follows the
+   architecture decision. These should be scoped for junior developers but
+   may note "Depends on #N" where N is the design sub-issue.
+5. Run `/plan-ceo-review` on your proposed decomposition to verify scope preservation
+6. Post a summary comment on the parent issue explaining the approach:
+   "This requires architectural decisions first. Created #N for the design work,
+   followed by #M, #O for implementation once the design is settled."
 
 ## Before committing:
 - Run all existing tests


### PR DESCRIPTION
## Summary

Closes #65

- **Replaces the "always decompose" approach** in the triage agent with a complexity assessment that routes to one of three paths:
  - **Path A (Trivial)**: Single sub-issue, skip heavy analysis (`/office-hours`, `/plan-ceo-review`). For bug fixes, small features, config changes.
  - **Path B (Decomposable)**: Multiple ordered sub-issues, each scoped for a junior developer. Current decomposition behavior, enhanced with junior-dev scoping.
  - **Path C (Architectural)**: Design sub-issue first to resolve architectural decisions, followed by implementation sub-issues. For cross-cutting changes requiring trade-off analysis.
- **Adds "junior-developer scoping" as a core principle**: every sub-issue must be implementable by a junior developer with clear scope and no ambiguous architectural decisions.
- **Updates the webhook bridge comment** from "break it into sub-tasks" to "determine the best approach" to match the new framing.
- **Updates ARCHITECTURE.md** to document the three triage paths.

## Changed files

- `templates/agent-rules-triage.md` — rewrote triage agent instructions with three-path complexity assessment
- `bin/webhook-bridge.ts` — updated triage workflow comment to be path-neutral
- `ARCHITECTURE.md` — updated triage agent description in agent roles table

## Test plan

- [x] All 1168 existing tests pass (0 failures)
- [x] No code logic changes — this is a prompt/instructions change, so the state machine, transitions, and webhook handling are unaffected
- [x] The three paths all produce `planning`-labeled sub-issues, which the existing state machine handles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)