### PR TITLE
[safer:architect] v2 module layout

### DIFF
--- a/v2/ao/dispatcher.ts
+++ b/v2/ao/dispatcher.ts
@@ -1,0 +1,47 @@
+/**
+ * v2/ao/dispatcher — shell out to `ao spawn <issue>` with the bot's
+ * installation token and the per-repo project id.
+ *
+ * Principle 5 (Junior Dev Rule): this module owns exactly one responsibility:
+ * translate a "dispatch this issue" intent into a spawned `ao` process with
+ * the right env. No DB writes, no role-rules file copy, no session lookup,
+ * no heartbeat/cleanup. Those were v1 bookkeeping against the SQLite store.
+ *
+ * Invariant 3 from the spec: nested spawn is first-class. Agents call this
+ * module's CLI equivalent (`ao spawn`) directly from their own VM; the
+ * bridge is NOT a spawn-routing bottleneck. This module exists for the
+ * bridge's own webhook-triggered spawns; nested spawns bypass it entirely.
+ */
+
+import type {
+  AoSessionName,
+  DispatchError,
+  InstallationToken,
+  IssueNumber,
+  ProjectName,
+  RepoFullName,
+  Result,
+} from "../types.ts";
+
+export interface DispatchContext {
+  readonly repo: RepoFullName;
+  readonly issue: IssueNumber;
+  readonly projectName: ProjectName;
+  readonly configPath: string;
+  readonly installationToken: InstallationToken;
+}
+
+/**
+ * Invoke `ao spawn <issue>` with env `AO_CONFIG_PATH`, `AO_PROJECT_ID`,
+ * `GH_TOKEN`. Returns the ao session name on success. Does NOT wait for
+ * the spawned agent to finish; returns as soon as `ao spawn` exits cleanly.
+ *
+ * Failure modes are enumerated in `DispatchError`. The caller decides
+ * whether to retry (there is no built-in retry here — v1's retry loop was
+ * coupled to DB rows; v2 callers that want retry build it from this).
+ */
+export function dispatch(
+  _ctx: DispatchContext
+): Promise<Result<AoSessionName, DispatchError>> {
+  throw new Error("not implemented");
+}

--- a/v2/bridge.ts
+++ b/v2/bridge.ts
@@ -1,0 +1,94 @@
+/**
+ * v2/bridge — the thinned webhook bridge.
+ *
+ * v1's `bin/webhook-bridge.ts` was 1724 LOC carrying: HTTP server, HMAC
+ * verify, mention dispatch, state-machine apply, side-effect executor,
+ * workflow/agent HTTP APIs, plannotator callback handler, startup
+ * recovery, shutdown. v2 keeps the HTTP server + HMAC + mention
+ * dispatch + gateway registration + SIGHUP reload + shutdown. Everything
+ * else in v1's bridge is deleted.
+ *
+ * Target LOC after the strip: ≤ 1100 (spec acceptance criterion 3).
+ *
+ * Principle 4 (Exhaustiveness): every webhook classification branch that
+ * reaches the bridge is handled. The `handleClassifiedWebhook` switch ends
+ * in `absurd` against the `ClassifiedWebhook` union.
+ */
+
+import type { ClassifiedWebhook } from "./gateway.ts";
+import type {
+  BotUsername,
+  DispatchError,
+  InstallationToken,
+  ProjectName,
+  RepoFullName,
+  Result,
+} from "./types.ts";
+
+// ── Boot config ─────────────────────────────────────────────────────
+
+export interface BridgeConfig {
+  readonly port: number;
+  readonly publicUrl: string;
+  readonly gatewayUrl: string;
+  readonly gatewaySecret: string | null;
+  readonly botUsername: BotUsername;
+  readonly aoConfigPath: string;
+  /** repo full_name → project name + secret env var + default branch */
+  readonly repos: ReadonlyMap<RepoFullName, RepoRoute>;
+}
+
+export interface RepoRoute {
+  readonly projectName: ProjectName;
+  readonly webhookSecretEnvVar: string;
+  readonly defaultBranch: string;
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────
+
+export interface RunningBridge {
+  readonly stop: () => Promise<void>;
+  readonly reload: (nextConfig: BridgeConfig) => Promise<void>;
+}
+
+/**
+ * Boot the HTTP server, register every configured repo with the gateway,
+ * start heartbeats, install SIGHUP → reload. Does not block on webhook
+ * traffic; returns immediately with a handle the caller uses to stop or
+ * reload. Reload is re-entrant: a second SIGHUP while one reload is in
+ * flight is ignored with a log line.
+ */
+export function startBridge(_config: BridgeConfig): Promise<RunningBridge> {
+  throw new Error("not implemented");
+}
+
+// ── Request routing (pure over the parsed webhook) ──────────────────
+
+/**
+ * Dispatch a classified webhook to its downstream action:
+ * - `ignore` → no-op, returns `Ok`.
+ * - `mention_command` → check command permissions, parse intent, call
+ *   `v2/ao/dispatcher.dispatch` when the command is `plan_this` or
+ *   `investigate_this`, post an ack comment.
+ *
+ * Errors from dispatch propagate as `Err`. The caller (the HTTP handler
+ * in `startBridge`) is responsible for turning that into an HTTP response
+ * shape and logging; this function does not call `console` or `log`.
+ */
+export function handleClassifiedWebhook(
+  _classified: ClassifiedWebhook,
+  _ctx: BridgeHandlerContext
+): Promise<Result<HandleOutcome, DispatchError>> {
+  throw new Error("not implemented");
+}
+
+export interface BridgeHandlerContext {
+  readonly mintToken: () => Promise<InstallationToken>;
+  readonly config: BridgeConfig;
+}
+
+export type HandleOutcome =
+  | { readonly kind: "ignored"; readonly reason: string }
+  | { readonly kind: "dispatched"; readonly repo: RepoFullName; readonly session: string }
+  | { readonly kind: "unauthorized"; readonly actor: string }
+  | { readonly kind: "command_unknown"; readonly raw: string };

--- a/v2/gateway.ts
+++ b/v2/gateway.ts
@@ -1,0 +1,110 @@
+/**
+ * v2/gateway — the bridge's view of the gateway service.
+ *
+ * The gateway itself (the static-URL Bun HTTP proxy under `gateway/`) is
+ * unchanged in v2 and stays out of this module. This file defines the
+ * bridge-side client surface: register on boot, deregister on shutdown,
+ * heartbeat while alive. It also exports the webhook intake contract that
+ * the bridge uses when the gateway forwards an event.
+ *
+ * Principle 3 (typed errors): every call returns `Result<T, GatewayError>`.
+ * No raw `throw`. Callers pattern-match on `_tag`.
+ */
+
+import type {
+  BotUsername,
+  DeliveryId,
+  GatewayError,
+  RepoFullName,
+  Result,
+  WebhookIntakeError,
+} from "./types.ts";
+
+// ── Bridge → gateway registration ───────────────────────────────────
+
+export interface GatewayClientConfig {
+  readonly gatewayUrl: string;
+  readonly secret: string | null;
+  readonly token: string | null;
+}
+
+/**
+ * Register this bridge with the gateway for the given repo. Idempotent:
+ * re-registering overwrites the previous `bridgeUrl` mapping.
+ */
+export function registerBridge(
+  _config: GatewayClientConfig,
+  _repo: RepoFullName,
+  _bridgeUrl: string
+): Promise<Result<void, GatewayError>> {
+  throw new Error("not implemented");
+}
+
+export function deregisterBridge(
+  _config: GatewayClientConfig,
+  _repo: RepoFullName,
+  _bridgeUrl: string
+): Promise<Result<void, GatewayError>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Start a periodic re-registration loop. Returns a disposer that stops the
+ * loop. Exactly-once semantics are not guaranteed across restarts; the
+ * gateway is expected to tolerate duplicate registrations.
+ */
+export function startHeartbeat(
+  _config: GatewayClientConfig,
+  _repos: ReadonlyArray<RepoFullName>,
+  _bridgeUrl: string,
+  _intervalMs: number
+): () => void {
+  throw new Error("not implemented");
+}
+
+// ── Webhook intake contract ─────────────────────────────────────────
+
+/**
+ * Shape handed to the bridge once the gateway has forwarded a GitHub webhook.
+ * The body is the raw string used for HMAC; the parsed payload is the
+ * decoded JSON the bridge reads for routing.
+ */
+export interface GatewayWebhookEnvelope {
+  readonly rawBody: string;
+  readonly signature: string | null;
+  readonly eventType: string;
+  readonly deliveryId: DeliveryId;
+  readonly repo: RepoFullName;
+  readonly payload: unknown;
+}
+
+/**
+ * Verify HMAC against the per-repo secret, decode the bot-relevant command
+ * (if any), and return the bridge's next-action intent. Pure over the
+ * envelope plus a secret resolver; no I/O beyond crypto.
+ *
+ * Downstream dispatch is not this module's concern — `v2/bridge.ts` owns
+ * that. This function's job is to make the webhook safe to act on.
+ */
+export function verifyAndClassify(
+  _envelope: GatewayWebhookEnvelope,
+  _resolveSecret: (repo: RepoFullName) => string | null,
+  _botUsername: BotUsername
+): Promise<Result<ClassifiedWebhook, WebhookIntakeError>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * What the bridge does next, named at the interface so each variant is
+ * exhaustive in the bridge's switch.
+ */
+export type ClassifiedWebhook =
+  | { readonly kind: "ignore"; readonly reason: string }
+  | {
+      readonly kind: "mention_command";
+      readonly repo: RepoFullName;
+      readonly issue: import("./types.ts").IssueNumber;
+      readonly commentId: import("./types.ts").CommentId;
+      readonly command: import("./types.ts").MentionCommand;
+      readonly triggeredBy: string;
+    };

--- a/v2/github-state.ts
+++ b/v2/github-state.ts
@@ -1,0 +1,96 @@
+/**
+ * v2/github-state — read durable workflow state from GitHub via `gh`.
+ *
+ * Replaces v1's SQLite `workflows` / `agent_sessions` / `transitions` tables.
+ * Spec invariant 2: GitHub is the record. Every read here is a `gh` shell
+ * call (or the Octokit equivalent) against the live repo; nothing is
+ * cached across process restart.
+ *
+ * Principle 2 (Validate at every boundary): every call's return value is
+ * decoded at the boundary from `gh`'s JSON output into the branded types
+ * declared here. No `Record<string, unknown>` on the public surface.
+ */
+
+import type {
+  BotUsername,
+  CommentId,
+  GithubStateError,
+  IssueNumber,
+  RepoFullName,
+  Result,
+} from "./types.ts";
+
+export type IssueState = "open" | "closed";
+
+export interface IssueSnapshot {
+  readonly repo: RepoFullName;
+  readonly number: IssueNumber;
+  readonly state: IssueState;
+  readonly labels: ReadonlyArray<string>;
+  readonly assignees: ReadonlyArray<string>;
+  readonly body: string;
+  readonly author: string;
+}
+
+export interface CommentSnapshot {
+  readonly id: CommentId;
+  readonly author: string;
+  readonly body: string;
+  readonly createdAt: string;
+}
+
+/**
+ * Read current state of an issue. Fails if `gh` is missing or the issue
+ * does not exist. Does NOT retry — the caller's concern.
+ */
+export function getIssue(
+  _repo: RepoFullName,
+  _issue: IssueNumber
+): Promise<Result<IssueSnapshot, GithubStateError>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Does this issue already have an agent working on it? Implemented as:
+ * "is the bot an assignee AND is the issue open." No local cache.
+ * The two possible answers are modeled as a discriminated union so callers
+ * cannot conflate "not claimed" with "query failed."
+ */
+export type Claim =
+  | { readonly kind: "unclaimed" }
+  | { readonly kind: "claimed"; readonly by: BotUsername };
+
+export function getAgentClaim(
+  _repo: RepoFullName,
+  _issue: IssueNumber,
+  _bot: BotUsername
+): Promise<Result<Claim, GithubStateError>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * List open issues in `repo` that carry `label`. Used by the bridge's
+ * startup recovery (if any): "what issues were the bot dispatched on and
+ * haven't closed yet." v1 derived this from SQLite; v2 derives it from
+ * GitHub.
+ */
+export function listOpenIssuesWithLabel(
+  _repo: RepoFullName,
+  _label: string
+): Promise<Result<ReadonlyArray<IssueSnapshot>, GithubStateError>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Post a comment as the bot. `installationToken` is resolved upstream by
+ * `v2/github-auth` (which wraps the existing `src/github/client.ts` token
+ * mint — not re-architected in v2). Returns the new comment's id so
+ * downstream code can edit it if needed.
+ */
+export function postComment(
+  _repo: RepoFullName,
+  _issue: IssueNumber,
+  _body: string
+): Promise<Result<CommentId, GithubStateError>> {
+  throw new Error("not implemented");
+}

--- a/v2/mention-parser.ts
+++ b/v2/mention-parser.ts
@@ -1,0 +1,36 @@
+/**
+ * v2/mention-parser — parse `@zapbot <command>` from a GitHub issue or PR
+ * comment body into a discriminated `MentionCommand`.
+ *
+ * Boundary: text that arrived from a GitHub webhook payload. The webhook has
+ * already been HMAC-verified before this module runs; the parser does NOT
+ * validate authenticity, only shape.
+ *
+ * Principle 4 (Exhaustiveness): the return type is a discriminated union.
+ * Callers must handle `unknown_command` explicitly (v1's `null` return is
+ * replaced — "no command present" and "bot mentioned with unrecognized
+ * command" are different cases and downstream reacts differently).
+ */
+
+import type { BotUsername, MentionCommand } from "./types.ts";
+
+/**
+ * Returns the parsed command if the body contains an `@<botUsername>` mention
+ * on a line that is not inside a code fence / blockquote; returns `null` if
+ * no bot mention is present at all.
+ */
+export function parseMention(
+  _body: string,
+  _botUsername: BotUsername
+): MentionCommand | null {
+  throw new Error("not implemented");
+}
+
+/**
+ * Strip fenced code blocks, inline code, and blockquote lines from a body so
+ * quoted mentions are not treated as commands. Exported for testing;
+ * `parseMention` calls it internally.
+ */
+export function stripQuotedContent(_body: string): string {
+  throw new Error("not implemented");
+}

--- a/v2/types.ts
+++ b/v2/types.ts
@@ -1,0 +1,75 @@
+/**
+ * v2 shared types — branded IDs, discriminated command shapes, typed error tags.
+ *
+ * Downstream rule: every public function in v2/ declares its parameter types
+ * and error channel from this file. No raw `string` for identifiers on a
+ * public signature. No `Promise<T>` for fallible calls — use `Result<T, E>`
+ * with a discriminated `E`.
+ */
+
+// ── Branded identifiers ─────────────────────────────────────────────
+
+export type RepoFullName = string & { readonly __brand: "RepoFullName" };
+export type IssueNumber = number & { readonly __brand: "IssueNumber" };
+export type CommentId = number & { readonly __brand: "CommentId" };
+export type DeliveryId = string & { readonly __brand: "DeliveryId" };
+export type ProjectName = string & { readonly __brand: "ProjectName" };
+export type InstallationToken = string & { readonly __brand: "InstallationToken" };
+export type AoSessionName = string & { readonly __brand: "AoSessionName" };
+export type BotUsername = string & { readonly __brand: "BotUsername" };
+
+// ── Result type (discriminated; errors are typed, not thrown) ───────
+
+export type Ok<T> = { readonly _tag: "Ok"; readonly value: T };
+export type Err<E> = { readonly _tag: "Err"; readonly error: E };
+export type Result<T, E> = Ok<T> | Err<E>;
+
+export function ok<T>(_value: T): Ok<T> {
+  throw new Error("not implemented");
+}
+export function err<E>(_error: E): Err<E> {
+  throw new Error("not implemented");
+}
+
+// ── Mention command (discriminated union) ───────────────────────────
+
+/**
+ * Parsed `@zapbot <command>` intent. `unknown_command` carries the raw text
+ * so the bridge can respond with a "I don't recognize that command" comment
+ * without embedding its own command vocabulary here.
+ */
+export type MentionCommand =
+  | { readonly kind: "plan_this" }
+  | { readonly kind: "investigate_this" }
+  | { readonly kind: "status" }
+  | { readonly kind: "unknown_command"; readonly raw: string };
+
+// ── Errors surfaced across module boundaries ────────────────────────
+
+export type GatewayError =
+  | { readonly _tag: "GatewayUnreachable"; readonly cause: string }
+  | { readonly _tag: "GatewayRejected"; readonly status: number; readonly body: string }
+  | { readonly _tag: "GatewayAuthMissing" };
+
+export type WebhookIntakeError =
+  | { readonly _tag: "InvalidJson" }
+  | { readonly _tag: "SignatureMismatch" }
+  | { readonly _tag: "UnconfiguredRepo"; readonly repo: RepoFullName }
+  | { readonly _tag: "SecretMissing"; readonly repo: RepoFullName };
+
+export type DispatchError =
+  | { readonly _tag: "TokenMintFailed"; readonly cause: string }
+  | { readonly _tag: "AoSpawnFailed"; readonly exitCode: number; readonly stderr: string }
+  | { readonly _tag: "ProjectNotConfigured"; readonly repo: RepoFullName };
+
+export type GithubStateError =
+  | { readonly _tag: "GhCliMissing" }
+  | { readonly _tag: "GhCliFailed"; readonly exitCode: number; readonly stderr: string }
+  | { readonly _tag: "IssueNotFound"; readonly repo: RepoFullName; readonly issue: IssueNumber }
+  | { readonly _tag: "ParseFailed"; readonly raw: string };
+
+// ── Exhaustiveness helper ───────────────────────────────────────────
+
+export function absurd(_x: never): never {
+  throw new Error("not implemented");
+}


### PR DESCRIPTION
Architecture only. Not for merge. Design doc comes as a comment on sub-issue #99.

Parent epic: #96
Spec: #98 (plan-approved at comment-4274476752)
Investigate inventory: #97 (comment-4274453943)
Sub-issue: #99

6 interface stubs under \`v2/\`: \`types.ts\`, \`gateway.ts\`, \`bridge.ts\`, \`ao/dispatcher.ts\`, \`github-state.ts\`, \`mention-parser.ts\`. Every body is exactly \`throw new Error("not implemented")\`. 458 LOC of types and signatures only. No existing source files modified on this branch.

The stubs encode:
- branded IDs (\`RepoFullName\`, \`IssueNumber\`, \`InstallationToken\`, ...)
- tagged error channels (\`GatewayError\`, \`WebhookIntakeError\`, \`DispatchError\`, \`GithubStateError\`)
- a discriminated \`MentionCommand\` union
- \`Result<T, E>\` return types on every fallible function

Downstream \`implement-*\` modalities fill in bodies against this contract. No \`package.json\` edits here; dep strip (\`better-sqlite3\`, \`kysely\`) lands with the implement PR.