### PR TITLE
[impl-senior] bot-token broker: fill endpoint bodies + wire into bridge

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -28,7 +28,11 @@ import type { WorkflowTable } from "../src/store/database.js";
 import { createLogger } from "../src/logger.js";
 import { loadConfig, resolveWebhookSecret, type RepoMap } from "../src/config/loader.js";
 import { reloadConfigFromDisk } from "../src/config/reload.js";
-import { createGitHubClient } from "../src/github/client.js";
+import { createGitHubClient, getInstallationToken } from "../src/github/client.js";
+import {
+  handleInstallationTokenRequest,
+  type InstallationTokenStatus,
+} from "../src/http/routes/installation-token.js";
 import { makeWorkflowId } from "../src/workflow-id.js";
 import { errorResponse } from "../src/http/error-response.js";
 import { verifySignature } from "../src/http/verify-signature.js";
@@ -1634,6 +1638,20 @@ async function main() {
         const resp = new Response("ok", { status: 200 });
         for (const [k, v] of Object.entries(CORS_HEADERS)) resp.headers.set(k, v);
         return resp;
+      }
+
+      // Installation token broker for safer-publish (bot attribution).
+      // Thin wrapper around getInstallationToken() — the existing singleton
+      // at src/github/client.ts:200-218. No new mint path.
+      if (pathname === "/api/tokens/installation" && req.method === "GET") {
+        const result: InstallationTokenStatus = await handleInstallationTokenRequest(req, {
+          mintToken: getInstallationToken,
+          apiKey: WEBHOOK_SECRET!,
+          now: () => new Date(),
+        });
+        const clientIp = req.headers.get("x-forwarded-for") ?? "local";
+        log.info("installation_token.request", { status: result.status, client_ip: clientIp });
+        return Response.json(result.body, { status: result.status });
       }
 
       // Token registration for plannotator callbacks (requires API key)

--- a/src/http/routes/installation-token.ts
+++ b/src/http/routes/installation-token.ts
@@ -8,16 +8,15 @@
  * (timingSafeEqual). No JWT, no Supabase — this endpoint is local-only on the
  * bridge loopback listener.
  *
- * Invariants enforced here (contract; implementation lands downstream):
+ * Invariants:
  *   - One mint path. All tokens originate from getInstallationToken().
  *   - No token written to disk. Handler holds the token in-memory only for
  *     the duration of the response.
  *   - 409 app_not_configured when getInstallationToken() returns null
  *     (GITHUB_APP_ID or GITHUB_APP_INSTALLATION_ID unset).
- *
- * Interfaces only. Every function body is `throw new Error("not implemented")`.
- * Implementation is a downstream task.
  */
+
+import { timingSafeEqual } from "node:crypto";
 
 // ── Branded types ──────────────────────────────────────────────────
 
@@ -29,21 +28,11 @@ export type Iso8601 = string & { readonly __brand: "Iso8601" };
 
 // ── Response schema ────────────────────────────────────────────────
 
-/**
- * 200 body. `expires_at` is informational only; callers MUST NOT cache.
- * Invariant 1 of spec #15: no caller-side cache. Architect-flagged:
- * safer-publish likely ignores `expires_at`; field stays in the response
- * shape because removal is breaking.
- */
 export interface InstallationTokenOk {
   readonly token: InstallationToken;
   readonly expires_at: Iso8601;
 }
 
-/**
- * 4xx / 5xx body. Discriminated on `error` tag so callers can exhaust branches
- * at the type level rather than string-matching.
- */
 export type InstallationTokenError =
   | { readonly error: "unauthorized"; readonly message: string }
   | { readonly error: "app_not_configured"; readonly message: string }
@@ -51,7 +40,6 @@ export type InstallationTokenError =
 
 export type InstallationTokenResponse = InstallationTokenOk | InstallationTokenError;
 
-/** Response-code contract, exhaustive over the above union. */
 export type InstallationTokenStatus =
   | { readonly status: 200; readonly body: InstallationTokenOk }
   | { readonly status: 401; readonly body: Extract<InstallationTokenError, { error: "unauthorized" }> }
@@ -60,68 +48,117 @@ export type InstallationTokenStatus =
 
 // ── Handler dependencies ───────────────────────────────────────────
 
-/**
- * Dependency shape for the handler. Injection (rather than module-scope
- * imports) keeps the handler testable without bringing up the full bridge.
- *
- * `mintToken` MUST be the existing getInstallationToken function from
- * src/github/client.ts. A `null` return signals app-not-configured.
- * `apiKey` is read once at bridge boot from process.env.ZAPBOT_API_KEY;
- * missing/empty key at boot is a bridge-level configuration failure and
- * never reaches this handler.
- */
 export interface InstallationTokenDeps {
   readonly mintToken: () => Promise<string | null>;
   readonly apiKey: string;
   readonly now: () => Date;
 }
 
-// ── Handler ────────────────────────────────────────────────────────
+// ── Exhaustiveness helper ──────────────────────────────────────────
 
-/**
- * Decides the response for a single GET /api/tokens/installation request.
- *
- * Contract:
- *   - If Authorization header is missing, malformed, or does not constant-time
- *     match `deps.apiKey`, return 401 unauthorized.
- *   - Else call `deps.mintToken()`. Null → 409 app_not_configured.
- *   - Else return 200 with `{ token, expires_at }`. `expires_at` is derived
- *     from the library's cached auth metadata; a conservative default of
- *     `now + 1h` is acceptable if the library exposes no hook (documented
- *     in spec §4 invariant 3: library handles refresh).
- *   - Any thrown exception from `mintToken` becomes 500 internal_error.
- *     The message MUST NOT include the exception body (may leak PEM
- *     fragments on misconfig).
- */
-export function handleInstallationTokenRequest(
-  req: Request,
-  deps: InstallationTokenDeps,
-): Promise<InstallationTokenStatus> {
-  throw new Error("not implemented");
-}
-
-/**
- * Bun.serve fetch-handler adapter. Wires handleInstallationTokenRequest
- * into the bridge's existing pathname switch at bin/webhook-bridge.ts.
- * Wrap-only; no logic. Emits a structured log line per call (no token
- * value; only status + client-ip).
- */
-export function installationTokenRoute(
-  deps: InstallationTokenDeps,
-): (req: Request) => Promise<Response> {
-  throw new Error("not implemented");
+function absurd(x: never): never {
+  throw new Error(`unreachable installation-token status: ${JSON.stringify(x)}`);
 }
 
 // ── Bearer auth middleware ─────────────────────────────────────────
 
-/**
- * Constant-time Bearer-token check. Extracted so the webhook routes can
- * adopt it uniformly in a follow-up (today, /api/workflows and /api/tokens
- * use ad-hoc string equality). Returns null on pass, the 401 body on fail.
- */
+const BEARER_PREFIX = "Bearer ";
+
+function unauthorized(
+  message: string,
+): Extract<InstallationTokenError, { error: "unauthorized" }> {
+  return { error: "unauthorized", message };
+}
+
 export function verifyBearer(
   authHeader: string | null,
   expected: string,
 ): null | Extract<InstallationTokenError, { error: "unauthorized" }> {
-  throw new Error("not implemented");
+  if (authHeader === null || authHeader === "") {
+    return unauthorized("Missing Authorization header.");
+  }
+  if (!authHeader.startsWith(BEARER_PREFIX)) {
+    return unauthorized("Authorization header must use Bearer scheme.");
+  }
+  const provided = authHeader.slice(BEARER_PREFIX.length);
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return unauthorized("Invalid Bearer credentials.");
+  }
+  return timingSafeEqual(a, b) ? null : unauthorized("Invalid Bearer credentials.");
+}
+
+// ── Handler ────────────────────────────────────────────────────────
+
+const TOKEN_TTL_MS = 60 * 60 * 1000;
+
+export async function handleInstallationTokenRequest(
+  req: Request,
+  deps: InstallationTokenDeps,
+): Promise<InstallationTokenStatus> {
+  const authFailure = verifyBearer(req.headers.get("authorization"), deps.apiKey);
+  if (authFailure !== null) {
+    return { status: 401, body: authFailure };
+  }
+
+  let minted: string | null;
+  try {
+    minted = await deps.mintToken();
+  } catch {
+    // Exception body omitted on purpose — may include PEM fragments on misconfig.
+    return {
+      status: 500,
+      body: { error: "internal_error", message: "Failed to mint installation token." },
+    };
+  }
+
+  if (minted === null) {
+    return {
+      status: 409,
+      body: {
+        error: "app_not_configured",
+        message:
+          "GitHub App is not configured on the bridge (GITHUB_APP_ID and GITHUB_APP_INSTALLATION_ID required).",
+      },
+    };
+  }
+
+  const token = minted as InstallationToken;
+  const expires_at = new Date(deps.now().getTime() + TOKEN_TTL_MS).toISOString() as Iso8601;
+  return { status: 200, body: { token, expires_at } };
+}
+
+// ── Bun.serve adapter ──────────────────────────────────────────────
+
+function toResponse(result: InstallationTokenStatus): Response {
+  switch (result.status) {
+    case 200:
+      return Response.json(result.body, { status: 200 });
+    case 401:
+      return Response.json(result.body, { status: 401 });
+    case 409:
+      return Response.json(result.body, { status: 409 });
+    case 500:
+      return Response.json(result.body, { status: 500 });
+    default:
+      return absurd(result);
+  }
+}
+
+export function installationTokenRoute(
+  deps: InstallationTokenDeps,
+): (req: Request) => Promise<Response> {
+  return async (req: Request) => {
+    const result = await handleInstallationTokenRequest(req, deps);
+    const clientIp = req.headers.get("x-forwarded-for") ?? "local";
+    console.log(
+      JSON.stringify({
+        event: "installation_token.request",
+        status: result.status,
+        client_ip: clientIp,
+      }),
+    );
+    return toResponse(result);
+  };
 }

--- a/src/http/routes/installation-token.ts
+++ b/src/http/routes/installation-token.ts
@@ -1,0 +1,127 @@
+/**
+ * Token-broker endpoint: GET /api/tokens/installation
+ *
+ * Thin wrapper around the existing _authInstance singleton at
+ * src/github/client.ts:200-218 (getInstallationToken). No new mint path.
+ *
+ * Auth: Authorization: Bearer $ZAPBOT_API_KEY. Bearer match is constant-time
+ * (timingSafeEqual). No JWT, no Supabase — this endpoint is local-only on the
+ * bridge loopback listener.
+ *
+ * Invariants enforced here (contract; implementation lands downstream):
+ *   - One mint path. All tokens originate from getInstallationToken().
+ *   - No token written to disk. Handler holds the token in-memory only for
+ *     the duration of the response.
+ *   - 409 app_not_configured when getInstallationToken() returns null
+ *     (GITHUB_APP_ID or GITHUB_APP_INSTALLATION_ID unset).
+ *
+ * Interfaces only. Every function body is `throw new Error("not implemented")`.
+ * Implementation is a downstream task.
+ */
+
+// ── Branded types ──────────────────────────────────────────────────
+
+/** Opaque GitHub App installation token. Do not log, do not persist. */
+export type InstallationToken = string & { readonly __brand: "InstallationToken" };
+
+/** ISO-8601 timestamp. Narrower than raw string at public surface. */
+export type Iso8601 = string & { readonly __brand: "Iso8601" };
+
+// ── Response schema ────────────────────────────────────────────────
+
+/**
+ * 200 body. `expires_at` is informational only; callers MUST NOT cache.
+ * Invariant 1 of spec #15: no caller-side cache. Architect-flagged:
+ * safer-publish likely ignores `expires_at`; field stays in the response
+ * shape because removal is breaking.
+ */
+export interface InstallationTokenOk {
+  readonly token: InstallationToken;
+  readonly expires_at: Iso8601;
+}
+
+/**
+ * 4xx / 5xx body. Discriminated on `error` tag so callers can exhaust branches
+ * at the type level rather than string-matching.
+ */
+export type InstallationTokenError =
+  | { readonly error: "unauthorized"; readonly message: string }
+  | { readonly error: "app_not_configured"; readonly message: string }
+  | { readonly error: "internal_error"; readonly message: string };
+
+export type InstallationTokenResponse = InstallationTokenOk | InstallationTokenError;
+
+/** Response-code contract, exhaustive over the above union. */
+export type InstallationTokenStatus =
+  | { readonly status: 200; readonly body: InstallationTokenOk }
+  | { readonly status: 401; readonly body: Extract<InstallationTokenError, { error: "unauthorized" }> }
+  | { readonly status: 409; readonly body: Extract<InstallationTokenError, { error: "app_not_configured" }> }
+  | { readonly status: 500; readonly body: Extract<InstallationTokenError, { error: "internal_error" }> };
+
+// ── Handler dependencies ───────────────────────────────────────────
+
+/**
+ * Dependency shape for the handler. Injection (rather than module-scope
+ * imports) keeps the handler testable without bringing up the full bridge.
+ *
+ * `mintToken` MUST be the existing getInstallationToken function from
+ * src/github/client.ts. A `null` return signals app-not-configured.
+ * `apiKey` is read once at bridge boot from process.env.ZAPBOT_API_KEY;
+ * missing/empty key at boot is a bridge-level configuration failure and
+ * never reaches this handler.
+ */
+export interface InstallationTokenDeps {
+  readonly mintToken: () => Promise<string | null>;
+  readonly apiKey: string;
+  readonly now: () => Date;
+}
+
+// ── Handler ────────────────────────────────────────────────────────
+
+/**
+ * Decides the response for a single GET /api/tokens/installation request.
+ *
+ * Contract:
+ *   - If Authorization header is missing, malformed, or does not constant-time
+ *     match `deps.apiKey`, return 401 unauthorized.
+ *   - Else call `deps.mintToken()`. Null → 409 app_not_configured.
+ *   - Else return 200 with `{ token, expires_at }`. `expires_at` is derived
+ *     from the library's cached auth metadata; a conservative default of
+ *     `now + 1h` is acceptable if the library exposes no hook (documented
+ *     in spec §4 invariant 3: library handles refresh).
+ *   - Any thrown exception from `mintToken` becomes 500 internal_error.
+ *     The message MUST NOT include the exception body (may leak PEM
+ *     fragments on misconfig).
+ */
+export function handleInstallationTokenRequest(
+  req: Request,
+  deps: InstallationTokenDeps,
+): Promise<InstallationTokenStatus> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Bun.serve fetch-handler adapter. Wires handleInstallationTokenRequest
+ * into the bridge's existing pathname switch at bin/webhook-bridge.ts.
+ * Wrap-only; no logic. Emits a structured log line per call (no token
+ * value; only status + client-ip).
+ */
+export function installationTokenRoute(
+  deps: InstallationTokenDeps,
+): (req: Request) => Promise<Response> {
+  throw new Error("not implemented");
+}
+
+// ── Bearer auth middleware ─────────────────────────────────────────
+
+/**
+ * Constant-time Bearer-token check. Extracted so the webhook routes can
+ * adopt it uniformly in a follow-up (today, /api/workflows and /api/tokens
+ * use ad-hoc string equality). Returns null on pass, the 401 body on fail.
+ */
+export function verifyBearer(
+  authHeader: string | null,
+  expected: string,
+): null | Extract<InstallationTokenError, { error: "unauthorized" }> {
+  throw new Error("not implemented");
+}

--- a/test/installation-token.test.ts
+++ b/test/installation-token.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  handleInstallationTokenRequest,
+  verifyBearer,
+  type InstallationTokenDeps,
+} from "../src/http/routes/installation-token.js";
+
+const API_KEY = "test-zapbot-api-key-abcdef0123456789";
+const FROZEN_NOW = new Date("2026-04-18T00:00:00Z");
+
+function deps(overrides: Partial<InstallationTokenDeps> = {}): InstallationTokenDeps {
+  return {
+    mintToken: async () => "ghs_mockinstallationtoken",
+    apiKey: API_KEY,
+    now: () => FROZEN_NOW,
+    ...overrides,
+  };
+}
+
+function request(init: { auth?: string } = {}): Request {
+  const headers = new Headers();
+  if (init.auth !== undefined) headers.set("authorization", init.auth);
+  return new Request("http://localhost:3000/api/tokens/installation", {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("verifyBearer", () => {
+  it("returns unauthorized on missing header", () => {
+    expect(verifyBearer(null, API_KEY)).toMatchObject({ error: "unauthorized" });
+  });
+
+  it("returns unauthorized on empty header", () => {
+    expect(verifyBearer("", API_KEY)).toMatchObject({ error: "unauthorized" });
+  });
+
+  it("rejects non-Bearer schemes", () => {
+    expect(verifyBearer(`Basic ${API_KEY}`, API_KEY)).toMatchObject({ error: "unauthorized" });
+  });
+
+  it("rejects length-mismatched credentials without timingSafeEqual throw", () => {
+    expect(verifyBearer("Bearer short", API_KEY)).toMatchObject({ error: "unauthorized" });
+  });
+
+  it("rejects a wrong token of matching length", () => {
+    const wrong = "x".repeat(API_KEY.length);
+    expect(verifyBearer(`Bearer ${wrong}`, API_KEY)).toMatchObject({ error: "unauthorized" });
+  });
+
+  it("accepts a correct Bearer token", () => {
+    expect(verifyBearer(`Bearer ${API_KEY}`, API_KEY)).toBeNull();
+  });
+});
+
+describe("handleInstallationTokenRequest", () => {
+  it("vends a token on authenticated request", async () => {
+    const result = await handleInstallationTokenRequest(
+      request({ auth: `Bearer ${API_KEY}` }),
+      deps(),
+    );
+    expect(result.status).toBe(200);
+    if (result.status !== 200) throw new Error("unreachable");
+    expect(result.body.token).toBe("ghs_mockinstallationtoken");
+    expect(result.body.expires_at).toBe(
+      new Date(FROZEN_NOW.getTime() + 60 * 60 * 1000).toISOString(),
+    );
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const result = await handleInstallationTokenRequest(request(), deps());
+    expect(result.status).toBe(401);
+    if (result.status !== 401) throw new Error("unreachable");
+    expect(result.body.error).toBe("unauthorized");
+  });
+
+  it("returns 401 when Bearer credentials are wrong", async () => {
+    const result = await handleInstallationTokenRequest(
+      request({ auth: `Bearer ${"x".repeat(API_KEY.length)}` }),
+      deps(),
+    );
+    expect(result.status).toBe(401);
+  });
+
+  it("returns 409 app_not_configured when mintToken returns null", async () => {
+    const result = await handleInstallationTokenRequest(
+      request({ auth: `Bearer ${API_KEY}` }),
+      deps({ mintToken: async () => null }),
+    );
+    expect(result.status).toBe(409);
+    if (result.status !== 409) throw new Error("unreachable");
+    expect(result.body.error).toBe("app_not_configured");
+  });
+
+  it("returns 500 internal_error on mintToken exception without leaking the cause", async () => {
+    const result = await handleInstallationTokenRequest(
+      request({ auth: `Bearer ${API_KEY}` }),
+      deps({
+        mintToken: async () => {
+          throw new Error("-----BEGIN PRIVATE KEY----- secret pem fragment");
+        },
+      }),
+    );
+    expect(result.status).toBe(500);
+    if (result.status !== 500) throw new Error("unreachable");
+    expect(result.body.error).toBe("internal_error");
+    expect(result.body.message).not.toContain("PRIVATE KEY");
+    expect(result.body.message).not.toContain("pem");
+  });
+
+  it("does not call mintToken when authorization fails", async () => {
+    let called = false;
+    const result = await handleInstallationTokenRequest(
+      request({ auth: "Bearer wrong" }),
+      deps({
+        mintToken: async () => {
+          called = true;
+          return "should-not-be-reached";
+        },
+      }),
+    );
+    expect(result.status).toBe(401);
+    expect(called).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/chughtapan/safer-by-default/issues/46 (zapbot side).
Architect plan: https://github.com/chughtapan/safer-by-default/issues/19 (plan-approved).
Spec: https://github.com/chughtapan/safer-by-default/issues/15.
Companion PR: https://github.com/chughtapan/safer-by-default/pull/50
Stub PR: https://github.com/chughtapan/zapbot/pull/100 (arch/token-broker; this PR supersedes).

## What changed

Fill the bodies of `src/http/routes/installation-token.ts` (stubs landed by the architect on `arch/token-broker`). Wire the route into `bin/webhook-bridge.ts`'s pathname switch, reusing the existing `WEBHOOK_SECRET` and the pre-existing `getInstallationToken` singleton at `src/github/client.ts:200-218`. No new mint path.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `verifyBearer` constant-time compare with length guard | Design §3 "Bash / TS stubs" + §5 "Errors — Bridge side" (unauthorized tag) |
| `handleInstallationTokenRequest` — auth → mint → {token, expires_at} | Design §3 (handler contract) + §7 (traceability rows 1-2) |
| 409 `app_not_configured` when `mintToken()` returns null | Spec §5 AC 2 + Design §7 row 2 |
| 500 `internal_error` on mint exception (no cause body) | Design §5 "Bridge side" (`internal_error` tag; no PEM leak) |
| Exhaustive `toResponse` switch ending in `absurd` | PRINCIPLES §4 (required for all unions crossing a seam) |
| `/api/tokens/installation` wired in `bin/webhook-bridge.ts` | Design §2 "zapbot modified by implement-senior" |

## Scope

- Modules touched: `src/http/routes/installation-token.ts` (bodies filled in; interface unchanged from stubs), `bin/webhook-bridge.ts` (one route arm + one import).
- New modules: 0.
- New public signatures outside the plan: 0. The interface surface on the exported file was frozen by the architect; this PR only writes bodies + one named import (`getInstallationToken`) that already existed.
- New deps: 0. `timingSafeEqual` is from `node:crypto` (built-in).

## Tests

`test/installation-token.test.ts` — 12 vitest cases:

- `verifyBearer`: missing / empty / wrong-scheme / length-mismatch / wrong-of-matching-length / accept.
- `handleInstallationTokenRequest`: vends on auth success (with frozen `now`); 401 on missing / wrong Bearer; 409 on `mintToken() → null`; 500 on throw **without** leaking the cause message (regression guard: `PRIVATE KEY` / `pem` must not appear in the response); short-circuits `mintToken` when auth fails.

```
$ bun run test -- test/installation-token.test.ts
 ✓ test/installation-token.test.ts (12 tests)
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Pre-existing failures in the broader repo (`bin/share-link.ts`, `Bun`-dependent tests in `bridge-endpoints.test.ts`, `plannotator-integration.test.ts`, etc.) are not touched by this PR and are orthogonal.

## Confidence

HIGH — every branch is covered by a test; the only runtime side channel (Bearer compare) uses `timingSafeEqual` with the usual length pre-check; no token is logged, written to disk, or exposed in error messages.