### PR TITLE
[safer:implement-junior] fast-check HMAC property test (closes #116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ bun run bridge         # start webhook bridge directly
 ./test/e2e-smoke.sh    # end-to-end smoke test
 ```
 
+## Testing
+
+Unit and property tests run under [vitest](https://vitest.dev).
+[fast-check](https://fast-check.dev) drives property-based coverage of the
+HMAC webhook verifier (`test/verify-signature.property.test.ts`, ~200 runs per
+property): valid signatures accepted, and mutations of the signature, body, or
+secret rejected.
+
+testcontainers and Playwright are deferred — v2 has no database layer and no
+browser-facing surface, so they have no target yet. Reintroduce when a DB or
+UI subsystem lands.
+
 ## Architecture
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the v2 module layout.

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       },
       "devDependencies": {
         "bun-types": "^1.3.12",
+        "fast-check": "^4.7.0",
         "typescript": "^6.0.2",
         "vitest": "^3.2.4",
       },
@@ -203,6 +204,8 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
+
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -230,6 +233,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "devDependencies": {
     "bun-types": "^1.3.12",
+    "fast-check": "^4.7.0",
     "typescript": "^6.0.2",
     "vitest": "^3.2.4"
   },

--- a/test/verify-signature.property.test.ts
+++ b/test/verify-signature.property.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { verifySignature } from "../src/http/verify-signature.js";
+
+// Match verify-signature.ts byte-for-byte: WebCrypto HMAC-SHA256, hex, "sha256=" prefix.
+async function sign(payload: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  return `sha256=${Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+const RUNS = 200;
+
+// Non-empty secret so the HMAC key is well-defined across both sides.
+const arbSecret = fc.string({ minLength: 1, maxLength: 64 });
+const arbBody = fc.string({ maxLength: 512 });
+
+describe("verifySignature (property)", () => {
+  it("accepts any correctly-signed payload", async () => {
+    await fc.assert(
+      fc.asyncProperty(arbSecret, arbBody, async (secret, body) => {
+        const sig = await sign(body, secret);
+        return (await verifySignature(body, sig, secret)) === true;
+      }),
+      { numRuns: RUNS }
+    );
+  });
+
+  it("rejects a mutated signature", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbSecret,
+        arbBody,
+        fc.nat(63), // position within the 64-hex-char digest
+        fc.integer({ min: 1, max: 15 }), // nonzero XOR to guarantee change
+        async (secret, body, hexIdx, xor) => {
+          const sig = await sign(body, secret);
+          const prefix = "sha256=";
+          const hex = sig.slice(prefix.length);
+          const originalNibble = parseInt(hex[hexIdx], 16);
+          const mutatedNibble = (originalNibble ^ xor) & 0xf;
+          const mutated =
+            prefix +
+            hex.slice(0, hexIdx) +
+            mutatedNibble.toString(16) +
+            hex.slice(hexIdx + 1);
+          return (await verifySignature(body, mutated, secret)) === false;
+        }
+      ),
+      { numRuns: RUNS }
+    );
+  });
+
+  it("rejects a mutated body against the original signature", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbSecret,
+        arbBody,
+        arbBody,
+        async (secret, body, suffix) => {
+          fc.pre(suffix.length > 0); // ensure the body actually changes
+          const originalSig = await sign(body, secret);
+          const mutatedBody = body + suffix;
+          return (
+            (await verifySignature(mutatedBody, originalSig, secret)) === false
+          );
+        }
+      ),
+      { numRuns: RUNS }
+    );
+  });
+
+  it("rejects a mutated secret against the original signature", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbSecret,
+        arbBody,
+        arbSecret,
+        async (secret, body, otherSecret) => {
+          fc.pre(otherSecret !== secret);
+          const originalSig = await sign(body, secret);
+          return (
+            (await verifySignature(body, originalSig, otherSecret)) === false
+          );
+        }
+      ),
+      { numRuns: RUNS }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #116 (v3 scope — HMAC property testing only; v2 has no DB so testcontainers/fc.commands dropped per issue).

- Adds `test/verify-signature.property.test.ts` with 4 fast-check properties over `src/http/verify-signature.ts:5`, ~200 runs each:
  1. Happy path: `verify(body, sign(body, secret), secret)` ⇒ `true`
  2. Mutated signature (one hex nibble flipped) ⇒ `false`
  3. Mutated body (original signature) ⇒ `false`
  4. Mutated secret (original signature) ⇒ `false`
- `pnpm add -D fast-check` (executed via `bun add -D` — zapbot uses bun per README `## Development`).
- README `## Testing` section documents vitest + fast-check, notes testcontainers/Playwright are deferred until a DB or UI subsystem exists.

No changes to `verify-signature.ts`.

## Test plan

- [x] `bun x vitest run test/verify-signature.property.test.ts` — 4/4 pass
- [x] `bun x vitest run` — full suite 129/129 pass
- [x] HMAC recomputed in the test via WebCrypto, matching `verify-signature.ts` byte-for-byte
- [x] No verify-signature.ts changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)