### PR TITLE
fix(spawner): guard cleanStaleWorktree on restorable ao session

### DIFF
--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -103,6 +103,31 @@ function generateAgentId(): string {
   return `agent-${crypto.randomUUID()}`;
 }
 
+// If an ao session for this issue reports a non-terminal status, its worktree
+// is still the legitimate home of in-progress work — the recovery path is
+// `ao session restore`, not `git worktree remove --force`. See
+// safer-by-default#65 (tier-1 reentrance spike).
+const RESTORABLE_AO_STATUSES = new Set(["active", "ready", "stuck", "terminated", "idle"]);
+
+async function hasRestorableAoSession(issueNumber: number): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["ao", "session", "ls", "--json"], { stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return false;
+    const sessions = JSON.parse(stdout) as Array<{ issueId?: number | string | null; status?: string }>;
+    for (const s of sessions) {
+      if (s?.issueId == null) continue;
+      const sid = typeof s.issueId === "string" ? Number(s.issueId) : s.issueId;
+      if (sid !== issueNumber) continue;
+      if (s.status && RESTORABLE_AO_STATUSES.has(s.status)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 async function cleanStaleWorktree(issueNumber: number): Promise<void> {
   const branch = `feat/issue-${issueNumber}`;
   try {
@@ -111,6 +136,15 @@ async function cleanStaleWorktree(issueNumber: number): Promise<void> {
     await proc.exited;
 
     if (!stdout.includes(`refs/heads/${branch}`)) return;
+
+    if (await hasRestorableAoSession(issueNumber)) {
+      log.warn(
+        `Skipping cleanStaleWorktree for ${branch}: restorable ao session present. ` +
+        `Use 'ao session restore' to resume; see safer-by-default#65.`,
+        { issueNumber, branch },
+      );
+      return;
+    }
 
     // Porcelain output is block-structured, separated by blank lines
     for (const block of stdout.split("\n\n")) {


### PR DESCRIPTION
## Summary

- Before `git worktree remove --force`, check if an ao session for this issue reports a non-terminal status (`active` / `ready` / `stuck` / `terminated` / `idle`).
- If so, skip the removal — the worktree is the legitimate home of in-progress work that can be resumed via `ao session restore`. Deleting it drops user work on the floor.
- Matches the recovery path proposed in the safer-by-default#65 tier-1 reentrance spike.

## Background

The safer-by-default#65 spike (tier-1 reentrance + local reconcile) composed a 3-source liveness verdict and mapped the `restorable` case to `ao session restore`, **not** `cleanStaleWorktree`. The spike's phase-5d-rewrite doc names this guard as a hard precondition. Filing as a targeted one-commit fix rather than waiting on the full /safer:spec rollout.

## Base branch

Filed against `arch/v2-layout` because `main` has been stripped in #104 and no longer contains `src/agents/spawner.ts`. When v2 re-lands the spawner, this guard rides along.

## Test plan

- [ ] Trigger a spawn for an issue where an ao session in `stuck` status already owns the worktree → expect `Skipping cleanStaleWorktree` log, worktree preserved.
- [ ] Trigger a spawn where the ao session has been killed (non-restorable) → expect current behavior, worktree removed.
- [ ] Verify `ao session ls --json` parse failure (e.g., ao not installed) returns false and preserves current behavior via the try/catch.

Ref: chughtapan/safer-by-default#65