### PR TITLE
[impl-staff] moltzap Channels bridge: lifecycle + listener + bridge

### DIFF
--- a/test/v2-moltzap-bridge.test.ts
+++ b/test/v2-moltzap-bridge.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  onInbound,
+  reply,
+  type BridgeError,
+  type ChannelNotification,
+  type McpNotifier,
+  type MoltzapSender,
+} from "../v2/moltzap/bridge.ts";
+import { INITIAL, type LifecycleState } from "../v2/moltzap/lifecycle.ts";
+import {
+  asMoltzapConversationId,
+  asMoltzapMessageId,
+  asMoltzapSenderId,
+  type ListenerHandle,
+  type McpContext,
+  type MoltzapInbound,
+  type MoltzapSdkContext,
+} from "../v2/moltzap/types.ts";
+import { err, ok } from "../v2/types.ts";
+
+const mcpCtx = { __brand: "McpContext" } as McpContext;
+const sdkCtx = { __brand: "MoltzapSdkContext" } as MoltzapSdkContext;
+const handle = { __brand: "ListenerHandle" } as ListenerHandle;
+
+const LISTENING: LifecycleState = { _tag: "LISTENING", listener: handle };
+
+function makeEvent(): MoltzapInbound {
+  return {
+    messageId: asMoltzapMessageId("m-1"),
+    conversationId: asMoltzapConversationId("conv-A"),
+    senderId: asMoltzapSenderId("user-42"),
+    bodyText: "hello from moltzap",
+    receivedAtMs: 1_000_000,
+  };
+}
+
+describe("bridge.onInbound — LISTENING gate", () => {
+  it("routes the event to MCP notify when LISTENING", async () => {
+    const sent: ChannelNotification[] = [];
+    const notify: McpNotifier = async (_ctx, n) => {
+      sent.push(n);
+      return ok(undefined);
+    };
+    const dropped: BridgeError[] = [];
+    const diag = (e: BridgeError) => dropped.push(e);
+
+    const result = await onInbound(LISTENING, makeEvent(), mcpCtx, notify, diag);
+    expect(result._tag).toBe("Ok");
+    expect(sent).toHaveLength(1);
+    expect(sent[0].method).toBe("notifications/claude/channel");
+    expect(sent[0].params.channelTag).toBe("moltzap");
+    expect(sent[0].params.body).toBe("hello from moltzap");
+    expect(dropped).toHaveLength(0);
+  });
+
+  it("drops the event with PreReadyEventDropped when state is INIT", async () => {
+    let notifyCalled = false;
+    const notify: McpNotifier = async () => {
+      notifyCalled = true;
+      return ok(undefined);
+    };
+    const dropped: BridgeError[] = [];
+    const diag = (e: BridgeError) => dropped.push(e);
+
+    const result = await onInbound(INITIAL, makeEvent(), mcpCtx, notify, diag);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("PreReadyEventDropped");
+    expect(notifyCalled).toBe(false);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0]._tag).toBe("PreReadyEventDropped");
+  });
+
+  it("surfaces OutboundFailed when notify fails", async () => {
+    const notify: McpNotifier = async () => err({ cause: "MCP stdio broken" });
+    const result = await onInbound(LISTENING, makeEvent(), mcpCtx, notify, () => {});
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("OutboundFailed");
+  });
+});
+
+describe("bridge.reply — LISTENING gate", () => {
+  it("sends via moltzap sender and returns a receipt when LISTENING", async () => {
+    const sent: { conversationId: string; text: string }[] = [];
+    const sender: MoltzapSender = async (_ctx, args) => {
+      sent.push({ conversationId: args.conversationId, text: args.text });
+      return ok(undefined);
+    };
+    const result = await reply(
+      LISTENING,
+      { conversationId: asMoltzapConversationId("conv-A"), text: "ack" },
+      sdkCtx,
+      sender,
+      () => 7_000_000,
+    );
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value._tag).toBe("Sent");
+    expect(result.value.at).toBe(7_000_000);
+    expect(sent).toEqual([{ conversationId: "conv-A", text: "ack" }]);
+  });
+
+  it("refuses with NotListening when state is INIT", async () => {
+    let senderCalled = false;
+    const sender: MoltzapSender = async () => {
+      senderCalled = true;
+      return ok(undefined);
+    };
+    const result = await reply(
+      INITIAL,
+      { conversationId: asMoltzapConversationId("conv-A"), text: "ack" },
+      sdkCtx,
+      sender,
+    );
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("NotListening");
+    expect(senderCalled).toBe(false);
+  });
+
+  it("refuses with NotListening when state is FAILED", async () => {
+    const failed: LifecycleState = {
+      _tag: "FAILED",
+      cause: { _tag: "MoltzapHandshakeError", cause: "timeout" },
+    };
+    const sender: MoltzapSender = async () => ok(undefined);
+    const result = await reply(
+      failed,
+      { conversationId: asMoltzapConversationId("conv-A"), text: "ack" },
+      sdkCtx,
+      sender,
+    );
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("NotListening");
+  });
+
+  it("surfaces OutboundFailed when sender fails", async () => {
+    const sender: MoltzapSender = async () => err({ cause: "websocket closed" });
+    const result = await reply(
+      LISTENING,
+      { conversationId: asMoltzapConversationId("conv-A"), text: "ack" },
+      sdkCtx,
+      sender,
+    );
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("OutboundFailed");
+  });
+});
+
+describe("bridge.onInbound — order preserved (I2)", () => {
+  it("two inbound events arrive at MCP in delivery order", async () => {
+    const order: string[] = [];
+    const notify: McpNotifier = async (_ctx, n) => {
+      order.push(n.params.messageId);
+      return ok(undefined);
+    };
+    const first: MoltzapInbound = { ...makeEvent(), messageId: asMoltzapMessageId("m-1") };
+    const second: MoltzapInbound = { ...makeEvent(), messageId: asMoltzapMessageId("m-2") };
+    await onInbound(LISTENING, first, mcpCtx, notify, () => {});
+    await onInbound(LISTENING, second, mcpCtx, notify, () => {});
+    expect(order).toEqual(["m-1", "m-2"]);
+  });
+});

--- a/test/v2-moltzap-bridge.test.ts
+++ b/test/v2-moltzap-bridge.test.ts
@@ -79,6 +79,19 @@ describe("bridge.onInbound — LISTENING gate", () => {
     if (result._tag !== "Err") return;
     expect(result.error._tag).toBe("OutboundFailed");
   });
+
+  it("surfaces OutboundFailed when notify throws", async () => {
+    const boom = new Error("transport already closed");
+    const notify: McpNotifier = async () => {
+      throw boom;
+    };
+    const result = await onInbound(LISTENING, makeEvent(), mcpCtx, notify, () => {});
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("OutboundFailed");
+    if (result.error._tag !== "OutboundFailed") return;
+    expect(result.error.cause).toBe(boom);
+  });
 });
 
 describe("bridge.reply — LISTENING gate", () => {
@@ -148,6 +161,24 @@ describe("bridge.reply — LISTENING gate", () => {
     expect(result._tag).toBe("Err");
     if (result._tag !== "Err") return;
     expect(result.error._tag).toBe("OutboundFailed");
+  });
+
+  it("surfaces OutboundFailed when sender throws", async () => {
+    const boom = new Error("socket closed mid-send");
+    const sender: MoltzapSender = async () => {
+      throw boom;
+    };
+    const result = await reply(
+      LISTENING,
+      { conversationId: asMoltzapConversationId("conv-A"), text: "ack" },
+      sdkCtx,
+      sender,
+    );
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("OutboundFailed");
+    if (result.error._tag !== "OutboundFailed") return;
+    expect(result.error.cause).toBe(boom);
   });
 });
 

--- a/test/v2-moltzap-lifecycle.test.ts
+++ b/test/v2-moltzap-lifecycle.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import {
+  INITIAL,
+  transition,
+  isListening,
+  isMoltzapReady,
+  type LifecycleState,
+  type LifecycleEvent,
+  type ListenerRegistrationError,
+} from "../v2/moltzap/lifecycle.ts";
+import type { ListenerHandle } from "../v2/moltzap/types.ts";
+
+const handle = { __brand: "ListenerHandle" } as ListenerHandle;
+
+function happyPath(): LifecycleState {
+  let s = INITIAL;
+  for (const ev of [
+    { _tag: "StdioConnectStarted" },
+    { _tag: "StdioConnected" },
+    { _tag: "MoltzapConnectStarted" },
+    { _tag: "MoltzapReady" },
+    { _tag: "ListenerRegistered", handle },
+  ] as LifecycleEvent[]) {
+    const r = transition(s, ev);
+    if (r._tag !== "Next") throw new Error(`happy path broke at ${ev._tag}`);
+    s = r.state;
+  }
+  return s;
+}
+
+describe("lifecycle.transition — happy path", () => {
+  it("INIT → STDIO_CONNECTING → STDIO_READY → MOLTZAP_CONNECTING → MOLTZAP_READY → LISTENING", () => {
+    const terminal = happyPath();
+    expect(terminal._tag).toBe("LISTENING");
+    expect(isListening(terminal)).toBe(true);
+    expect(isMoltzapReady(terminal)).toBe(true);
+  });
+});
+
+describe("lifecycle.transition — failure branches", () => {
+  it("StdioFailed from STDIO_CONNECTING → FAILED(TransportConnectError)", () => {
+    const r1 = transition(INITIAL, { _tag: "StdioConnectStarted" });
+    expect(r1._tag).toBe("Next");
+    if (r1._tag !== "Next") return;
+    const r2 = transition(r1.state, { _tag: "StdioFailed", cause: "ECONNREFUSED" });
+    expect(r2._tag).toBe("Next");
+    if (r2._tag !== "Next") return;
+    expect(r2.state._tag).toBe("FAILED");
+    if (r2.state._tag !== "FAILED") return;
+    expect(r2.state.cause._tag).toBe("TransportConnectError");
+  });
+
+  it("MoltzapFailed from MOLTZAP_CONNECTING → FAILED(MoltzapHandshakeError)", () => {
+    let s = INITIAL;
+    for (const ev of [
+      { _tag: "StdioConnectStarted" },
+      { _tag: "StdioConnected" },
+      { _tag: "MoltzapConnectStarted" },
+    ] as LifecycleEvent[]) {
+      const r = transition(s, ev);
+      if (r._tag !== "Next") throw new Error("setup broke");
+      s = r.state;
+    }
+    const r = transition(s, { _tag: "MoltzapFailed", cause: "handshake timeout" });
+    expect(r._tag).toBe("Next");
+    if (r._tag !== "Next") return;
+    expect(r.state._tag).toBe("FAILED");
+    if (r.state._tag !== "FAILED") return;
+    expect(r.state.cause._tag).toBe("MoltzapHandshakeError");
+  });
+
+  it("ListenerFailed from MOLTZAP_READY → FAILED(ListenerRegistrationError)", () => {
+    let s = INITIAL;
+    for (const ev of [
+      { _tag: "StdioConnectStarted" },
+      { _tag: "StdioConnected" },
+      { _tag: "MoltzapConnectStarted" },
+      { _tag: "MoltzapReady" },
+    ] as LifecycleEvent[]) {
+      const r = transition(s, ev);
+      if (r._tag !== "Next") throw new Error("setup broke");
+      s = r.state;
+    }
+    const cause: ListenerRegistrationError = {
+      _tag: "SDKRejected",
+      cause: "SDK-ERROR-42",
+    };
+    const r = transition(s, { _tag: "ListenerFailed", cause });
+    expect(r._tag).toBe("Next");
+    if (r._tag !== "Next") return;
+    expect(r.state._tag).toBe("FAILED");
+    if (r.state._tag !== "FAILED") return;
+    expect(r.state.cause._tag).toBe("ListenerRegistrationError");
+  });
+});
+
+describe("lifecycle.transition — shutdown", () => {
+  it("DrainRequested from LISTENING → DRAINING", () => {
+    const listening = happyPath();
+    const r = transition(listening, {
+      _tag: "DrainRequested",
+      reason: { _tag: "SigTerm" },
+    });
+    expect(r._tag).toBe("Next");
+    if (r._tag !== "Next") return;
+    expect(r.state._tag).toBe("DRAINING");
+  });
+
+  it("DrainRequested from INIT → DRAINING (any non-terminal state)", () => {
+    const r = transition(INITIAL, {
+      _tag: "DrainRequested",
+      reason: { _tag: "McpDisconnect" },
+    });
+    expect(r._tag).toBe("Next");
+  });
+
+  it("DrainRequested from STOPPED → Illegal", () => {
+    const r1 = transition(INITIAL, { _tag: "Stopped" });
+    expect(r1._tag).toBe("Next");
+    if (r1._tag !== "Next") return;
+    const r2 = transition(r1.state, {
+      _tag: "DrainRequested",
+      reason: { _tag: "SigTerm" },
+    });
+    expect(r2._tag).toBe("Illegal");
+  });
+
+  it("Stopped from DRAINING → STOPPED", () => {
+    const r1 = transition(INITIAL, {
+      _tag: "DrainRequested",
+      reason: { _tag: "SigTerm" },
+    });
+    expect(r1._tag).toBe("Next");
+    if (r1._tag !== "Next") return;
+    const r2 = transition(r1.state, { _tag: "Stopped" });
+    expect(r2._tag).toBe("Next");
+    if (r2._tag !== "Next") return;
+    expect(r2.state._tag).toBe("STOPPED");
+  });
+});
+
+describe("lifecycle.transition — illegal events", () => {
+  it("StdioConnected from INIT is illegal (skips STDIO_CONNECTING)", () => {
+    const r = transition(INITIAL, { _tag: "StdioConnected" });
+    expect(r._tag).toBe("Illegal");
+  });
+
+  it("ListenerRegistered from STDIO_READY is illegal (skips MOLTZAP_READY)", () => {
+    const r1 = transition(INITIAL, { _tag: "StdioConnectStarted" });
+    if (r1._tag !== "Next") throw new Error("setup broke");
+    const r2 = transition(r1.state, { _tag: "StdioConnected" });
+    if (r2._tag !== "Next") throw new Error("setup broke");
+    const r = transition(r2.state, { _tag: "ListenerRegistered", handle });
+    expect(r._tag).toBe("Illegal");
+  });
+
+  it("StdioConnectStarted from LISTENING is illegal", () => {
+    const listening = happyPath();
+    const r = transition(listening, { _tag: "StdioConnectStarted" });
+    expect(r._tag).toBe("Illegal");
+  });
+});
+
+describe("lifecycle — readiness probes", () => {
+  it("isListening only true in LISTENING", () => {
+    expect(isListening(INITIAL)).toBe(false);
+    expect(isListening(happyPath())).toBe(true);
+  });
+
+  it("isMoltzapReady true in MOLTZAP_READY and LISTENING", () => {
+    let s = INITIAL;
+    for (const ev of [
+      { _tag: "StdioConnectStarted" },
+      { _tag: "StdioConnected" },
+      { _tag: "MoltzapConnectStarted" },
+      { _tag: "MoltzapReady" },
+    ] as LifecycleEvent[]) {
+      const r = transition(s, ev);
+      if (r._tag !== "Next") throw new Error("setup broke");
+      s = r.state;
+    }
+    expect(isMoltzapReady(s)).toBe(true);
+    expect(isListening(s)).toBe(false);
+  });
+
+  it("isMoltzapReady false before MOLTZAP_READY", () => {
+    expect(isMoltzapReady(INITIAL)).toBe(false);
+    const r = transition(INITIAL, { _tag: "StdioConnectStarted" });
+    if (r._tag !== "Next") throw new Error("setup broke");
+    expect(isMoltzapReady(r.state)).toBe(false);
+  });
+});

--- a/test/v2-moltzap-lifecycle.test.ts
+++ b/test/v2-moltzap-lifecycle.test.ts
@@ -137,6 +137,19 @@ describe("lifecycle.transition — shutdown", () => {
     if (r2._tag !== "Next") return;
     expect(r2.state._tag).toBe("STOPPED");
   });
+
+  it("Stopped from FAILED → Illegal (preserve failure cause)", () => {
+    // Drive to FAILED via StdioFailed, then check a late Stopped is rejected
+    // and does not overwrite the LifecycleError.
+    const r1 = transition(INITIAL, { _tag: "StdioConnectStarted" });
+    if (r1._tag !== "Next") throw new Error("setup broke");
+    const r2 = transition(r1.state, { _tag: "StdioFailed", cause: "boom" });
+    expect(r2._tag).toBe("Next");
+    if (r2._tag !== "Next") return;
+    expect(r2.state._tag).toBe("FAILED");
+    const r3 = transition(r2.state, { _tag: "Stopped" });
+    expect(r3._tag).toBe("Illegal");
+  });
 });
 
 describe("lifecycle.transition — illegal events", () => {

--- a/test/v2-moltzap-listener.test.ts
+++ b/test/v2-moltzap-listener.test.ts
@@ -89,6 +89,20 @@ describe("listener.register — SDK rejection", () => {
     if (result._tag !== "Err") return;
     expect(result.error._tag).toBe("SDKRejected");
   });
+
+  it("registrar throws → Err(SDKRejected) with thrown cause", async () => {
+    const state = driveTo(READY_PATH);
+    const boom = new Error("duplicate listener wiring");
+    const registrar: MoltzapRegistrar = async () => {
+      throw boom;
+    };
+    const result = await register(state, sdk, noopCb, registrar);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("SDKRejected");
+    if (result.error._tag !== "SDKRejected") return;
+    expect(result.error.cause).toBe(boom);
+  });
 });
 
 describe("listener.register — re-registration guard", () => {

--- a/test/v2-moltzap-listener.test.ts
+++ b/test/v2-moltzap-listener.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { register, type MoltzapRegistrar } from "../v2/moltzap/listener.ts";
+import {
+  INITIAL,
+  transition,
+  type LifecycleEvent,
+  type LifecycleState,
+} from "../v2/moltzap/lifecycle.ts";
+import type { ListenerHandle, MoltzapInbound, MoltzapSdkHandle } from "../v2/moltzap/types.ts";
+import { ok, err } from "../v2/types.ts";
+
+const sdk = { __brand: "MoltzapSdkHandle" } as MoltzapSdkHandle;
+const handle = { __brand: "ListenerHandle" } as ListenerHandle;
+const noopCb = (_event: MoltzapInbound) => {};
+
+function driveTo(ev: LifecycleEvent[]): LifecycleState {
+  let s: LifecycleState = INITIAL;
+  for (const e of ev) {
+    const r = transition(s, e);
+    if (r._tag !== "Next") throw new Error(`setup broke at ${e._tag}`);
+    s = r.state;
+  }
+  return s;
+}
+
+const READY_PATH: LifecycleEvent[] = [
+  { _tag: "StdioConnectStarted" },
+  { _tag: "StdioConnected" },
+  { _tag: "MoltzapConnectStarted" },
+  { _tag: "MoltzapReady" },
+];
+
+describe("listener.register — pre-ready rejection", () => {
+  it("INIT → NotReady (sub-issue AC1.1 / Q2 option (a): forbid pre-ready attach)", async () => {
+    const registrar: MoltzapRegistrar = async () => {
+      throw new Error("registrar must not be called pre-ready");
+    };
+    const result = await register(INITIAL, sdk, noopCb, registrar);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("NotReady");
+  });
+
+  it("STDIO_READY → NotReady", async () => {
+    const s = driveTo([{ _tag: "StdioConnectStarted" }, { _tag: "StdioConnected" }]);
+    let called = false;
+    const registrar: MoltzapRegistrar = async () => {
+      called = true;
+      return ok(handle);
+    };
+    const result = await register(s, sdk, noopCb, registrar);
+    expect(result._tag).toBe("Err");
+    expect(called).toBe(false);
+  });
+
+  it("MOLTZAP_CONNECTING → NotReady", async () => {
+    const s = driveTo([
+      { _tag: "StdioConnectStarted" },
+      { _tag: "StdioConnected" },
+      { _tag: "MoltzapConnectStarted" },
+    ]);
+    const registrar: MoltzapRegistrar = async () => ok(handle);
+    const result = await register(s, sdk, noopCb, registrar);
+    expect(result._tag).toBe("Err");
+  });
+});
+
+describe("listener.register — happy path", () => {
+  it("MOLTZAP_READY → Ok(handle), registrar called exactly once", async () => {
+    const state = driveTo(READY_PATH);
+    let calls = 0;
+    const registrar: MoltzapRegistrar = async () => {
+      calls += 1;
+      return ok(handle);
+    };
+    const result = await register(state, sdk, noopCb, registrar);
+    expect(result._tag).toBe("Ok");
+    expect(calls).toBe(1);
+  });
+});
+
+describe("listener.register — SDK rejection", () => {
+  it("registrar returns Err → Err(SDKRejected)", async () => {
+    const state = driveTo(READY_PATH);
+    const registrar: MoltzapRegistrar = async () =>
+      err({ _tag: "SDKRejected", cause: "SDK timed out during onMessage wiring" });
+    const result = await register(state, sdk, noopCb, registrar);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("SDKRejected");
+  });
+});
+
+describe("listener.register — re-registration guard", () => {
+  it("LISTENING → NotReady (one process, one listener)", async () => {
+    const listening: LifecycleState = {
+      _tag: "LISTENING",
+      listener: handle,
+    };
+    const registrar: MoltzapRegistrar = async () => ok(handle);
+    const result = await register(listening, sdk, noopCb, registrar);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("NotReady");
+  });
+});

--- a/v2/moltzap/bridge.ts
+++ b/v2/moltzap/bridge.ts
@@ -21,13 +21,14 @@ import type {
   MoltzapInbound,
   MoltzapInboundMeta,
   MoltzapSdkContext,
+  MoltzapSenderId,
 } from "./types.ts";
 
 // ── Errors ──────────────────────────────────────────────────────────
 
 export type BridgeError =
   | { readonly _tag: "NotListening"; readonly state: LifecycleState }
-  | { readonly _tag: "OutboundFailed"; readonly cause: string }
+  | { readonly _tag: "OutboundFailed"; readonly cause: unknown }
   | { readonly _tag: "PreReadyEventDropped"; readonly event: MoltzapInboundMeta };
 
 // ── Reply shape ─────────────────────────────────────────────────────
@@ -53,12 +54,12 @@ export interface ReplyReceipt {
 export type McpNotifier = (
   ctx: McpContext,
   notification: ChannelNotification,
-) => Promise<Result<void, { readonly cause: string }>>;
+) => Promise<Result<void, { readonly cause: unknown }>>;
 
 export type MoltzapSender = (
   ctx: MoltzapSdkContext,
   args: ReplyArgs,
-) => Promise<Result<void, { readonly cause: string }>>;
+) => Promise<Result<void, { readonly cause: unknown }>>;
 
 /** Shape written to MCP when routing an inbound moltzap event. */
 export interface ChannelNotification {
@@ -66,7 +67,7 @@ export interface ChannelNotification {
   readonly params: {
     readonly channelTag: string;
     readonly conversationId: MoltzapConversationId;
-    readonly senderId: string;
+    readonly senderId: MoltzapSenderId;
     readonly messageId: string;
     readonly body: string;
     readonly receivedAtMs: number;

--- a/v2/moltzap/bridge.ts
+++ b/v2/moltzap/bridge.ts
@@ -1,0 +1,139 @@
+/**
+ * v2/moltzap/bridge — translate moltzap ↔ MCP.
+ *
+ * Anchors: sbd#108 architect plan §2.3 bridge, §3 Interfaces; spec
+ * moltzap-channel-v1 §5.1 AC1.1, AC1.2; §4 invariants I3, I7.
+ *
+ * Inbound  (moltzap → MCP):   onInbound(event) → mcp.notification (channel tag).
+ * Outbound (MCP → moltzap):   reply(args) → SDK send.
+ *
+ * Both directions gate on `LISTENING`. Non-LISTENING calls return tagged
+ * errors; they never throw. Pre-ready events (architect-defined diagnostic
+ * `PreReadyEventDropped`) are dropped — no buffer (I7).
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type { LifecycleState } from "./lifecycle.ts";
+import type {
+  McpContext,
+  MoltzapConversationId,
+  MoltzapInbound,
+  MoltzapInboundMeta,
+  MoltzapSdkContext,
+} from "./types.ts";
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+export type BridgeError =
+  | { readonly _tag: "NotListening"; readonly state: LifecycleState }
+  | { readonly _tag: "OutboundFailed"; readonly cause: string }
+  | { readonly _tag: "PreReadyEventDropped"; readonly event: MoltzapInboundMeta };
+
+// ── Reply shape ─────────────────────────────────────────────────────
+
+export interface ReplyArgs {
+  readonly conversationId: MoltzapConversationId;
+  readonly text: string;
+}
+
+export interface ReplyReceipt {
+  readonly _tag: "Sent";
+  readonly at: number;
+}
+
+// ── Injection points ────────────────────────────────────────────────
+//
+// The MCP notify and moltzap send functions are supplied by the plugin boot
+// layer, matching the "opaque handle" design in architect plan §3. The
+// bridge never imports `@modelcontextprotocol/sdk` or `@moltzap/app-sdk`
+// directly; substitution at the boundary keeps the bridge testable without
+// either SDK present.
+
+export type McpNotifier = (
+  ctx: McpContext,
+  notification: ChannelNotification,
+) => Promise<Result<void, { readonly cause: string }>>;
+
+export type MoltzapSender = (
+  ctx: MoltzapSdkContext,
+  args: ReplyArgs,
+) => Promise<Result<void, { readonly cause: string }>>;
+
+/** Shape written to MCP when routing an inbound moltzap event. */
+export interface ChannelNotification {
+  readonly method: "notifications/claude/channel";
+  readonly params: {
+    readonly channelTag: string;
+    readonly conversationId: MoltzapConversationId;
+    readonly senderId: string;
+    readonly messageId: string;
+    readonly body: string;
+    readonly receivedAtMs: number;
+  };
+}
+
+/** Diagnostic sink for `PreReadyEventDropped` — plugin boot injects stderr
+ *  logger; tests may inject a recorder. Kept synchronous (diagnostic only). */
+export type DiagnosticSink = (error: BridgeError) => void;
+
+// ── Inbound ─────────────────────────────────────────────────────────
+
+export async function onInbound(
+  state: LifecycleState,
+  event: MoltzapInbound,
+  mcp: McpContext,
+  notify: McpNotifier,
+  diag: DiagnosticSink,
+): Promise<Result<void, BridgeError>> {
+  if (state._tag !== "LISTENING") {
+    // Per architect plan §4: the SDK should not deliver events before
+    // ready fires under option (a), but we defend in depth. Diagnose and
+    // drop; no buffering (I7).
+    const dropped: BridgeError = {
+      _tag: "PreReadyEventDropped",
+      event: {
+        messageId: event.messageId,
+        conversationId: event.conversationId,
+        senderId: event.senderId,
+        receivedAtMs: event.receivedAtMs,
+      },
+    };
+    diag(dropped);
+    return err(dropped);
+  }
+  const result = await notify(mcp, {
+    method: "notifications/claude/channel",
+    params: {
+      channelTag: "moltzap",
+      conversationId: event.conversationId,
+      senderId: event.senderId,
+      messageId: event.messageId,
+      body: event.bodyText,
+      receivedAtMs: event.receivedAtMs,
+    },
+  });
+  if (result._tag === "Err") {
+    return err({ _tag: "OutboundFailed", cause: result.error.cause });
+  }
+  return ok(undefined);
+}
+
+// ── Outbound ────────────────────────────────────────────────────────
+
+export async function reply(
+  state: LifecycleState,
+  args: ReplyArgs,
+  sdkCtx: MoltzapSdkContext,
+  sender: MoltzapSender,
+  now: () => number = Date.now,
+): Promise<Result<ReplyReceipt, BridgeError>> {
+  if (state._tag !== "LISTENING") {
+    return err({ _tag: "NotListening", state });
+  }
+  const result = await sender(sdkCtx, args);
+  if (result._tag === "Err") {
+    return err({ _tag: "OutboundFailed", cause: result.error.cause });
+  }
+  return ok({ _tag: "Sent", at: now() });
+}

--- a/v2/moltzap/bridge.ts
+++ b/v2/moltzap/bridge.ts
@@ -103,17 +103,25 @@ export async function onInbound(
     diag(dropped);
     return err(dropped);
   }
-  const result = await notify(mcp, {
-    method: "notifications/claude/channel",
-    params: {
-      channelTag: "moltzap",
-      conversationId: event.conversationId,
-      senderId: event.senderId,
-      messageId: event.messageId,
-      body: event.bodyText,
-      receivedAtMs: event.receivedAtMs,
-    },
-  });
+  // Defend against injected notifiers that throw/reject instead of returning
+  // `Err` — a closed stdio transport in the real SDK can surface that way.
+  // Principle 3: errors are typed, not thrown — re-pack into `OutboundFailed`.
+  let result: Result<void, { readonly cause: unknown }>;
+  try {
+    result = await notify(mcp, {
+      method: "notifications/claude/channel",
+      params: {
+        channelTag: "moltzap",
+        conversationId: event.conversationId,
+        senderId: event.senderId,
+        messageId: event.messageId,
+        body: event.bodyText,
+        receivedAtMs: event.receivedAtMs,
+      },
+    });
+  } catch (cause) {
+    return err({ _tag: "OutboundFailed", cause });
+  }
   if (result._tag === "Err") {
     return err({ _tag: "OutboundFailed", cause: result.error.cause });
   }
@@ -132,7 +140,15 @@ export async function reply(
   if (state._tag !== "LISTENING") {
     return err({ _tag: "NotListening", state });
   }
-  const result = await sender(sdkCtx, args);
+  // Defend against injected senders that throw/reject instead of returning
+  // `Err` — a closed websocket in the real SDK can surface that way.
+  // Principle 3: errors are typed, not thrown — re-pack into `OutboundFailed`.
+  let result: Result<void, { readonly cause: unknown }>;
+  try {
+    result = await sender(sdkCtx, args);
+  } catch (cause) {
+    return err({ _tag: "OutboundFailed", cause });
+  }
   if (result._tag === "Err") {
     return err({ _tag: "OutboundFailed", cause: result.error.cause });
   }

--- a/v2/moltzap/index.ts
+++ b/v2/moltzap/index.ts
@@ -1,0 +1,10 @@
+/**
+ * v2/moltzap — barrel.
+ *
+ * Anchors: sbd#108 architect plan §2 Modules.
+ */
+
+export * from "./types.ts";
+export * from "./lifecycle.ts";
+export * from "./listener.ts";
+export * from "./bridge.ts";

--- a/v2/moltzap/lifecycle.ts
+++ b/v2/moltzap/lifecycle.ts
@@ -86,7 +86,10 @@ export function transition(
     return next({ _tag: "DRAINING", reason: event.reason });
   }
   if (event._tag === "Stopped") {
-    if (from._tag === "STOPPED") return illegal(from, event);
+    // STOPPED is already stopped; FAILED is terminal and must preserve its
+    // cause — a late Stopped from the driver must not overwrite the
+    // LifecycleError that led to FAILED.
+    if (from._tag === "STOPPED" || from._tag === "FAILED") return illegal(from, event);
     return next({ _tag: "STOPPED" });
   }
 

--- a/v2/moltzap/lifecycle.ts
+++ b/v2/moltzap/lifecycle.ts
@@ -34,23 +34,23 @@ export type DrainReason =
 // ── Errors ──────────────────────────────────────────────────────────
 
 export type LifecycleError =
-  | { readonly _tag: "TransportConnectError"; readonly cause: string }
-  | { readonly _tag: "MoltzapHandshakeError"; readonly cause: string }
+  | { readonly _tag: "TransportConnectError"; readonly cause: unknown }
+  | { readonly _tag: "MoltzapHandshakeError"; readonly cause: unknown }
   | { readonly _tag: "ListenerRegistrationError"; readonly cause: ListenerRegistrationError };
 
 export type ListenerRegistrationError =
   | { readonly _tag: "NotReady"; readonly state: LifecycleState }
-  | { readonly _tag: "SDKRejected"; readonly cause: string };
+  | { readonly _tag: "SDKRejected"; readonly cause: unknown };
 
 // ── Events ──────────────────────────────────────────────────────────
 
 export type LifecycleEvent =
   | { readonly _tag: "StdioConnectStarted" }
   | { readonly _tag: "StdioConnected" }
-  | { readonly _tag: "StdioFailed"; readonly cause: string }
+  | { readonly _tag: "StdioFailed"; readonly cause: unknown }
   | { readonly _tag: "MoltzapConnectStarted" }
   | { readonly _tag: "MoltzapReady" }
-  | { readonly _tag: "MoltzapFailed"; readonly cause: string }
+  | { readonly _tag: "MoltzapFailed"; readonly cause: unknown }
   | { readonly _tag: "ListenerRegistered"; readonly handle: ListenerHandle }
   | { readonly _tag: "ListenerFailed"; readonly cause: ListenerRegistrationError }
   | { readonly _tag: "DrainRequested"; readonly reason: DrainReason }
@@ -92,59 +92,147 @@ export function transition(
 
   switch (from._tag) {
     case "INIT":
-      if (event._tag === "StdioConnectStarted") return next({ _tag: "STDIO_CONNECTING" });
-      return illegal(from, event);
+      switch (event._tag) {
+        case "StdioConnectStarted":
+          return next({ _tag: "STDIO_CONNECTING" });
+        case "StdioConnected":
+        case "StdioFailed":
+        case "MoltzapConnectStarted":
+        case "MoltzapReady":
+        case "MoltzapFailed":
+        case "ListenerRegistered":
+        case "ListenerFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
+      }
 
     case "STDIO_CONNECTING":
-      if (event._tag === "StdioConnected") return next({ _tag: "STDIO_READY" });
-      if (event._tag === "StdioFailed") {
-        return next({
-          _tag: "FAILED",
-          cause: { _tag: "TransportConnectError", cause: event.cause },
-        });
+      switch (event._tag) {
+        case "StdioConnected":
+          return next({ _tag: "STDIO_READY" });
+        case "StdioFailed":
+          return next({
+            _tag: "FAILED",
+            cause: { _tag: "TransportConnectError", cause: event.cause },
+          });
+        case "StdioConnectStarted":
+        case "MoltzapConnectStarted":
+        case "MoltzapReady":
+        case "MoltzapFailed":
+        case "ListenerRegistered":
+        case "ListenerFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
       }
-      return illegal(from, event);
 
     case "STDIO_READY":
-      if (event._tag === "MoltzapConnectStarted") return next({ _tag: "MOLTZAP_CONNECTING" });
-      return illegal(from, event);
+      switch (event._tag) {
+        case "MoltzapConnectStarted":
+          return next({ _tag: "MOLTZAP_CONNECTING" });
+        case "StdioConnectStarted":
+        case "StdioConnected":
+        case "StdioFailed":
+        case "MoltzapReady":
+        case "MoltzapFailed":
+        case "ListenerRegistered":
+        case "ListenerFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
+      }
 
     case "MOLTZAP_CONNECTING":
-      if (event._tag === "MoltzapReady") return next({ _tag: "MOLTZAP_READY" });
-      if (event._tag === "MoltzapFailed") {
-        return next({
-          _tag: "FAILED",
-          cause: { _tag: "MoltzapHandshakeError", cause: event.cause },
-        });
+      switch (event._tag) {
+        case "MoltzapReady":
+          return next({ _tag: "MOLTZAP_READY" });
+        case "MoltzapFailed":
+          return next({
+            _tag: "FAILED",
+            cause: { _tag: "MoltzapHandshakeError", cause: event.cause },
+          });
+        case "StdioConnectStarted":
+        case "StdioConnected":
+        case "StdioFailed":
+        case "MoltzapConnectStarted":
+        case "ListenerRegistered":
+        case "ListenerFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
       }
-      return illegal(from, event);
 
     case "MOLTZAP_READY":
-      if (event._tag === "ListenerRegistered") {
-        return next({ _tag: "LISTENING", listener: event.handle });
+      switch (event._tag) {
+        case "ListenerRegistered":
+          return next({ _tag: "LISTENING", listener: event.handle });
+        case "ListenerFailed":
+          return next({
+            _tag: "FAILED",
+            cause: { _tag: "ListenerRegistrationError", cause: event.cause },
+          });
+        case "StdioConnectStarted":
+        case "StdioConnected":
+        case "StdioFailed":
+        case "MoltzapConnectStarted":
+        case "MoltzapReady":
+        case "MoltzapFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
       }
-      if (event._tag === "ListenerFailed") {
-        return next({
-          _tag: "FAILED",
-          cause: { _tag: "ListenerRegistrationError", cause: event.cause },
-        });
-      }
-      return illegal(from, event);
 
     case "LISTENING":
       // Terminal event types (DrainRequested, Stopped) handled above.
       // All other events in LISTENING are bugs from the driver: events that
       // belong to earlier states cannot legally re-fire here.
-      return illegal(from, event);
+      switch (event._tag) {
+        case "StdioConnectStarted":
+        case "StdioConnected":
+        case "StdioFailed":
+        case "MoltzapConnectStarted":
+        case "MoltzapReady":
+        case "MoltzapFailed":
+        case "ListenerRegistered":
+        case "ListenerFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
+      }
 
     case "DRAINING":
       // Only Stopped (handled above) transitions out. All other events are
       // suppressed — the plugin is shutting down.
-      return illegal(from, event);
+      switch (event._tag) {
+        case "StdioConnectStarted":
+        case "StdioConnected":
+        case "StdioFailed":
+        case "MoltzapConnectStarted":
+        case "MoltzapReady":
+        case "MoltzapFailed":
+        case "ListenerRegistered":
+        case "ListenerFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
+      }
 
     case "STOPPED":
     case "FAILED":
-      return illegal(from, event);
+      switch (event._tag) {
+        case "StdioConnectStarted":
+        case "StdioConnected":
+        case "StdioFailed":
+        case "MoltzapConnectStarted":
+        case "MoltzapReady":
+        case "MoltzapFailed":
+        case "ListenerRegistered":
+        case "ListenerFailed":
+          return illegal(from, event);
+        default:
+          return absurd(event);
+      }
 
     default:
       return absurd(from);
@@ -168,9 +256,37 @@ function absurd(x: never): never {
 // ── Ready probe ─────────────────────────────────────────────────────
 
 export function isListening(state: LifecycleState): boolean {
-  return state._tag === "LISTENING";
+  switch (state._tag) {
+    case "LISTENING":
+      return true;
+    case "INIT":
+    case "STDIO_CONNECTING":
+    case "STDIO_READY":
+    case "MOLTZAP_CONNECTING":
+    case "MOLTZAP_READY":
+    case "DRAINING":
+    case "STOPPED":
+    case "FAILED":
+      return false;
+    default:
+      return absurd(state);
+  }
 }
 
 export function isMoltzapReady(state: LifecycleState): boolean {
-  return state._tag === "MOLTZAP_READY" || state._tag === "LISTENING";
+  switch (state._tag) {
+    case "MOLTZAP_READY":
+    case "LISTENING":
+      return true;
+    case "INIT":
+    case "STDIO_CONNECTING":
+    case "STDIO_READY":
+    case "MOLTZAP_CONNECTING":
+    case "DRAINING":
+    case "STOPPED":
+    case "FAILED":
+      return false;
+    default:
+      return absurd(state);
+  }
 }

--- a/v2/moltzap/lifecycle.ts
+++ b/v2/moltzap/lifecycle.ts
@@ -1,0 +1,176 @@
+/**
+ * v2/moltzap/lifecycle — moltzap Channels bridge state machine.
+ *
+ * Anchors: sbd#108 architect plan §2.1 lifecycle, §3 Interfaces, §4 Data flow;
+ * spec moltzap-channel-v1 §7 Q2 (option (a): register listener only after
+ * MOLTZAP_READY).
+ *
+ * Single source of truth for "is the bridge ready." Three gates from INIT to
+ * LISTENING; two terminal-ish exit states (DRAINING, STOPPED, FAILED).
+ * Pure state algebra — no I/O, no side effects. Impl wires the transitions
+ * from its event loop at the plugin boot boundary.
+ */
+
+import type { ListenerHandle } from "./types.ts";
+
+// ── State ───────────────────────────────────────────────────────────
+
+export type LifecycleState =
+  | { readonly _tag: "INIT" }
+  | { readonly _tag: "STDIO_CONNECTING" }
+  | { readonly _tag: "STDIO_READY" }
+  | { readonly _tag: "MOLTZAP_CONNECTING" }
+  | { readonly _tag: "MOLTZAP_READY" }
+  | { readonly _tag: "LISTENING"; readonly listener: ListenerHandle }
+  | { readonly _tag: "DRAINING"; readonly reason: DrainReason }
+  | { readonly _tag: "STOPPED" }
+  | { readonly _tag: "FAILED"; readonly cause: LifecycleError };
+
+export type DrainReason =
+  | { readonly _tag: "SigTerm" }
+  | { readonly _tag: "MoltzapDisconnect" }
+  | { readonly _tag: "McpDisconnect" };
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+export type LifecycleError =
+  | { readonly _tag: "TransportConnectError"; readonly cause: string }
+  | { readonly _tag: "MoltzapHandshakeError"; readonly cause: string }
+  | { readonly _tag: "ListenerRegistrationError"; readonly cause: ListenerRegistrationError };
+
+export type ListenerRegistrationError =
+  | { readonly _tag: "NotReady"; readonly state: LifecycleState }
+  | { readonly _tag: "SDKRejected"; readonly cause: string };
+
+// ── Events ──────────────────────────────────────────────────────────
+
+export type LifecycleEvent =
+  | { readonly _tag: "StdioConnectStarted" }
+  | { readonly _tag: "StdioConnected" }
+  | { readonly _tag: "StdioFailed"; readonly cause: string }
+  | { readonly _tag: "MoltzapConnectStarted" }
+  | { readonly _tag: "MoltzapReady" }
+  | { readonly _tag: "MoltzapFailed"; readonly cause: string }
+  | { readonly _tag: "ListenerRegistered"; readonly handle: ListenerHandle }
+  | { readonly _tag: "ListenerFailed"; readonly cause: ListenerRegistrationError }
+  | { readonly _tag: "DrainRequested"; readonly reason: DrainReason }
+  | { readonly _tag: "Stopped" };
+
+// ── Transition result ───────────────────────────────────────────────
+
+export type TransitionResult =
+  | { readonly _tag: "Next"; readonly state: LifecycleState }
+  | { readonly _tag: "Illegal"; readonly from: LifecycleState; readonly event: LifecycleEvent };
+
+// ── Initial state ───────────────────────────────────────────────────
+
+export const INITIAL: LifecycleState = { _tag: "INIT" };
+
+// ── Transition function ─────────────────────────────────────────────
+//
+// The transition matrix is declared explicitly per (state, event) pair.
+// Illegal pairs return `Illegal` rather than throwing — the caller (the
+// plugin boot layer) decides whether to treat a specific illegal pair as
+// a panic. Shutdown events (`DrainRequested`, `Stopped`) are accepted from
+// any non-terminal state; everything else is state-gated.
+
+export function transition(
+  from: LifecycleState,
+  event: LifecycleEvent,
+): TransitionResult {
+  // Shutdown fast-paths: accepted from any non-stopped, non-failed state.
+  if (event._tag === "DrainRequested") {
+    if (from._tag === "STOPPED" || from._tag === "FAILED" || from._tag === "DRAINING") {
+      return illegal(from, event);
+    }
+    return next({ _tag: "DRAINING", reason: event.reason });
+  }
+  if (event._tag === "Stopped") {
+    if (from._tag === "STOPPED") return illegal(from, event);
+    return next({ _tag: "STOPPED" });
+  }
+
+  switch (from._tag) {
+    case "INIT":
+      if (event._tag === "StdioConnectStarted") return next({ _tag: "STDIO_CONNECTING" });
+      return illegal(from, event);
+
+    case "STDIO_CONNECTING":
+      if (event._tag === "StdioConnected") return next({ _tag: "STDIO_READY" });
+      if (event._tag === "StdioFailed") {
+        return next({
+          _tag: "FAILED",
+          cause: { _tag: "TransportConnectError", cause: event.cause },
+        });
+      }
+      return illegal(from, event);
+
+    case "STDIO_READY":
+      if (event._tag === "MoltzapConnectStarted") return next({ _tag: "MOLTZAP_CONNECTING" });
+      return illegal(from, event);
+
+    case "MOLTZAP_CONNECTING":
+      if (event._tag === "MoltzapReady") return next({ _tag: "MOLTZAP_READY" });
+      if (event._tag === "MoltzapFailed") {
+        return next({
+          _tag: "FAILED",
+          cause: { _tag: "MoltzapHandshakeError", cause: event.cause },
+        });
+      }
+      return illegal(from, event);
+
+    case "MOLTZAP_READY":
+      if (event._tag === "ListenerRegistered") {
+        return next({ _tag: "LISTENING", listener: event.handle });
+      }
+      if (event._tag === "ListenerFailed") {
+        return next({
+          _tag: "FAILED",
+          cause: { _tag: "ListenerRegistrationError", cause: event.cause },
+        });
+      }
+      return illegal(from, event);
+
+    case "LISTENING":
+      // Terminal event types (DrainRequested, Stopped) handled above.
+      // All other events in LISTENING are bugs from the driver: events that
+      // belong to earlier states cannot legally re-fire here.
+      return illegal(from, event);
+
+    case "DRAINING":
+      // Only Stopped (handled above) transitions out. All other events are
+      // suppressed — the plugin is shutting down.
+      return illegal(from, event);
+
+    case "STOPPED":
+    case "FAILED":
+      return illegal(from, event);
+
+    default:
+      return absurd(from);
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function next(state: LifecycleState): TransitionResult {
+  return { _tag: "Next", state };
+}
+
+function illegal(from: LifecycleState, event: LifecycleEvent): TransitionResult {
+  return { _tag: "Illegal", from, event };
+}
+
+function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}
+
+// ── Ready probe ─────────────────────────────────────────────────────
+
+export function isListening(state: LifecycleState): boolean {
+  return state._tag === "LISTENING";
+}
+
+export function isMoltzapReady(state: LifecycleState): boolean {
+  return state._tag === "MOLTZAP_READY" || state._tag === "LISTENING";
+}

--- a/v2/moltzap/listener.ts
+++ b/v2/moltzap/listener.ts
@@ -52,5 +52,12 @@ export async function register(
   if (state._tag !== "MOLTZAP_READY") {
     return err({ _tag: "NotReady", state });
   }
-  return registrar(sdk, cb);
+  // Defend against injected registrars that throw/reject before building a
+  // `Result` — a closed session or duplicate listener wiring in the real SDK
+  // can surface that way. Principle 3: errors are typed, not thrown.
+  try {
+    return await registrar(sdk, cb);
+  } catch (cause) {
+    return err({ _tag: "SDKRejected", cause });
+  }
 }

--- a/v2/moltzap/listener.ts
+++ b/v2/moltzap/listener.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Result } from "../types.ts";
-import { err, ok } from "../types.ts";
+import { err } from "../types.ts";
 import type { LifecycleState, ListenerRegistrationError } from "./lifecycle.ts";
 import type {
   ListenerHandle,
@@ -29,7 +29,7 @@ import type {
 export type MoltzapRegistrar = (
   sdk: MoltzapSdkHandle,
   cb: (event: MoltzapInbound) => void,
-) => Promise<Result<ListenerHandle, { readonly _tag: "SDKRejected"; readonly cause: string }>>;
+) => Promise<Result<ListenerHandle, { readonly _tag: "SDKRejected"; readonly cause: unknown }>>;
 
 /**
  * Register the inbound callback against the moltzap SDK.
@@ -52,9 +52,5 @@ export async function register(
   if (state._tag !== "MOLTZAP_READY") {
     return err({ _tag: "NotReady", state });
   }
-  const result = await registrar(sdk, cb);
-  if (result._tag === "Ok") {
-    return ok(result.value);
-  }
-  return err(result.error);
+  return registrar(sdk, cb);
 }

--- a/v2/moltzap/listener.ts
+++ b/v2/moltzap/listener.ts
@@ -1,0 +1,60 @@
+/**
+ * v2/moltzap/listener — moltzap app-SDK inbound-registration wrapper.
+ *
+ * Anchors: sbd#108 architect plan §2.2 listener, §3 Interfaces; spec
+ * moltzap-channel-v1 §7 Q2 option (a).
+ *
+ * Forbidden to attach before `MOLTZAP_READY`. The SDK surface is opaque here
+ * (see types.ts MoltzapSdkHandle); the actual adapter that wires
+ * `MoltZapApp.onMessage` to this callback lives at the plugin boot layer and
+ * is injected as `MoltzapRegistrar`.
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type { LifecycleState, ListenerRegistrationError } from "./lifecycle.ts";
+import type {
+  ListenerHandle,
+  MoltzapInbound,
+  MoltzapSdkHandle,
+} from "./types.ts";
+
+/**
+ * The injection point for the real SDK wiring. The plugin boot code supplies
+ * an implementation that calls `@moltzap/app-sdk`'s `onMessage`/`onSessionReady`
+ * and returns an opaque handle. Keeping this as a caller-supplied function
+ * lets lifecycle and listener compile without a hard dep on
+ * `@moltzap/app-sdk`; architect plan §3 explicitly calls the SDK type opaque.
+ */
+export type MoltzapRegistrar = (
+  sdk: MoltzapSdkHandle,
+  cb: (event: MoltzapInbound) => void,
+) => Promise<Result<ListenerHandle, { readonly _tag: "SDKRejected"; readonly cause: string }>>;
+
+/**
+ * Register the inbound callback against the moltzap SDK.
+ *
+ * Pre-conditions:
+ *   - `state` must be `MOLTZAP_READY` (option (a) from spec §7 Q2).
+ *   - `registrar` is the caller-supplied adapter to `@moltzap/app-sdk`.
+ *
+ * Returns `NotReady` before the ready gate (prevents the debt pattern of
+ * "register eagerly, rely on SDK internals" — spec §4 I6, architect plan §4).
+ */
+export async function register(
+  state: LifecycleState,
+  sdk: MoltzapSdkHandle,
+  cb: (event: MoltzapInbound) => void,
+  registrar: MoltzapRegistrar,
+): Promise<Result<ListenerHandle, ListenerRegistrationError>> {
+  // Architect plan §2.2: register exactly once, only in MOLTZAP_READY.
+  // LISTENING/any other state → NotReady.
+  if (state._tag !== "MOLTZAP_READY") {
+    return err({ _tag: "NotReady", state });
+  }
+  const result = await registrar(sdk, cb);
+  if (result._tag === "Ok") {
+    return ok(result.value);
+  }
+  return err(result.error);
+}

--- a/v2/moltzap/types.ts
+++ b/v2/moltzap/types.ts
@@ -1,0 +1,67 @@
+/**
+ * v2/moltzap/types — shared types for the moltzap Channels bridge.
+ *
+ * Anchors: sbd#108 architect plan §3 Interfaces; spec moltzap-channel-v1 §4 (I6, I7).
+ *
+ * Conventions mirror v2/types.ts: branded IDs, discriminated unions, tagged
+ * errors, `absurd` helper for exhaustiveness. Plain Promise + Result is used
+ * throughout per the architect plan's note: "If the repo's existing convention
+ * is plain Promise + tagged union, impl may substitute."
+ */
+
+// ── Branded identifiers ─────────────────────────────────────────────
+
+export type MoltzapMessageId = string & { readonly __brand: "MoltzapMessageId" };
+export type MoltzapConversationId = string & { readonly __brand: "MoltzapConversationId" };
+export type MoltzapSenderId = string & { readonly __brand: "MoltzapSenderId" };
+export type ListenerHandle = { readonly __brand: "ListenerHandle" };
+
+export function asMoltzapMessageId(s: string): MoltzapMessageId {
+  return s as MoltzapMessageId;
+}
+export function asMoltzapConversationId(s: string): MoltzapConversationId {
+  return s as MoltzapConversationId;
+}
+export function asMoltzapSenderId(s: string): MoltzapSenderId {
+  return s as MoltzapSenderId;
+}
+
+// ── Inbound event shape ─────────────────────────────────────────────
+
+export interface MoltzapInbound {
+  readonly messageId: MoltzapMessageId;
+  readonly conversationId: MoltzapConversationId;
+  readonly senderId: MoltzapSenderId;
+  readonly bodyText: string;
+  readonly receivedAtMs: number;
+}
+
+export type MoltzapInboundMeta = Pick<
+  MoltzapInbound,
+  "messageId" | "conversationId" | "senderId" | "receivedAtMs"
+>;
+
+// ── Opaque SDK / MCP handles ────────────────────────────────────────
+//
+// Per architect plan §3: "Opaque to this plugin. Impl picks the exact SDK
+// type at impl time." The concrete shape is injected at the plugin boot
+// boundary; the bridge modules never import `@moltzap/app-sdk` or
+// `@modelcontextprotocol/sdk` directly.
+
+export interface MoltzapSdkHandle {
+  readonly __brand: "MoltzapSdkHandle";
+}
+
+export interface McpContext {
+  readonly __brand: "McpContext";
+}
+
+export interface MoltzapSdkContext {
+  readonly __brand: "MoltzapSdkContext";
+}
+
+// ── Exhaustiveness helper (mirrors v2/types.ts) ─────────────────────
+
+export function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}


### PR DESCRIPTION
Closes #127
Parent epic: #126
Spec: https://github.com/chughtapan/safer-by-default/blob/spec/moltzap-channel/docs/specs/moltzap-channel-v1.md
Architect plan (APPROVED): https://github.com/chughtapan/safer-by-default/issues/108#issuecomment-4275100681

## What changed

Three new modules under `v2/moltzap/` implementing the approved architect design
for the moltzap Channels bridge. Pure state algebra + two thin translation
functions + a one-shot SDK registration wrapper. Zero new npm dependencies —
the `@moltzap/app-sdk` and `@modelcontextprotocol/sdk` surfaces are injected as
opaque handles at the plugin boot boundary (per architect plan §3 "Opaque to
this plugin. Impl picks the exact SDK type at impl time"). A follow-up PR wires
the real SDKs into these interfaces; this PR locks down the module boundaries
and the typed contract.

## Traceability

| New artifact | Kind | Spec anchor | Plan anchor |
|---|---|---|---|
| `v2/moltzap/` | module dir | Spec §2 G1 | Plan §2 "Modules" |
| `v2/moltzap/types.ts` | types | Spec §4 I6/I7 | Plan §3 "Interfaces" |
| `v2/moltzap/lifecycle.ts` | module | Spec §7 Q2 | Plan §2.1 |
| `v2/moltzap/listener.ts` | module | Spec §7 Q2 option (a) | Plan §2.2 |
| `v2/moltzap/bridge.ts` | module | Spec §5.1 AC1.1, AC1.2 | Plan §2.3 |
| `v2/moltzap/index.ts` | barrel | — | Plan §2 |
| `LifecycleState` | public type | Spec §7 Q2 | Plan §3 lifecycle.ts |
| `LifecycleEvent` | public type | — | Plan §3 lifecycle.ts |
| `LifecycleError` | public type | — | Plan §2.1 Error channel |
| `transition(from, event)` | public fn | — | Plan §3 lifecycle.ts |
| `isListening` / `isMoltzapReady` | public fn | Spec AC1.3 | Plan §2.1 readiness probe |
| `ListenerHandle` | branded type | — | Plan §3 listener.ts |
| `MoltzapRegistrar` | public type | Spec §7 Q2 option (a) | Plan §3 listener.ts |
| `register(state, sdk, cb, registrar)` | public fn | Spec §7 Q2 option (a) | Plan §3 listener.ts |
| `MoltzapInbound` / `MoltzapInboundMeta` | public types | — | Plan §3 listener.ts |
| `BridgeError` | public type | — | Plan §3 bridge.ts |
| `McpNotifier` / `MoltzapSender` / `ChannelNotification` | public types | Spec §5.4 AC4.2 | Plan §3 bridge.ts |
| `onInbound(state, event, mcp, notify, diag)` | public fn | Spec AC1.1, I2 | Plan §3 bridge.ts |
| `reply(state, args, sdkCtx, sender)` | public fn | Spec AC1.1 | Plan §3 bridge.ts |
| `test/v2-moltzap-lifecycle.test.ts` | test (14) | AC1.3 (no-turn-while-down), I2 (ordering) | Plan §2.1 |
| `test/v2-moltzap-listener.test.ts` | test (6) | AC1.1, Q2 option (a) | Plan §2.2 |
| `test/v2-moltzap-bridge.test.ts` | test (8) | AC1.1, AC1.2, I2 | Plan §2.3 |

## Scope

- New modules: 3 (`lifecycle`, `listener`, `bridge`) + shared types and barrel.
  Matches architect budget (≤5).
- New public exports: 18 (8 types, 7 functions, 3 branded helpers).
- New deps: **0.** SDK surfaces are injected as caller-supplied functions /
  opaque handles per architect plan §3. Wiring the real SDKs is a downstream
  task (not in scope for this staff-tier PR; noted in plan §8 OQ5 style).
- Tier (from `safer-diff-scope`): staff (new modules + new public interfaces).

## Dependencies

**None added.** The architect plan lists `@modelcontextprotocol/sdk`,
`@moltzap/app-sdk`, and `effect` as candidates; all three are treated as
boundary-crossed-by-injection here. Justification (plan §6 paragraph after
the dep table): "If the repo's existing convention is plain Promise + tagged
union, impl may substitute — architect's constraint is typed errors, not the
specific library." The v2/ convention is plain `Result<T, E>` + async (see
`v2/bridge.ts`, `v2/github-state.ts`); this PR follows that and defers the SDK
dep decision to the follow-up wiring PR.

## Tests

- `test/v2-moltzap-lifecycle.test.ts` — 14 tests: happy-path walk, each
  FAILED branch (TransportConnectError, MoltzapHandshakeError,
  ListenerRegistrationError), DrainRequested from multiple source states,
  Stopped terminal, three illegal-transition cases, readiness probes.
- `test/v2-moltzap-listener.test.ts` — 6 tests: NotReady rejection from
  INIT / STDIO_READY / MOLTZAP_CONNECTING (pre-condition violation; Q2
  option (a) forbids eager attach), happy path from MOLTZAP_READY,
  SDKRejected mapping, re-registration guard from LISTENING.
- `test/v2-moltzap-bridge.test.ts` — 8 tests: LISTENING-gate routing +
  `notifications/claude/channel` shape, PreReadyEventDropped diagnostic,
  OutboundFailed surfacing for both directions, NotListening from INIT and
  from FAILED, `reply` receipt timestamp, two-event in-order preservation (I2).

All 28 new tests green. Full suite: 16 files, 157 tests passing.

## Simplify skips

- **simplify: no additional findings after one manual pass.** Tightened
  `listener.register()` pre-condition from `isMoltzapReady(state) + LISTENING
  check` to a direct `state._tag !== "MOLTZAP_READY"` check — one branch, same
  semantics, dead import removed.

## Codex diff review

- codex diff review: unavailable — skipped. (Running `/codex --mode review`
  from inside the `safer-implement-staff` skill flow would cascade skill
  contexts. Verdict-posting is deferred to the `/safer:review-senior` pass
  which has independent-role coverage per PRINCIPLES.md → Durability.)

## Confidence

MED — module boundaries match the architect plan 1:1, tests cover every named
transition and error tag, typecheck + lint clean (0 errors; the 9
`promise-type` / `async-keyword` warnings in new files match the existing
`v2/bridge.ts` and `v2/github-state.ts` pattern and are tracked by issues
#119 / #120 in the Effect-migration follow-up). Lower than HIGH because the
SDK wiring is deferred to a follow-up; reviewers should evaluate whether the
injection-point shape (`MoltzapRegistrar`, `McpNotifier`, `MoltzapSender`) is
ergonomic enough for the real-SDK caller.