### PR TITLE
[impl-senior] fast-check property tests: broker routing + HMAC helper

### DIFF
--- a/test/helpers/sign.ts
+++ b/test/helpers/sign.ts
@@ -1,0 +1,14 @@
+export async function sign(payload: string, secret: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  return `sha256=${Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")}`;
+}

--- a/test/property/broker-routing.property.test.ts
+++ b/test/property/broker-routing.property.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "vitest";
+import * as fc from "fast-check";
+import { verifyAndClassify, type GatewayWebhookEnvelope } from "../../v2/gateway.ts";
+import { asDeliveryId, asRepoFullName, asBotUsername } from "../../v2/types.ts";
+import type { RepoFullName } from "../../v2/types.ts";
+import { sign } from "../helpers/sign.ts";
+
+const RUNS = 100;
+const BOT = asBotUsername("zapbot[bot]");
+
+const arbSecret = fc.string({ minLength: 1, maxLength: 64 });
+const arbRawBody = fc.string({ maxLength: 256 });
+const arbRepo = fc
+  .constantFrom("acme/app", "org/repo", "user/project")
+  .map(asRepoFullName);
+const arbNonIssueCommentEvent = fc
+  .string({ minLength: 1, maxLength: 32 })
+  .filter((s) => s !== "issue_comment");
+
+function makeEnvelope(
+  rawBody: string,
+  signature: string | null,
+  eventType: string,
+  repo: RepoFullName
+): GatewayWebhookEnvelope {
+  return {
+    rawBody,
+    signature,
+    eventType,
+    deliveryId: asDeliveryId("prop-test-delivery"),
+    repo,
+    payload: {},
+  };
+}
+
+describe("verifyAndClassify (property: broker routing)", () => {
+  it("missing secret always yields SecretMissing regardless of payload or event", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbRepo,
+        arbRawBody,
+        arbNonIssueCommentEvent,
+        async (repo, rawBody, eventType) => {
+          const envelope = makeEnvelope(rawBody, null, eventType, repo);
+          const result = await verifyAndClassify(envelope, () => null, BOT);
+          return result._tag === "Err" && result.error._tag === "SecretMissing";
+        }
+      ),
+      { numRuns: RUNS }
+    );
+  });
+
+  it("null signature always yields SignatureMismatch when a secret exists", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbRepo,
+        arbSecret,
+        arbRawBody,
+        arbNonIssueCommentEvent,
+        async (repo, secret, rawBody, eventType) => {
+          const envelope = makeEnvelope(rawBody, null, eventType, repo);
+          const result = await verifyAndClassify(envelope, () => secret, BOT);
+          return result._tag === "Err" && result.error._tag === "SignatureMismatch";
+        }
+      ),
+      { numRuns: RUNS }
+    );
+  });
+
+  it("non-issue_comment events with a valid signature always route to ignore", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbRepo,
+        arbSecret,
+        arbRawBody,
+        arbNonIssueCommentEvent,
+        async (repo, secret, rawBody, eventType) => {
+          const sig = await sign(rawBody, secret);
+          const envelope = makeEnvelope(rawBody, sig, eventType, repo);
+          const result = await verifyAndClassify(envelope, () => secret, BOT);
+          return result._tag === "Ok" && result.value.kind === "ignore";
+        }
+      ),
+      { numRuns: RUNS }
+    );
+  });
+
+  it("routing is deterministic: identical envelope and secret always yield the same outcome", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        arbRepo,
+        arbSecret,
+        arbRawBody,
+        fc.string({ minLength: 1, maxLength: 32 }),
+        async (repo, secret, rawBody, eventType) => {
+          const sig = await sign(rawBody, secret);
+          const envelope = makeEnvelope(rawBody, sig, eventType, repo);
+          const [r1, r2] = await Promise.all([
+            verifyAndClassify(envelope, () => secret, BOT),
+            verifyAndClassify(envelope, () => secret, BOT),
+          ]);
+          if (r1._tag !== r2._tag) return false;
+          if (r1._tag === "Ok" && r2._tag === "Ok") return r1.value.kind === r2.value.kind;
+          return true;
+        }
+      ),
+      { numRuns: RUNS }
+    );
+  });
+});

--- a/test/verify-signature.property.test.ts
+++ b/test/verify-signature.property.test.ts
@@ -1,22 +1,7 @@
 import { describe, it, expect } from "vitest";
 import * as fc from "fast-check";
 import { verifySignature } from "../src/http/verify-signature.js";
-
-// Match verify-signature.ts byte-for-byte: WebCrypto HMAC-SHA256, hex, "sha256=" prefix.
-async function sign(payload: string, secret: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
-  return `sha256=${Array.from(new Uint8Array(sig))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("")}`;
-}
+import { sign } from "./helpers/sign.ts";
 
 const RUNS = 200;
 


### PR DESCRIPTION
Closes #129
Architect plan: zapbot#129 body (self-contained acceptance spec)

## What changed

Adds `test/property/broker-routing.property.test.ts` with 4 async fast-check property tests for `verifyAndClassify` (v2/gateway). Extracts the duplicate `sign()` HMAC helper into `test/helpers/sign.ts` and updates the existing `test/verify-signature.property.test.ts` to import from it. All 133 tests pass.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `test/property/broker-routing.property.test.ts` (new) | Issue §Targets: "Broker routing — event-type → destination; idempotency" |
| P1: missing secret → `SecretMissing` | Issue §Targets: broker routing + Validate at every boundary |
| P2: null signature → `SignatureMismatch` | Issue §Targets: "tamper → verify fails" |
| P3: non-`issue_comment` event + valid sig → `ignore` | Issue §Targets: "event-type → destination" routing |
| P4: same envelope + secret → same outcome | Issue §Targets: "idempotency" |
| `test/helpers/sign.ts` (new) | Simplify: `sign()` was byte-for-byte duplicated in both property test files |
| `test/verify-signature.property.test.ts` (modified) | Simplify: import `sign` from shared helper; removes 13-line duplicate |

## Scope

- Files touched: `test/property/broker-routing.property.test.ts` (new), `test/helpers/sign.ts` (new), `test/verify-signature.property.test.ts` (sign() de-duped)
- Tier: senior (cross-file, property test infrastructure + de-dup refactor)
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests

- 4 new property tests in `test/property/broker-routing.property.test.ts`, 100 runs each
- All 4 cover `verifyAndClassify` (v2/gateway): SecretMissing, SignatureMismatch, routing, determinism
- Existing `verify-signature.property.test.ts` (4 tests) unchanged behaviorally — now imports `sign` from shared helper
- `pnpm test`: 133 passed (14 files)

## Simplify findings applied

- Extracted duplicate `sign()` to `test/helpers/sign.ts` — byte-for-byte identical between `broker-routing.property.test.ts` and `verify-signature.property.test.ts`
- Removed `arbBot = fc.constant(...)` — using a plain module-level constant `BOT` avoids the illusion of bot-identity coverage from fast-check

## Simplify skips

- `importKey` caching per secret: skipped — secret is an fc arbitrary varying per run; can't pre-derive. Existing file follows the same pattern. Consistent with project convention.
- Test 4 deletion (determinism): skipped — it catches accidental global state bugs in `verifyAndClassify` (e.g. a shared `Set` or counter), which maps directly to the issue's "idempotency" target.

## Sibling PR note

Sibling: #130 (`impl-senior-zap115-stryker-wire`) wires Stryker mutation CI — it touches `package.json`, `stryker.config.mjs`, `.github/workflows/`, `README.md`, `.gitignore`. No overlap with this diff. If #130 lands first, rebase this branch on main.

## Confidence

HIGH — Property tests are pure fast-check assertions over a testable pure function (`verifyAndClassify`). All 133 tests pass locally. No new deps, no config changes, no new public surface.

/safer:review-senior mandatory before merge.