### PR TITLE
[arch] moltzap: sender-identity allowlist gate (I1)

### DIFF
--- a/v2/moltzap/identity-allowlist.ts
+++ b/v2/moltzap/identity-allowlist.ts
@@ -1,0 +1,68 @@
+/**
+ * v2/moltzap/identity-allowlist — sender-identity gate (I1).
+ *
+ * Anchors: spec moltzap-channel-v1 §4 I1, §5.1 AC1.2, §5.2 AC2.2; sub-issue
+ * zap#133 architect decision (option b).
+ *
+ * The bridge's LISTENING gate (v2/moltzap/bridge.onInbound) closes I3
+ * (presence). It does NOT close I1 (sender-authenticated inbound). Spec I1
+ * names an ungated path as a prompt-injection vector; AC1.2 requires a
+ * sender-identity allowlist check. This module is that gate, separate from
+ * the lifecycle gate by design — two invariants, two gates.
+ *
+ * Composition: plugin boot calls `gateInbound` before `bridge.onInbound`.
+ * Non-allowlisted events return `SenderNotAllowed` and are dropped with a
+ * diagnostic at the caller. No turn in the Claude session, no transcript
+ * side effect (AC1.2).
+ */
+
+import type { Result } from "../types.ts";
+import type {
+  MoltzapInbound,
+  MoltzapInboundMeta,
+  MoltzapSenderId,
+} from "./types.ts";
+
+// ── Allowlist handle ────────────────────────────────────────────────
+//
+// Opaque branded type. Constructed once at plugin boot from a configured set
+// of sender IDs (config source is impl-junior's choice — env, JSON, etc. —
+// per OQ1). Frozen for the lifetime of the plugin process; reload requires
+// restart (OQ3). The caller never mutates or inspects the underlying set;
+// only `fromSenderIds` constructs and `gateInbound` checks.
+
+export interface SenderAllowlist {
+  readonly __brand: "SenderAllowlist";
+}
+
+/** Construct a frozen allowlist from a configured set of sender IDs. */
+export function fromSenderIds(ids: readonly MoltzapSenderId[]): SenderAllowlist {
+  throw new Error("not implemented");
+}
+
+// ── Error channel ───────────────────────────────────────────────────
+
+export type AllowlistError = {
+  readonly _tag: "SenderNotAllowed";
+  readonly senderId: MoltzapSenderId;
+  readonly event: MoltzapInboundMeta;
+};
+
+// ── Gate ────────────────────────────────────────────────────────────
+
+/**
+ * Check an inbound event against the configured allowlist.
+ *
+ * Ok(event)            — sender is on the allowlist; caller forwards to
+ *                         `bridge.onInbound`.
+ * Err(SenderNotAllowed) — sender is NOT on the allowlist; caller drops
+ *                         (logs a diagnostic, does not forward to bridge).
+ *
+ * Pure; synchronous; O(1) set membership. No side effects.
+ */
+export function gateInbound(
+  allowlist: SenderAllowlist,
+  event: MoltzapInbound,
+): Result<MoltzapInbound, AllowlistError> {
+  throw new Error("not implemented");
+}

--- a/v2/moltzap/index.ts
+++ b/v2/moltzap/index.ts
@@ -8,3 +8,4 @@ export * from "./types.ts";
 export * from "./lifecycle.ts";
 export * from "./listener.ts";
 export * from "./bridge.ts";
+export * from "./identity-allowlist.ts";


### PR DESCRIPTION
Architecture only. Not for merge.

Closes #133 (on merge of a follow-up impl-junior PR, not this one).
Parent epic: #126.
Spec anchor: moltzap-channel-v1 §4 I1, §5.1 AC1.2, §5.2 AC2.2.
Design doc: see sub-issue #133 comment.

## What

One new module: `v2/moltzap/identity-allowlist.ts`.

- `SenderAllowlist` — branded opaque handle over a frozen set of `MoltzapSenderId`.
- `fromSenderIds(ids) → SenderAllowlist` — constructor at plugin boot.
- `AllowlistError = { _tag: "SenderNotAllowed"; senderId; event: MoltzapInboundMeta }`.
- `gateInbound(allowlist, event) → Result<MoltzapInbound, AllowlistError>` — sync, pure, O(1).

One barrel edit: `v2/moltzap/index.ts` re-exports the new module.

Every body is `throw new Error("not implemented")`. No other logic.

## Why option (b) and not (a) or (c)

- (a) bridge-only: the bridge's `LISTENING` gate closes I3 (presence), not I1 (sender identity). Spec explicitly names "ungated path is a prompt-injection vector." Rejected.
- (c) defer: I1 is a v1 invariant with a dedicated acceptance criterion (AC1.2). Deferring requires a /safer:spec revision, not an architect call. Rejected.
- (b) add identity-allowlist layer: two invariants → two gates. Selected.

## Scope

- New modules: 1 (budget ≤5).
- New public exports: 4 (1 type, 1 error union, 2 functions).
- New deps: 0.
- Files touched outside new module: 1 (`index.ts` barrel export).

## Checklist

- [x] All 8 design-doc sections filled (on sub-issue comment).
- [x] Every stub body is exactly `throw new Error("not implemented")`.
- [x] No `any`, no `Record<string, unknown>` on public signatures.
- [x] `SenderNotAllowed` is a discriminated tagged error — no raw throws in the contract.
- [x] Traceability table maps I1, AC1.2, AC2.2 → module.
- [x] Typecheck clean (`bunx tsc --noEmit`).
- [x] Lint clean (warnings match existing v2/moltzap pattern: 2 `no-raw-throw-new-error` warnings on the stubs, same as bridge.ts).