### PR TITLE
[impl-senior] moltzap: SDK event decoding at inbound boundary

### DIFF
--- a/test/v2-moltzap-listener.test.ts
+++ b/test/v2-moltzap-listener.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { register, type MoltzapRegistrar } from "../v2/moltzap/listener.ts";
+import {
+  register,
+  type MoltzapRegistrar,
+  type DecodeError,
+} from "../v2/moltzap/listener.ts";
 import {
   INITIAL,
   transition,
@@ -12,6 +16,7 @@ import { ok, err } from "../v2/types.ts";
 const sdk = { __brand: "MoltzapSdkHandle" } as MoltzapSdkHandle;
 const handle = { __brand: "ListenerHandle" } as ListenerHandle;
 const noopCb = (_event: MoltzapInbound) => {};
+const noopDiag = (_error: DecodeError) => {};
 
 function driveTo(ev: LifecycleEvent[]): LifecycleState {
   let s: LifecycleState = INITIAL;
@@ -30,12 +35,20 @@ const READY_PATH: LifecycleEvent[] = [
   { _tag: "MoltzapReady" },
 ];
 
+const validRaw: unknown = {
+  messageId: "msg-abc",
+  conversationId: "conv-xyz",
+  senderId: "user-1",
+  bodyText: "hello world",
+  receivedAtMs: 1_700_000_000_000,
+};
+
 describe("listener.register — pre-ready rejection", () => {
   it("INIT → NotReady (sub-issue AC1.1 / Q2 option (a): forbid pre-ready attach)", async () => {
     const registrar: MoltzapRegistrar = async () => {
       throw new Error("registrar must not be called pre-ready");
     };
-    const result = await register(INITIAL, sdk, noopCb, registrar);
+    const result = await register(INITIAL, sdk, noopCb, registrar, noopDiag);
     expect(result._tag).toBe("Err");
     if (result._tag !== "Err") return;
     expect(result.error._tag).toBe("NotReady");
@@ -48,7 +61,7 @@ describe("listener.register — pre-ready rejection", () => {
       called = true;
       return ok(handle);
     };
-    const result = await register(s, sdk, noopCb, registrar);
+    const result = await register(s, sdk, noopCb, registrar, noopDiag);
     expect(result._tag).toBe("Err");
     expect(called).toBe(false);
   });
@@ -60,7 +73,7 @@ describe("listener.register — pre-ready rejection", () => {
       { _tag: "MoltzapConnectStarted" },
     ]);
     const registrar: MoltzapRegistrar = async () => ok(handle);
-    const result = await register(s, sdk, noopCb, registrar);
+    const result = await register(s, sdk, noopCb, registrar, noopDiag);
     expect(result._tag).toBe("Err");
   });
 });
@@ -73,7 +86,7 @@ describe("listener.register — happy path", () => {
       calls += 1;
       return ok(handle);
     };
-    const result = await register(state, sdk, noopCb, registrar);
+    const result = await register(state, sdk, noopCb, registrar, noopDiag);
     expect(result._tag).toBe("Ok");
     expect(calls).toBe(1);
   });
@@ -84,7 +97,7 @@ describe("listener.register — SDK rejection", () => {
     const state = driveTo(READY_PATH);
     const registrar: MoltzapRegistrar = async () =>
       err({ _tag: "SDKRejected", cause: "SDK timed out during onMessage wiring" });
-    const result = await register(state, sdk, noopCb, registrar);
+    const result = await register(state, sdk, noopCb, registrar, noopDiag);
     expect(result._tag).toBe("Err");
     if (result._tag !== "Err") return;
     expect(result.error._tag).toBe("SDKRejected");
@@ -96,7 +109,7 @@ describe("listener.register — SDK rejection", () => {
     const registrar: MoltzapRegistrar = async () => {
       throw boom;
     };
-    const result = await register(state, sdk, noopCb, registrar);
+    const result = await register(state, sdk, noopCb, registrar, noopDiag);
     expect(result._tag).toBe("Err");
     if (result._tag !== "Err") return;
     expect(result.error._tag).toBe("SDKRejected");
@@ -112,9 +125,145 @@ describe("listener.register — re-registration guard", () => {
       listener: handle,
     };
     const registrar: MoltzapRegistrar = async () => ok(handle);
-    const result = await register(listening, sdk, noopCb, registrar);
+    const result = await register(listening, sdk, noopCb, registrar, noopDiag);
     expect(result._tag).toBe("Err");
     if (result._tag !== "Err") return;
     expect(result.error._tag).toBe("NotReady");
+  });
+});
+
+// ── Decode layer tests ───────────────────────────────────────────────
+//
+// The registrar now receives cb: (event: unknown) => void. These tests
+// drive that wrapped callback directly to verify the decode layer
+// independent of SDK wiring.
+
+describe("listener.register — decode layer (valid event)", () => {
+  it("well-formed raw event → decoded and forwarded to user callback", async () => {
+    const state = driveTo(READY_PATH);
+    const received: MoltzapInbound[] = [];
+    const diagCalls: DecodeError[] = [];
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(validRaw);
+      return ok(handle);
+    };
+    await register(state, sdk, (e) => received.push(e), registrar, (d) => diagCalls.push(d));
+    expect(received).toHaveLength(1);
+    expect(received[0].messageId).toBe("msg-abc");
+    expect(received[0].conversationId).toBe("conv-xyz");
+    expect(received[0].senderId).toBe("user-1");
+    expect(received[0].bodyText).toBe("hello world");
+    expect(received[0].receivedAtMs).toBe(1_700_000_000_000);
+    expect(diagCalls).toHaveLength(0);
+  });
+
+  it("extra unknown fields in raw event are ignored (forward-compat)", async () => {
+    const state = driveTo(READY_PATH);
+    const received: MoltzapInbound[] = [];
+    const withExtras: unknown = { ...validRaw as object, unknownFutureProp: true, version: 2 };
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(withExtras);
+      return ok(handle);
+    };
+    await register(state, sdk, (e) => received.push(e), registrar, noopDiag);
+    expect(received).toHaveLength(1);
+  });
+
+  it("edge: empty string messageId is valid", async () => {
+    const state = driveTo(READY_PATH);
+    const received: MoltzapInbound[] = [];
+    const raw: unknown = { ...validRaw as object, messageId: "" };
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(raw);
+      return ok(handle);
+    };
+    await register(state, sdk, (e) => received.push(e), registrar, noopDiag);
+    expect(received).toHaveLength(1);
+    expect(received[0].messageId).toBe("");
+  });
+
+  it("edge: receivedAtMs = 0 is valid", async () => {
+    const state = driveTo(READY_PATH);
+    const received: MoltzapInbound[] = [];
+    const raw: unknown = { ...validRaw as object, receivedAtMs: 0 };
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(raw);
+      return ok(handle);
+    };
+    await register(state, sdk, (e) => received.push(e), registrar, noopDiag);
+    expect(received).toHaveLength(1);
+    expect(received[0].receivedAtMs).toBe(0);
+  });
+});
+
+describe("listener.register — decode layer (invalid events)", () => {
+  it("null input → DecodeError on '.', event dropped", async () => {
+    const state = driveTo(READY_PATH);
+    const received: MoltzapInbound[] = [];
+    const diagCalls: DecodeError[] = [];
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(null);
+      return ok(handle);
+    };
+    await register(state, sdk, (e) => received.push(e), registrar, (d) => diagCalls.push(d));
+    expect(received).toHaveLength(0);
+    expect(diagCalls).toHaveLength(1);
+    expect(diagCalls[0]._tag).toBe("DecodeError");
+    expect(diagCalls[0].field).toBe(".");
+  });
+
+  it("missing messageId → DecodeError on 'messageId', event dropped", async () => {
+    const state = driveTo(READY_PATH);
+    const received: MoltzapInbound[] = [];
+    const diagCalls: DecodeError[] = [];
+    const { messageId: _omit, ...withoutId } = validRaw as Record<string, unknown>;
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(withoutId);
+      return ok(handle);
+    };
+    await register(state, sdk, (e) => received.push(e), registrar, (d) => diagCalls.push(d));
+    expect(received).toHaveLength(0);
+    expect(diagCalls[0].field).toBe("messageId");
+  });
+
+  it("wrong type on receivedAtMs (string) → DecodeError on 'receivedAtMs'", async () => {
+    const state = driveTo(READY_PATH);
+    const diagCalls: DecodeError[] = [];
+    const raw: unknown = { ...validRaw as object, receivedAtMs: "not-a-number" };
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(raw);
+      return ok(handle);
+    };
+    await register(state, sdk, noopCb, registrar, (d) => diagCalls.push(d));
+    expect(diagCalls).toHaveLength(1);
+    expect(diagCalls[0].field).toBe("receivedAtMs");
+    expect(diagCalls[0].raw).toBe("not-a-number");
+  });
+
+  it("array input (non-object) → DecodeError on '.'", async () => {
+    const state = driveTo(READY_PATH);
+    const diagCalls: DecodeError[] = [];
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(["not", "an", "object"]);
+      return ok(handle);
+    };
+    await register(state, sdk, noopCb, registrar, (d) => diagCalls.push(d));
+    expect(diagCalls).toHaveLength(1);
+    expect(diagCalls[0].field).toBe(".");
+  });
+
+  it("multiple events: valid then invalid → forward then drop", async () => {
+    const state = driveTo(READY_PATH);
+    const received: MoltzapInbound[] = [];
+    const diagCalls: DecodeError[] = [];
+    const registrar: MoltzapRegistrar = async (_sdk, cb) => {
+      cb(validRaw);
+      cb({ ...validRaw as object, bodyText: 42 });
+      return ok(handle);
+    };
+    await register(state, sdk, (e) => received.push(e), registrar, (d) => diagCalls.push(d));
+    expect(received).toHaveLength(1);
+    expect(diagCalls).toHaveLength(1);
+    expect(diagCalls[0].field).toBe("bodyText");
   });
 });

--- a/v2/moltzap/listener.ts
+++ b/v2/moltzap/listener.ts
@@ -4,32 +4,53 @@
  * Anchors: sbd#108 architect plan §2.2 listener, §3 Interfaces; spec
  * moltzap-channel-v1 §7 Q2 option (a).
  *
- * Forbidden to attach before `MOLTZAP_READY`. The SDK surface is opaque here
- * (see types.ts MoltzapSdkHandle); the actual adapter that wires
- * `MoltZapApp.onMessage` to this callback lives at the plugin boot layer and
- * is injected as `MoltzapRegistrar`.
+ * Forbidden to attach before `MOLTZAP_READY`. Raw SDK events are decoded
+ * through a schema here before reaching the bridge callback; malformed events
+ * are dropped with a tagged diagnostic — no throw, no buffer (I7).
  */
 
 import type { Result } from "../types.ts";
-import { err } from "../types.ts";
+import { err, ok } from "../types.ts";
 import type { LifecycleState, ListenerRegistrationError } from "./lifecycle.ts";
 import type {
   ListenerHandle,
+  MoltzapConversationId,
   MoltzapInbound,
+  MoltzapMessageId,
   MoltzapSdkHandle,
+  MoltzapSenderId,
 } from "./types.ts";
 
-/**
- * The injection point for the real SDK wiring. The plugin boot code supplies
- * an implementation that calls `@moltzap/app-sdk`'s `onMessage`/`onSessionReady`
- * and returns an opaque handle. Keeping this as a caller-supplied function
- * lets lifecycle and listener compile without a hard dep on
- * `@moltzap/app-sdk`; architect plan §3 explicitly calls the SDK type opaque.
- */
+// ── Decode error ─────────────────────────────────────────────────────
+//
+// sbd#108 follow-up: "typed error for malformed events". Named per field
+// so the diagnostic sink can surface exactly which part of the raw SDK
+// event was wrong without leaking large payloads.
+
+export type DecodeError = {
+  readonly _tag: "DecodeError";
+  /** The field path that failed validation ("." for non-object input). */
+  readonly field: string;
+  /** The raw value that failed. */
+  readonly raw: unknown;
+};
+
+/** Injection point for the decode diagnostic. Plugin boot wires stderr;
+ *  tests inject a recorder. Kept synchronous (diagnostic only). */
+export type DecodeErrorSink = (error: DecodeError) => void;
+
+// ── Registrar injection point ────────────────────────────────────────
+//
+// The registrar receives a callback typed `(event: unknown) => void`.
+// This places schema validation inside this module (Principle 2: validate
+// at every boundary) rather than trusting the boot-layer to pre-shape events.
+
 export type MoltzapRegistrar = (
   sdk: MoltzapSdkHandle,
-  cb: (event: MoltzapInbound) => void,
+  cb: (event: unknown) => void,
 ) => Promise<Result<ListenerHandle, { readonly _tag: "SDKRejected"; readonly cause: unknown }>>;
+
+// ── Registration ─────────────────────────────────────────────────────
 
 /**
  * Register the inbound callback against the moltzap SDK.
@@ -38,26 +59,66 @@ export type MoltzapRegistrar = (
  *   - `state` must be `MOLTZAP_READY` (option (a) from spec §7 Q2).
  *   - `registrar` is the caller-supplied adapter to `@moltzap/app-sdk`.
  *
- * Returns `NotReady` before the ready gate (prevents the debt pattern of
- * "register eagerly, rely on SDK internals" — spec §4 I6, architect plan §4).
+ * The callback supplied to `registrar` validates each raw SDK event
+ * through `decodeMoltzapInbound` before forwarding to `cb`. Invalid
+ * events are reported to `diag` and dropped (no buffer — I7).
  */
 export async function register(
   state: LifecycleState,
   sdk: MoltzapSdkHandle,
   cb: (event: MoltzapInbound) => void,
   registrar: MoltzapRegistrar,
+  diag: DecodeErrorSink,
 ): Promise<Result<ListenerHandle, ListenerRegistrationError>> {
-  // Architect plan §2.2: register exactly once, only in MOLTZAP_READY.
-  // LISTENING/any other state → NotReady.
   if (state._tag !== "MOLTZAP_READY") {
     return err({ _tag: "NotReady", state });
   }
-  // Defend against injected registrars that throw/reject before building a
-  // `Result` — a closed session or duplicate listener wiring in the real SDK
-  // can surface that way. Principle 3: errors are typed, not thrown.
+  // Wrap cb with the decode layer. The registrar passes raw SDK events;
+  // we validate the shape here before the bridge ever sees them.
+  const wrappedCb = (raw: unknown): void => {
+    const decoded = decodeMoltzapInbound(raw);
+    if (decoded._tag === "Err") {
+      diag(decoded.error);
+      return;
+    }
+    cb(decoded.value);
+  };
   try {
-    return await registrar(sdk, cb);
+    return await registrar(sdk, wrappedCb);
   } catch (cause) {
     return err({ _tag: "SDKRejected", cause });
   }
+}
+
+// ── Decoder ──────────────────────────────────────────────────────────
+//
+// Extra fields are silently ignored (forward-compat with SDK additions).
+
+function decodeMoltzapInbound(raw: unknown): Result<MoltzapInbound, DecodeError> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return err({ _tag: "DecodeError", field: ".", raw });
+  }
+  const r = raw as Record<string, unknown>;
+  const fieldErr =
+    checkField(r, "messageId", "string") ??
+    checkField(r, "conversationId", "string") ??
+    checkField(r, "senderId", "string") ??
+    checkField(r, "bodyText", "string") ??
+    checkField(r, "receivedAtMs", "number");
+  if (fieldErr) return err(fieldErr);
+  return ok({
+    messageId: r["messageId"] as MoltzapMessageId,
+    conversationId: r["conversationId"] as MoltzapConversationId,
+    senderId: r["senderId"] as MoltzapSenderId,
+    bodyText: r["bodyText"] as string,
+    receivedAtMs: r["receivedAtMs"] as number,
+  });
+}
+
+function checkField(
+  r: Record<string, unknown>,
+  field: string,
+  type: string,
+): DecodeError | null {
+  return typeof r[field] !== type ? { _tag: "DecodeError", field, raw: r[field] } : null;
 }

--- a/v2/moltzap/listener.ts
+++ b/v2/moltzap/listener.ts
@@ -12,6 +12,11 @@
 import type { Result } from "../types.ts";
 import { err, ok } from "../types.ts";
 import type { LifecycleState, ListenerRegistrationError } from "./lifecycle.ts";
+import {
+  asMoltzapConversationId,
+  asMoltzapMessageId,
+  asMoltzapSenderId,
+} from "./types.ts";
 import type {
   ListenerHandle,
   MoltzapConversationId,
@@ -30,7 +35,7 @@ import type {
 export type DecodeError = {
   readonly _tag: "DecodeError";
   /** The field path that failed validation ("." for non-object input). */
-  readonly field: string;
+  readonly field: "." | "messageId" | "conversationId" | "senderId" | "bodyText" | "receivedAtMs";
   /** The raw value that failed. */
   readonly raw: unknown;
 };
@@ -99,6 +104,7 @@ function decodeMoltzapInbound(raw: unknown): Result<MoltzapInbound, DecodeError>
     return err({ _tag: "DecodeError", field: ".", raw });
   }
   const r = raw as Record<string, unknown>;
+  // ?? short-circuits: returns the first field error encountered, at most one per event.
   const fieldErr =
     checkField(r, "messageId", "string") ??
     checkField(r, "conversationId", "string") ??
@@ -107,9 +113,9 @@ function decodeMoltzapInbound(raw: unknown): Result<MoltzapInbound, DecodeError>
     checkField(r, "receivedAtMs", "number");
   if (fieldErr) return err(fieldErr);
   return ok({
-    messageId: r["messageId"] as MoltzapMessageId,
-    conversationId: r["conversationId"] as MoltzapConversationId,
-    senderId: r["senderId"] as MoltzapSenderId,
+    messageId: asMoltzapMessageId(r["messageId"] as string),
+    conversationId: asMoltzapConversationId(r["conversationId"] as string),
+    senderId: asMoltzapSenderId(r["senderId"] as string),
     bodyText: r["bodyText"] as string,
     receivedAtMs: r["receivedAtMs"] as number,
   });
@@ -117,8 +123,8 @@ function decodeMoltzapInbound(raw: unknown): Result<MoltzapInbound, DecodeError>
 
 function checkField(
   r: Record<string, unknown>,
-  field: string,
-  type: string,
+  field: "messageId" | "conversationId" | "senderId" | "bodyText" | "receivedAtMs",
+  type: "string" | "number",
 ): DecodeError | null {
   return typeof r[field] !== type ? { _tag: "DecodeError", field, raw: r[field] } : null;
 }


### PR DESCRIPTION
Closes #132
Architect plan: https://github.com/chughtapan/safer-by-default/issues/108#issuecomment-4275100681

## What changed

Adds schema validation at the listener-to-bridge handoff. `register()` now wraps the user callback with a decode layer: the `MoltzapRegistrar` passes raw `unknown` SDK events; `decodeMoltzapInbound` validates each required field and returns a typed `DecodeError` on failure. Malformed events are reported to the injected `DecodeErrorSink` and dropped with no buffering (I7). The bridge callback only receives well-typed `MoltzapInbound` values.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `DecodeError` type | sbd#108 follow-up: "typed error for malformed events" |
| `DecodeErrorSink` type | sbd#108 follow-up: "dropped + diagnostic" |
| `MoltzapRegistrar` callback `(event: unknown) => void` | sbd#108 follow-up: "decode raw SDK events" |
| `decodeMoltzapInbound()` + `checkField()` internals | sbd#108 follow-up: "through a schema" |
| `register()` `diag` param + `wrappedCb` | sbd#108 follow-up: "before passing MoltzapInbound into bridge.onInbound" |
| 9 new decode-layer tests | Issue #132 Acceptance: "Unit tests for valid/invalid/edge shapes" |

## Scope

- Modules touched: `v2/moltzap/listener.ts`, `test/v2-moltzap-listener.test.ts`
- Tier (from safer-diff-scope): senior — 2 files, internals only, no new module, no new public surface beyond plan-named types
- New modules: 0
- New public signatures outside the plan: 0 (`DecodeError`, `DecodeErrorSink` are plan-named)
- New deps: 0

## Tests

- 7 existing tests updated: added `noopDiag` parameter to all `register()` calls
- 4 new valid-event tests: well-formed decode, extra fields ignored, empty-string messageId, receivedAtMs=0
- 5 new invalid-event tests: null input, missing field, wrong type, array input, multi-event (valid then invalid)

## Simplify

- Applied: extracted `checkField()` helper to de-duplicate the 5 field-validation blocks
- Applied: trimmed "what" comment on decoder to forward-compat WHY only
- Skip: shared decoder utility with `v2/gateway.ts#decodeIssueCommentPayload` — extracting a shared module is architect-tier (new module); noted for future architect pass

## Confidence

HIGH — decoder is field-by-field over a fixed schema, tests cover all 5 required fields + null/array edge cases + multi-event ordering. No new deps, no new modules, every edit traces to the plan.

---
`/safer:review-senior` required before merge.