### PR TITLE
[impl-senior] remove stale installer/setup leftovers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,6 @@ STATE_DIR="$HOME/.zapbot"
 SKILLS=(
   "zap:skills/zap/SKILL.md"
   "zapbot-publish:skills/zapbot-publish/SKILL.md"
-  "zapbot-status:skills/zapbot-status/SKILL.md"
 )
 
 echo "=== Zapbot Skill Install ==="
@@ -57,12 +56,6 @@ echo "$GITHUB_RAW" > "$STATE_DIR/github-raw-url"
 # Set upgrade marker if version changed
 if [ -n "$OLD_VERSION" ] && [ "$OLD_VERSION" != "$REMOTE_VERSION" ]; then
   echo "$OLD_VERSION" > "$STATE_DIR/just-upgraded-from"
-fi
-
-# Install plannotator if missing
-if ! command -v plannotator >/dev/null 2>&1; then
-  echo "  Installing plannotator..."
-  curl -fsSL https://plannotator.ai/install.sh | bash 2>/dev/null || echo "  Warning: plannotator install failed (optional)"
 fi
 
 echo ""

--- a/setup
+++ b/setup
@@ -134,7 +134,7 @@ ln -snf "$ZAPBOT_DIR" "$SKILLS_DIR/zapbot"
 link_skill_dirs "$ZAPBOT_DIR" "$SKILLS_DIR"
 
 # Make scripts executable
-chmod +x "$ZAPBOT_DIR/bin/"* "$ZAPBOT_DIR/setup" "$ZAPBOT_DIR/start.sh" "$ZAPBOT_DIR/test/e2e-smoke.sh" 2>/dev/null || true
+chmod +x "$ZAPBOT_DIR/bin/"* "$ZAPBOT_DIR/setup" "$ZAPBOT_DIR/start.sh" 2>/dev/null || true
 
 # Create ~/.zapbot/ dir
 STATE_DIR="$HOME/.zapbot"


### PR DESCRIPTION
Refs #152

## What changed
- remove the deleted `skills/zapbot-status/SKILL.md` entry from `install.sh`
- stop `install.sh` from bootstrapping optional `plannotator`, which is no longer on the live runtime path
- stop `setup` from chmod'ing the deleted `test/e2e-smoke.sh` script

## Scope
- keeps the live `ZAPBOT_REPO` compatibility fallback intact
- keeps the live `triage this` mention alias intact
- no new dependencies or broader refactors

## Verification
- `bash -n install.sh setup`
- `HOME=$(mktemp -d) ZAPBOT_GITHUB_RAW=file:///tmp/zapbot-152-worktree bash ./install.sh`
- `./setup --help`
- `bun test`
- `bun run build`
- `bun run lint` (warnings only, no errors)