### PR TITLE
chore: remove stale installer/setup leftovers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,6 @@ STATE_DIR="$HOME/.zapbot"
 SKILLS=(
   "zap:skills/zap/SKILL.md"
   "zapbot-publish:skills/zapbot-publish/SKILL.md"
-  "zapbot-status:skills/zapbot-status/SKILL.md"
 )
 
 echo "=== Zapbot Skill Install ==="
@@ -57,12 +56,6 @@ echo "$GITHUB_RAW" > "$STATE_DIR/github-raw-url"
 # Set upgrade marker if version changed
 if [ -n "$OLD_VERSION" ] && [ "$OLD_VERSION" != "$REMOTE_VERSION" ]; then
   echo "$OLD_VERSION" > "$STATE_DIR/just-upgraded-from"
-fi
-
-# Install plannotator if missing
-if ! command -v plannotator >/dev/null 2>&1; then
-  echo "  Installing plannotator..."
-  curl -fsSL https://plannotator.ai/install.sh | bash 2>/dev/null || echo "  Warning: plannotator install failed (optional)"
 fi
 
 echo ""

--- a/setup
+++ b/setup
@@ -134,7 +134,7 @@ ln -snf "$ZAPBOT_DIR" "$SKILLS_DIR/zapbot"
 link_skill_dirs "$ZAPBOT_DIR" "$SKILLS_DIR"
 
 # Make scripts executable
-chmod +x "$ZAPBOT_DIR/bin/"* "$ZAPBOT_DIR/setup" "$ZAPBOT_DIR/start.sh" "$ZAPBOT_DIR/test/e2e-smoke.sh" 2>/dev/null || true
+chmod +x "$ZAPBOT_DIR/bin/"* "$ZAPBOT_DIR/setup" "$ZAPBOT_DIR/start.sh" 2>/dev/null || true
 
 # Create ~/.zapbot/ dir
 STATE_DIR="$HOME/.zapbot"


### PR DESCRIPTION
## Summary
- Remove deleted `skills/zapbot-status/SKILL.md` from `install.sh` SKILLS array
- Remove `plannotator` install block from `install.sh` (no longer consumed by runtime)
- Remove deleted `test/e2e-smoke.sh` from `setup` chmod command

## Context
Closes #152. The accepted investigation (#157) identified these three stale references after ao-native completion. All live compatibility paths are kept intact.

## Test plan
- [x] `bun run test` — 202 tests pass
- [x] `bun run build` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [ ] Verify `install.sh` no longer attempts to fetch `zapbot-status` or install `plannotator`
- [ ] Verify `setup` no longer references `test/e2e-smoke.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)