### PR TITLE
[impl-staff] implement Claude-first MoltZap channel runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "zap-1",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@moltzap/client": "2026.414.0",
         "@octokit/auth-app": "^8.2.0",
         "@octokit/rest": "^22.0.1",
         "yaml": "^2.8.3",
@@ -91,6 +93,8 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
@@ -102,6 +106,12 @@
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "@moltzap/client": ["@moltzap/client@2026.414.0", "", { "dependencies": { "@moltzap/protocol": "2026.408.0", "commander": "^13.0.0", "ws": "^8.18.0" }, "bin": { "moltzap": "dist/cli/index.js" } }, "sha512-3bnqo5GUf1vUJjgJy5c/GJoWrfexwMsUx19TEVK7jSL/GOFqozcHkhlra90FYKVJFMvX4AOLfLp3Hk5era299A=="],
+
+    "@moltzap/protocol": ["@moltzap/protocol@2026.408.0", "", { "dependencies": { "@sinclair/typebox": "^0.34.0", "ajv": "^8.17.0", "ajv-formats": "^3.0.0" }, "peerDependencies": { "ws": "^8.0.0" }, "optionalPeers": ["ws"] }, "sha512-IiMCYJbMRwn277/CcKdg6QJmpIMINN2O1Gree/h+hU/qzKk/t3rsS0pOv0fHZlTxehgfyY+KBtOkxTFW7YjHoA=="],
 
     "@octokit/auth-app": ["@octokit/auth-app@8.2.0", "", { "dependencies": { "@octokit/auth-oauth-app": "^9.0.3", "@octokit/auth-oauth-user": "^6.0.2", "@octokit/request": "^10.0.6", "@octokit/request-error": "^7.0.2", "@octokit/types": "^16.0.0", "toad-cache": "^3.7.0", "universal-github-app-jwt": "^2.2.0", "universal-user-agent": "^7.0.0" } }, "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g=="],
 
@@ -189,6 +199,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
 
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -229,11 +241,15 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -245,11 +261,19 @@
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -263,7 +287,19 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -273,9 +309,25 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": "bin/esbuild" }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -299,7 +351,17 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
 
     "fast-check": ["fast-check@4.7.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ=="],
 
@@ -311,9 +373,13 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -321,13 +387,35 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
     "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -335,11 +423,21 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
@@ -348,6 +446,8 @@
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -365,6 +465,16 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -372,6 +482,16 @@
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -381,9 +501,13 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -393,29 +517,61 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "postcss": ["postcss@8.5.9", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -439,9 +595,13 @@
 
     "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
@@ -451,7 +611,11 @@
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": "bin/vite.js" }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
@@ -465,17 +629,37 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "@moltzap/protocol/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@moltzap/protocol/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "@moltzap/client": "2026.414.0",
     "@octokit/auth-app": "^8.2.0",
     "@octokit/rest": "^22.0.1",
     "yaml": "^2.8.3"

--- a/test/helpers/claude-channel-server-entry.ts
+++ b/test/helpers/claude-channel-server-entry.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import process from "node:process";
+import { bootClaudeChannelServer } from "../../v2/claude-channel/server.ts";
+import { ok } from "../../v2/types.ts";
+import {
+  asMoltzapConversationId,
+  asMoltzapMessageId,
+  asMoltzapSenderId,
+} from "../../v2/moltzap/types.ts";
+
+const replyFile = process.env.CLAUDE_CHANNEL_REPLY_FILE ?? "";
+const permissionFile = process.env.CLAUDE_CHANNEL_PERMISSION_FILE ?? "";
+const pushOnStart = process.env.CLAUDE_CHANNEL_PUSH_ON_START === "1";
+const permissionVerdict = process.env.CLAUDE_CHANNEL_PERMISSION_VERDICT;
+
+const booted = await bootClaudeChannelServer(
+  {
+    serverName: "moltzap",
+    instructions: "Test Claude channel server",
+    enableReplyTool: true,
+    enablePermissionRelay: permissionFile.length > 0,
+  },
+  {
+    sendReply: async (args) => {
+      await fs.appendFile(replyFile, `${JSON.stringify(args)}\n`, "utf8");
+      return ok(undefined);
+    },
+    forwardPermissionRequest:
+      permissionFile.length > 0
+        ? async (request) => {
+            await fs.appendFile(permissionFile, `${JSON.stringify(request)}\n`, "utf8");
+            return ok(undefined);
+          }
+        : undefined,
+  },
+);
+
+if (booted._tag === "Err") {
+  console.error(JSON.stringify(booted.error));
+  process.exit(1);
+}
+
+if (pushOnStart) {
+  setTimeout(() => {
+    void booted.value.push({
+      method: "notifications/claude/channel",
+      params: {
+        content: "hello from spawned channel server",
+        meta: {
+          conversation_id: asMoltzapConversationId("conv-spawned"),
+          sender_id: asMoltzapSenderId("orch-1"),
+          message_id: asMoltzapMessageId("msg-spawned"),
+          received_at_ms: "1234",
+        },
+      },
+    });
+  }, 150);
+}
+
+if (permissionVerdict === "allow" || permissionVerdict === "deny") {
+  setTimeout(() => {
+    void booted.value.pushPermissionVerdict({
+      method: "notifications/claude/channel/permission",
+      params: {
+        request_id: "req-spawned",
+        behavior: permissionVerdict,
+      },
+    });
+  }, 250);
+}
+
+const keepAlive = setInterval(() => {}, 1_000);
+
+async function stopAndExit(): Promise<void> {
+  clearInterval(keepAlive);
+  await booted.value.stop();
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  void stopAndExit();
+});

--- a/test/v2-ao-claude-channel-launch.test.ts
+++ b/test/v2-ao-claude-channel-launch.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  planClaudeChannelLaunch,
+  renderSessionMcpConfig,
+} from "../v2/ao/claude-channel-launch.ts";
+
+const server = {
+  name: "moltzap",
+  command: "bun",
+  args: ["run", "channel-server.ts"],
+  env: {
+    MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
+    MOLTZAP_API_KEY: "test-key",
+  },
+} as const;
+
+describe("renderSessionMcpConfig", () => {
+  it("renders a session-local Claude MCP config", () => {
+    const result = renderSessionMcpConfig(server);
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(JSON.parse(result.value)).toEqual({
+      mcpServers: {
+        moltzap: {
+          command: "bun",
+          args: ["run", "channel-server.ts"],
+          env: {
+            MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
+            MOLTZAP_API_KEY: "test-key",
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects invalid MCP config input", () => {
+    const result = renderSessionMcpConfig({
+      ...server,
+      command: "   ",
+    });
+    expect(result).toEqual({
+      _tag: "Err",
+      error: {
+        _tag: "McpConfigInvalid",
+        reason: "server.command must be a non-empty string",
+      },
+    });
+  });
+});
+
+describe("planClaudeChannelLaunch", () => {
+  it("plans the development-channel launch path", () => {
+    const result = planClaudeChannelLaunch({
+      server,
+      entry: { _tag: "DevelopmentServer", serverName: "moltzap" },
+      mcpConfigPath: "/tmp/session/.mcp.json",
+    });
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: {
+        mcpConfigPath: "/tmp/session/.mcp.json",
+        mcpConfigJson: JSON.stringify(
+          {
+            mcpServers: {
+              moltzap: {
+                command: "bun",
+                args: ["run", "channel-server.ts"],
+                env: {
+                  MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
+                  MOLTZAP_API_KEY: "test-key",
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+        extraArgs: [
+          "--mcp-config",
+          "/tmp/session/.mcp.json",
+          "--dangerously-load-development-channels",
+          "server:moltzap",
+        ],
+        entry: { _tag: "DevelopmentServer", serverName: "moltzap" },
+      },
+    });
+  });
+
+  it("plans the allowlisted plugin launch path", () => {
+    const result = planClaudeChannelLaunch({
+      server,
+      entry: {
+        _tag: "ApprovedPlugin",
+        pluginName: "moltzap",
+        marketplace: "claude-plugins-official",
+      },
+      mcpConfigPath: "/tmp/session/.mcp.json",
+    });
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value.extraArgs).toEqual([
+      "--mcp-config",
+      "/tmp/session/.mcp.json",
+      "--channels",
+      "plugin:moltzap@claude-plugins-official",
+    ]);
+  });
+
+  it("rejects development entries that do not match the configured MCP server name", () => {
+    const result = planClaudeChannelLaunch({
+      server,
+      entry: { _tag: "DevelopmentServer", serverName: "other" },
+      mcpConfigPath: "/tmp/session/.mcp.json",
+    });
+    expect(result).toEqual({
+      _tag: "Err",
+      error: {
+        _tag: "McpConfigInvalid",
+        reason: "development entry server name other must match MCP server moltzap",
+      },
+    });
+  });
+});

--- a/test/v2-claude-channel-event.test.ts
+++ b/test/v2-claude-channel-event.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  toClaudeChannelNotification,
+  toClaudePermissionNotification,
+} from "../v2/claude-channel/event.ts";
+import {
+  asMoltzapConversationId,
+  asMoltzapMessageId,
+  asMoltzapSenderId,
+  type MoltzapInbound,
+} from "../v2/moltzap/types.ts";
+
+function makeInbound(overrides: Partial<MoltzapInbound> = {}): MoltzapInbound {
+  return {
+    messageId: asMoltzapMessageId("msg-1"),
+    conversationId: asMoltzapConversationId("conv-1"),
+    senderId: asMoltzapSenderId("agent-1"),
+    bodyText: "hello from moltzap",
+    receivedAtMs: 1_234,
+    ...overrides,
+  };
+}
+
+describe("toClaudeChannelNotification", () => {
+  it("maps a MoltZap inbound message into the official Claude channel notification shape", () => {
+    const result = toClaudeChannelNotification(makeInbound());
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: {
+        method: "notifications/claude/channel",
+        params: {
+          content: "hello from moltzap",
+          meta: {
+            conversation_id: "conv-1",
+            sender_id: "agent-1",
+            message_id: "msg-1",
+            received_at_ms: "1234",
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects blank content", () => {
+    const result = toClaudeChannelNotification(makeInbound({ bodyText: "   " }));
+    expect(result).toEqual({ _tag: "Err", error: { _tag: "ContentEmpty" } });
+  });
+
+  it("rejects invalid metadata", () => {
+    const result = toClaudeChannelNotification(
+      makeInbound({ senderId: asMoltzapSenderId(""), receivedAtMs: Number.NaN }),
+    );
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("MetaInvalid");
+  });
+});
+
+describe("toClaudePermissionNotification", () => {
+  it("maps a permission verdict into the Claude permission notification shape", () => {
+    const result = toClaudePermissionNotification({
+      requestId: "req-1",
+      behavior: "allow",
+    });
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: {
+        method: "notifications/claude/channel/permission",
+        params: {
+          request_id: "req-1",
+          behavior: "allow",
+        },
+      },
+    });
+  });
+
+  it("rejects blank permission request ids", () => {
+    const result = toClaudePermissionNotification({
+      requestId: "   ",
+      behavior: "deny",
+    });
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "PermissionRequestIdInvalid", value: "   " },
+    });
+  });
+});

--- a/test/v2-claude-channel-server.test.ts
+++ b/test/v2-claude-channel-server.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { Notification } from "@modelcontextprotocol/sdk/types.js";
+
+const helperPath = path.join(process.cwd(), "test/helpers/claude-channel-server-entry.ts");
+const bunLookup = spawnSync("which", ["bun"], { encoding: "utf8" });
+const bunCommand = bunLookup.status === 0 ? bunLookup.stdout.trim() : "bun";
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+afterEach(() => {
+  // No-op placeholder so vitest runs the file serially without leaked globals.
+});
+
+describe("bootClaudeChannelServer", () => {
+  it("serves the reply tool, handles tool calls, and emits Claude channel notifications over stdio", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-claude-channel-"));
+    const replyFile = path.join(tempDir, "reply.log");
+    const permissionFile = path.join(tempDir, "permission.log");
+    const notifications: Notification[] = [];
+
+    const client = new Client({ name: "zapbot-test-client", version: "1.0.0" });
+    client.fallbackNotificationHandler = async (notification) => {
+      notifications.push(notification);
+    };
+
+    const transport = new StdioClientTransport({
+      command: bunCommand,
+      args: [helperPath],
+      cwd: process.cwd(),
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        CLAUDE_CHANNEL_REPLY_FILE: replyFile,
+        CLAUDE_CHANNEL_PERMISSION_FILE: permissionFile,
+        CLAUDE_CHANNEL_PUSH_ON_START: "1",
+        CLAUDE_CHANNEL_PERMISSION_VERDICT: "allow",
+      },
+    });
+    let stderr = "";
+    transport.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    try {
+      await client.connect(transport);
+
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toContain("reply");
+
+      const replyResult = await client.callTool({
+        name: "reply",
+        arguments: {
+          conversationId: "conv-test",
+          text: "reply from client",
+        },
+      });
+      expect(replyResult.isError).not.toBe(true);
+
+      await client.notification({
+        method: "notifications/claude/channel/permission_request",
+        params: {
+          request_id: "req-client",
+          tool_name: "bash",
+          description: "Run a shell command",
+          input_preview: "ls -la",
+        },
+      } as never);
+
+      await waitFor(() => fs.existsSync(replyFile) && fs.readFileSync(replyFile, "utf8").includes("conv-test"));
+      await waitFor(
+        () =>
+          notifications.some(
+            (notification) => notification.method === "notifications/claude/channel",
+          ) &&
+          notifications.some(
+            (notification) =>
+              notification.method === "notifications/claude/channel/permission",
+          ) &&
+          fs.existsSync(permissionFile) &&
+          fs.readFileSync(permissionFile, "utf8").includes("req-client"),
+      );
+
+      const replyLog = fs.readFileSync(replyFile, "utf8");
+      expect(replyLog).toContain("\"conversationId\":\"conv-test\"");
+      expect(replyLog).toContain("\"text\":\"reply from client\"");
+
+      const channelNotification = notifications.find(
+        (notification) => notification.method === "notifications/claude/channel",
+      );
+      expect(channelNotification).toBeDefined();
+      expect(channelNotification?.params).toMatchObject({
+        content: "hello from spawned channel server",
+      });
+
+      const permissionNotification = notifications.find(
+        (notification) => notification.method === "notifications/claude/channel/permission",
+      );
+      expect(permissionNotification).toBeDefined();
+      expect(permissionNotification?.params).toMatchObject({
+        request_id: "req-spawned",
+        behavior: "allow",
+      });
+    } catch (cause) {
+      throw new Error(
+        `stdio channel test failed: ${String(cause)}${
+          stderr.length > 0 ? `\nchild stderr:\n${stderr}` : ""
+        }`,
+      );
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+});

--- a/test/v2-moltzap-channel-runtime.test.ts
+++ b/test/v2-moltzap-channel-runtime.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { bootSessionChannelRuntime } from "../v2/moltzap/channel-runtime.ts";
+import { ok, err } from "../v2/types.ts";
+import type { SessionClientHandle } from "../v2/moltzap/session-client.ts";
+import type {
+  ListenerHandle,
+  MoltzapInbound,
+  MoltzapSdkContext,
+  MoltzapSdkHandle,
+} from "../v2/moltzap/types.ts";
+import {
+  asMoltzapConversationId,
+  asMoltzapMessageId,
+  asMoltzapSenderId,
+} from "../v2/moltzap/types.ts";
+
+const sdk = { __brand: "MoltzapSdkHandle" } as MoltzapSdkHandle;
+const sdkContext = { __brand: "MoltzapSdkContext" } as MoltzapSdkContext;
+const listenerHandle = { __brand: "ListenerHandle" } as ListenerHandle;
+
+function makeClient(): SessionClientHandle {
+  return {
+    role: "worker",
+    normalizedServerUrl: "ws://127.0.0.1:41973",
+    sdk,
+    localSenderId: asMoltzapSenderId("worker-1"),
+    orchestratorSenderId: asMoltzapSenderId("orch-1"),
+    close: async () => ok(undefined),
+  };
+}
+
+function makeInbound(): MoltzapInbound {
+  return {
+    messageId: asMoltzapMessageId("msg-1"),
+    conversationId: asMoltzapConversationId("conv-1"),
+    senderId: asMoltzapSenderId("orch-1"),
+    bodyText: "hello",
+    receivedAtMs: 123,
+  };
+}
+
+describe("bootSessionChannelRuntime", () => {
+  it("boots the shared runtime, routes inbound messages, and sends replies once LISTENING", async () => {
+    const inbound: MoltzapInbound[] = [];
+    const outbound: Array<{ conversationId: string; text: string }> = [];
+    let registeredCallback: ((event: unknown) => void) | null = null;
+
+    const runtime = await bootSessionChannelRuntime(makeClient(), {
+      sdkContext,
+      registrar: async (_sdk, cb) => {
+        registeredCallback = cb;
+        return ok(listenerHandle);
+      },
+      sender: async (_ctx, args) => {
+        outbound.push({
+          conversationId: args.conversationId,
+          text: args.text,
+        });
+        return ok(undefined);
+      },
+      onInbound: async (event) => {
+        inbound.push(event);
+        return ok(undefined);
+      },
+      decodeDiag: () => {},
+      bridgeDiag: () => {},
+      now: () => 77,
+    });
+
+    expect(runtime._tag).toBe("Ok");
+    if (runtime._tag !== "Ok") return;
+    expect(runtime.value.state._tag).toBe("LISTENING");
+
+    registeredCallback?.(makeInbound());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(inbound).toHaveLength(1);
+
+    const send = await runtime.value.send({
+      conversationId: asMoltzapConversationId("conv-1"),
+      text: "ack",
+    });
+    expect(send).toEqual({
+      _tag: "Ok",
+      value: { _tag: "Sent", at: 77 },
+    });
+    expect(outbound).toEqual([{ conversationId: "conv-1", text: "ack" }]);
+  });
+
+  it("moves to FAILED if inbound routing rejects", async () => {
+    let registeredCallback: ((event: unknown) => void) | null = null;
+    const runtime = await bootSessionChannelRuntime(makeClient(), {
+      sdkContext,
+      registrar: async (_sdk, cb) => {
+        registeredCallback = cb;
+        return ok(listenerHandle);
+      },
+      sender: async () => ok(undefined),
+      onInbound: async () => err({ _tag: "InboundRouteFailed", cause: "router rejected" }),
+      decodeDiag: () => {},
+      bridgeDiag: () => {},
+    });
+    expect(runtime._tag).toBe("Ok");
+    if (runtime._tag !== "Ok") return;
+
+    registeredCallback?.(makeInbound());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(runtime.value.state._tag).toBe("FAILED");
+  });
+});

--- a/test/v2-moltzap-runtime.test.ts
+++ b/test/v2-moltzap-runtime.test.ts
@@ -122,7 +122,7 @@ describe("moltzap runtime / buildMoltzapSpawnEnv", () => {
 
   it("registers a fresh agent when a registration secret is configured", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ apiKey: "registered-key" }), {
+      new Response(JSON.stringify({ apiKey: "registered-key", agentId: "agent-123" }), {
         status: 201,
         headers: { "Content-Type": "application/json" },
       }),
@@ -141,6 +141,7 @@ describe("moltzap runtime / buildMoltzapSpawnEnv", () => {
       value: {
         MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
         MOLTZAP_API_KEY: "registered-key",
+        MOLTZAP_LOCAL_SENDER_ID: "agent-123",
         MOLTZAP_ALLOWED_SENDERS: "agent-a",
       },
     });

--- a/test/v2-moltzap-session-client.test.ts
+++ b/test/v2-moltzap-session-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  connectSessionClient,
+  loadSessionClientEnv,
+  type SessionClientConnector,
+  type SessionClientEnv,
+} from "../v2/moltzap/session-client.ts";
+import { err, ok } from "../v2/types.ts";
+import type { MoltzapSdkHandle } from "../v2/moltzap/types.ts";
+
+const fakeSdk = { __brand: "MoltzapSdkHandle" } as MoltzapSdkHandle;
+
+describe("loadSessionClientEnv", () => {
+  it("normalizes the ws transport suffix and loads an orchestrator session env", () => {
+    const result = loadSessionClientEnv(
+      {
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973/ws",
+        MOLTZAP_API_KEY: "test-key",
+        MOLTZAP_LOCAL_SENDER_ID: "agent-orchestrator",
+        MOLTZAP_ALLOWED_SENDERS: "agent-a, agent-b ",
+      },
+      "orchestrator",
+    );
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: {
+        role: "orchestrator",
+        serverUrl: "ws://127.0.0.1:41973",
+        apiKey: "test-key",
+        localSenderId: "agent-orchestrator",
+        orchestratorSenderId: null,
+        allowlistCsv: "agent-a,agent-b",
+      },
+    });
+  });
+
+  it("requires the orchestrator sender id for worker sessions", () => {
+    const result = loadSessionClientEnv(
+      {
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973/ws",
+        MOLTZAP_API_KEY: "test-key",
+        MOLTZAP_LOCAL_SENDER_ID: "worker-1",
+      },
+      "worker",
+    );
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "MissingOrchestratorSenderId", role: "worker" },
+    });
+  });
+
+  it("rejects malformed URLs", () => {
+    const result = loadSessionClientEnv(
+      {
+        MOLTZAP_SERVER_URL: "mailto:not-supported",
+        MOLTZAP_API_KEY: "test-key",
+        MOLTZAP_LOCAL_SENDER_ID: "worker-1",
+        MOLTZAP_ORCHESTRATOR_SENDER_ID: "orch-1",
+      },
+      "worker",
+    );
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "InvalidServerUrl", value: "mailto:not-supported" },
+    });
+  });
+});
+
+describe("connectSessionClient", () => {
+  const env: SessionClientEnv = {
+    role: "worker",
+    serverUrl: "ws://127.0.0.1:41973",
+    apiKey: "test-key",
+    localSenderId: "worker-1" as never,
+    orchestratorSenderId: "orch-1" as never,
+    allowlistCsv: null,
+  };
+
+  it("wraps the connector result in a session handle", async () => {
+    let disconnected = false;
+    const connector: SessionClientConnector = {
+      connect: async () => ok(fakeSdk),
+      disconnect: async () => {
+        disconnected = true;
+        return ok(undefined);
+      },
+    };
+    const result = await connectSessionClient(env, connector);
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value.normalizedServerUrl).toBe("ws://127.0.0.1:41973");
+    const closed = await result.value.close();
+    expect(closed).toEqual({ _tag: "Ok", value: undefined });
+    expect(disconnected).toBe(true);
+  });
+
+  it("surfaces connector failures as typed errors", async () => {
+    const connector: SessionClientConnector = {
+      connect: async () => err({ _tag: "ConnectFailed", cause: "socket closed" }),
+      disconnect: async () => ok(undefined),
+    };
+    const result = await connectSessionClient(env, connector);
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "ConnectFailed", cause: "socket closed" },
+    });
+  });
+});

--- a/test/v2-orchestrator-control-event.test.ts
+++ b/test/v2-orchestrator-control-event.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { toOrchestratorControlPrompt } from "../v2/orchestrator/control-event.ts";
+import {
+  asCommentId,
+  asDeliveryId,
+  asIssueNumber,
+  asProjectName,
+  asRepoFullName,
+} from "../v2/types.ts";
+
+describe("toOrchestratorControlPrompt", () => {
+  it("renders the raw GitHub comment into a durable orchestrator prompt", () => {
+    const result = toOrchestratorControlPrompt({
+      _tag: "GitHubControlEvent",
+      repo: asRepoFullName("acme/app"),
+      projectName: asProjectName("app"),
+      issue: asIssueNumber(42),
+      commentId: asCommentId(77),
+      deliveryId: asDeliveryId("delivery-1"),
+      commentBody: "@zapbot please review the open work and decide the next step",
+      triggeredBy: "carol",
+    });
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value.title).toContain("acme/app#42");
+    expect(result.value.body).toContain("github_comment_body:");
+    expect(result.value.body).toContain("please review the open work");
+  });
+
+  it("rejects blank GitHub comments", () => {
+    const result = toOrchestratorControlPrompt({
+      _tag: "GitHubControlEvent",
+      repo: asRepoFullName("acme/app"),
+      projectName: asProjectName("app"),
+      issue: asIssueNumber(42),
+      commentId: asCommentId(77),
+      deliveryId: asDeliveryId("delivery-1"),
+      commentBody: "   ",
+      triggeredBy: "carol",
+    });
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "PromptShapeInvalid", reason: "commentBody must be a non-empty string" },
+    });
+  });
+});

--- a/test/v2-orchestrator-runtime.test.ts
+++ b/test/v2-orchestrator-runtime.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  ensureProjectOrchestrator,
+  forwardControlPrompt,
+  type AoControlHost,
+} from "../v2/orchestrator/runtime.ts";
+import { asAoSessionName, asProjectName, err, ok } from "../v2/types.ts";
+import { asMoltzapSenderId } from "../v2/moltzap/types.ts";
+
+describe("ensureProjectOrchestrator", () => {
+  it("starts and resolves the persistent orchestrator", async () => {
+    const calls: string[] = [];
+    const host: AoControlHost = {
+      ensureStarted: async () => {
+        calls.push("ensureStarted");
+        return ok(undefined);
+      },
+      resolveReady: async () => {
+        calls.push("resolveReady");
+        return ok({
+          session: asAoSessionName("app-orchestrator"),
+          senderId: asMoltzapSenderId("orch-1"),
+          mode: "started",
+        });
+      },
+      sendPrompt: async () => ok(undefined),
+    };
+    const result = await ensureProjectOrchestrator(asProjectName("app"), host);
+    expect(result._tag).toBe("Ok");
+    expect(calls).toEqual(["ensureStarted", "resolveReady"]);
+  });
+});
+
+describe("forwardControlPrompt", () => {
+  it("sends the rendered prompt to the ready orchestrator session", async () => {
+    const sent: Array<{ session: string; title: string }> = [];
+    const host: AoControlHost = {
+      ensureStarted: async () => ok(undefined),
+      resolveReady: async () =>
+        ok({
+          session: asAoSessionName("app-orchestrator"),
+          senderId: asMoltzapSenderId("orch-1"),
+          mode: "reused",
+        }),
+      sendPrompt: async (session, prompt) => {
+        sent.push({ session, title: prompt.title });
+        return ok(undefined);
+      },
+    };
+    const result = await forwardControlPrompt(
+      asProjectName("app"),
+      { title: "hello", body: "body" },
+      host,
+    );
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: {
+        session: "app-orchestrator",
+        senderId: "orch-1",
+      },
+    });
+    expect(sent).toEqual([{ session: "app-orchestrator", title: "hello" }]);
+  });
+
+  it("bubbles AoSendFailed as a typed error", async () => {
+    const host: AoControlHost = {
+      ensureStarted: async () => ok(undefined),
+      resolveReady: async () =>
+        ok({
+          session: asAoSessionName("app-orchestrator"),
+          senderId: asMoltzapSenderId("orch-1"),
+          mode: "reused",
+        }),
+      sendPrompt: async () => err({ _tag: "AoSendFailed", cause: "pipe closed" }),
+    };
+    const result = await forwardControlPrompt(
+      asProjectName("app"),
+      { title: "hello", body: "body" },
+      host,
+    );
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "AoSendFailed", cause: "pipe closed" },
+    });
+  });
+});

--- a/v2/ao/claude-channel-launch.ts
+++ b/v2/ao/claude-channel-launch.ts
@@ -1,0 +1,145 @@
+/**
+ * v2/ao/claude-channel-launch — plan the Claude Code launch flags and
+ * session-local MCP config needed to activate a MoltZap-backed custom channel.
+ *
+ * Architect phase only: public surface, no implementation.
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+
+export type ClaudeChannelEntry =
+  | { readonly _tag: "DevelopmentServer"; readonly serverName: string }
+  | {
+      readonly _tag: "ApprovedPlugin";
+      readonly pluginName: string;
+      readonly marketplace: string;
+    };
+
+export interface SessionMcpServerConfig {
+  readonly name: string;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly env: Readonly<Record<string, string>>;
+}
+
+export interface ClaudeChannelLaunchPlan {
+  readonly mcpConfigPath: string;
+  readonly mcpConfigJson: string;
+  readonly extraArgs: readonly string[];
+  readonly entry: ClaudeChannelEntry;
+}
+
+export type ClaudeChannelLaunchPlanError =
+  | { readonly _tag: "InvalidServerName"; readonly value: string }
+  | { readonly _tag: "InvalidPluginReference"; readonly value: string }
+  | { readonly _tag: "McpConfigInvalid"; readonly reason: string };
+
+/**
+ * Render the session-local MCP config JSON Claude Code will consume through
+ * `--mcp-config`.
+ */
+export function renderSessionMcpConfig(
+  server: SessionMcpServerConfig,
+): Result<string, Extract<ClaudeChannelLaunchPlanError, { readonly _tag: "McpConfigInvalid" }>> {
+  if (server.command.trim().length === 0) {
+    return err({ _tag: "McpConfigInvalid", reason: "server.command must be a non-empty string" });
+  }
+  if (server.args.some((arg) => arg.trim().length === 0)) {
+    return err({ _tag: "McpConfigInvalid", reason: "server.args must not contain empty strings" });
+  }
+  const invalidEnvKey = Object.entries(server.env).find(
+    ([key, value]) => key.trim().length === 0 || value.trim().length === 0,
+  );
+  if (invalidEnvKey !== undefined) {
+    return err({
+      _tag: "McpConfigInvalid",
+      reason: `server.env contains an invalid entry for ${invalidEnvKey[0] || "<empty>"}`,
+    });
+  }
+  return ok(
+    JSON.stringify(
+      {
+        mcpServers: {
+          [server.name]: {
+            command: server.command,
+            args: [...server.args],
+            env: { ...server.env },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+/**
+ * Produce the exact Claude CLI flags needed to activate either a development
+ * server channel entry or an allowlisted plugin channel entry for this session.
+ */
+export function planClaudeChannelLaunch(input: {
+  readonly server: SessionMcpServerConfig;
+  readonly entry: ClaudeChannelEntry;
+  readonly mcpConfigPath: string;
+}): Result<ClaudeChannelLaunchPlan, ClaudeChannelLaunchPlanError> {
+  if (!isValidEntryName(input.server.name)) {
+    return err({ _tag: "InvalidServerName", value: input.server.name });
+  }
+  if (input.mcpConfigPath.trim().length === 0) {
+    return err({ _tag: "McpConfigInvalid", reason: "mcpConfigPath must be a non-empty string" });
+  }
+  const mcpConfigJson = renderSessionMcpConfig(input.server);
+  if (mcpConfigJson._tag === "Err") {
+    return mcpConfigJson;
+  }
+  const entryArgs = toEntryArgs(input.entry, input.server.name);
+  if (entryArgs._tag === "Err") {
+    return entryArgs;
+  }
+  return ok({
+    mcpConfigPath: input.mcpConfigPath,
+    mcpConfigJson: mcpConfigJson.value,
+    extraArgs: ["--mcp-config", input.mcpConfigPath, ...entryArgs.value],
+    entry: input.entry,
+  });
+}
+
+function toEntryArgs(
+  entry: ClaudeChannelEntry,
+  serverName: string,
+): Result<readonly string[], Extract<ClaudeChannelLaunchPlanError, { readonly _tag: "InvalidPluginReference" | "InvalidServerName" | "McpConfigInvalid" }>> {
+  switch (entry._tag) {
+    case "DevelopmentServer":
+      if (!isValidEntryName(entry.serverName)) {
+        return err({ _tag: "InvalidServerName", value: entry.serverName });
+      }
+      if (entry.serverName !== serverName) {
+        return err({
+          _tag: "McpConfigInvalid",
+          reason: `development entry server name ${entry.serverName} must match MCP server ${serverName}`,
+        });
+      }
+      return ok([
+        "--dangerously-load-development-channels",
+        `server:${entry.serverName}`,
+      ]);
+    case "ApprovedPlugin": {
+      const pluginRef = `${entry.pluginName}@${entry.marketplace}`;
+      if (!isValidEntryName(entry.pluginName) || !isValidEntryName(entry.marketplace)) {
+        return err({ _tag: "InvalidPluginReference", value: pluginRef });
+      }
+      return ok(["--channels", `plugin:${pluginRef}`]);
+    }
+    default:
+      return absurd(entry);
+  }
+}
+
+function isValidEntryName(value: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(value);
+}
+
+function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}

--- a/v2/claude-channel/event.ts
+++ b/v2/claude-channel/event.ts
@@ -1,0 +1,120 @@
+/**
+ * v2/claude-channel/event — shape MoltZap traffic into Claude Code's official
+ * channel notification contract.
+ *
+ * Architect phase only: public surface, no implementation.
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type {
+  MoltzapConversationId,
+  MoltzapInbound,
+  MoltzapMessageId,
+  MoltzapSenderId,
+} from "../moltzap/types.ts";
+
+export interface ClaudeChannelNotification {
+  readonly method: "notifications/claude/channel";
+  readonly params: {
+    readonly content: string;
+    readonly meta: {
+      readonly conversation_id: MoltzapConversationId;
+      readonly sender_id: MoltzapSenderId;
+      readonly message_id: MoltzapMessageId;
+      readonly received_at_ms: string;
+    };
+  };
+}
+
+export interface ClaudePermissionVerdict {
+  readonly requestId: string;
+  readonly behavior: "allow" | "deny";
+}
+
+export interface ClaudeChannelPermissionNotification {
+  readonly method: "notifications/claude/channel/permission";
+  readonly params: {
+    readonly request_id: string;
+    readonly behavior: ClaudePermissionVerdict["behavior"];
+  };
+}
+
+export type ClaudeChannelEventShapeError =
+  | { readonly _tag: "ContentEmpty" }
+  | { readonly _tag: "MetaInvalid"; readonly reason: string }
+  | { readonly _tag: "PermissionRequestIdInvalid"; readonly value: string };
+
+/**
+ * Convert a decoded MoltZap inbound message into the notification shape Claude
+ * Code expects for a custom channel server.
+ */
+export function toClaudeChannelNotification(
+  event: MoltzapInbound,
+): Result<ClaudeChannelNotification, ClaudeChannelEventShapeError> {
+  if (event.bodyText.trim().length === 0) {
+    return err({ _tag: "ContentEmpty" });
+  }
+  const metaError = validateInboundMeta(event);
+  if (metaError !== null) {
+    return err(metaError);
+  }
+  return ok({
+    method: "notifications/claude/channel",
+    params: {
+      content: event.bodyText,
+      meta: {
+        conversation_id: event.conversationId,
+        sender_id: event.senderId,
+        message_id: event.messageId,
+        received_at_ms: String(event.receivedAtMs),
+      },
+    },
+  });
+}
+
+/**
+ * Convert a parsed remote allow/deny verdict into Claude Code's permission
+ * relay notification shape.
+ */
+export function toClaudePermissionNotification(
+  verdict: ClaudePermissionVerdict,
+): Result<ClaudeChannelPermissionNotification, ClaudeChannelEventShapeError> {
+  if (verdict.requestId.trim().length === 0) {
+    return err({
+      _tag: "PermissionRequestIdInvalid",
+      value: verdict.requestId,
+    });
+  }
+  return ok({
+    method: "notifications/claude/channel/permission",
+    params: {
+      request_id: verdict.requestId.trim(),
+      behavior: verdict.behavior,
+    },
+  });
+}
+
+function validateInboundMeta(
+  event: MoltzapInbound,
+): Extract<ClaudeChannelEventShapeError, { readonly _tag: "MetaInvalid" }> | null {
+  if (!isNonEmptyBrand(event.conversationId)) {
+    return { _tag: "MetaInvalid", reason: "conversation_id must be a non-empty string" };
+  }
+  if (!isNonEmptyBrand(event.senderId)) {
+    return { _tag: "MetaInvalid", reason: "sender_id must be a non-empty string" };
+  }
+  if (!isNonEmptyBrand(event.messageId)) {
+    return { _tag: "MetaInvalid", reason: "message_id must be a non-empty string" };
+  }
+  if (!Number.isFinite(event.receivedAtMs) || event.receivedAtMs < 0) {
+    return { _tag: "MetaInvalid", reason: "received_at_ms must be a non-negative finite number" };
+  }
+  return null;
+}
+
+function isNonEmptyBrand(
+  value: MoltzapConversationId | MoltzapSenderId | MoltzapMessageId,
+): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}

--- a/v2/claude-channel/server.ts
+++ b/v2/claude-channel/server.ts
@@ -1,0 +1,369 @@
+/**
+ * v2/claude-channel/server — session-local MCP server that exposes the
+ * official Claude Code channel contract over stdio.
+ *
+ * Architect phase only: public surface, no implementation.
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type { MoltzapConversationId } from "../moltzap/types.ts";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Notification, Result as McpResult, Request } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+  type ListToolsResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import type {
+  ClaudeChannelNotification,
+  ClaudeChannelPermissionNotification,
+} from "./event.ts";
+
+export interface ClaudeChannelReplyArgs {
+  readonly conversationId: MoltzapConversationId;
+  readonly text: string;
+}
+
+export interface ClaudePermissionRequest {
+  readonly requestId: string;
+  readonly toolName: string;
+  readonly description: string;
+  readonly inputPreview: string;
+}
+
+export interface ClaudeChannelServerConfig {
+  readonly serverName: string;
+  readonly instructions: string;
+  readonly enableReplyTool: boolean;
+  readonly enablePermissionRelay: boolean;
+}
+
+export interface ClaudeChannelServerDeps {
+  readonly sendReply: (
+    args: ClaudeChannelReplyArgs,
+  ) => Promise<Result<void, ClaudeChannelReplyError>>;
+  readonly forwardPermissionRequest?: (
+    request: ClaudePermissionRequest,
+  ) => Promise<Result<void, ClaudeChannelPermissionRequestError>>;
+}
+
+export interface ClaudeChannelServerHandle {
+  readonly push: (
+    notification: ClaudeChannelNotification,
+  ) => Promise<Result<void, ClaudeChannelEmitError>>;
+  readonly pushPermissionVerdict: (
+    notification: ClaudeChannelPermissionNotification,
+  ) => Promise<Result<void, ClaudeChannelEmitError>>;
+  readonly stop: () => Promise<Result<void, ClaudeChannelStopError>>;
+}
+
+export type ClaudeChannelServerBootError =
+  | { readonly _tag: "StdioConnectFailed"; readonly cause: string }
+  | { readonly _tag: "ReplyToolRegistrationFailed"; readonly cause: string }
+  | {
+      readonly _tag: "PermissionRelayRegistrationFailed";
+      readonly cause: string;
+    };
+
+export type ClaudeChannelEmitError = {
+  readonly _tag: "EmitFailed";
+  readonly cause: string;
+};
+
+export type ClaudeChannelReplyError = {
+  readonly _tag: "ReplyFailed";
+  readonly cause: string;
+};
+
+export type ClaudeChannelPermissionRequestError = {
+  readonly _tag: "PermissionRequestForwardFailed";
+  readonly cause: string;
+};
+
+export type ClaudeChannelStopError = {
+  readonly _tag: "StopFailed";
+  readonly cause: string;
+};
+
+/**
+ * Boot the session-local MCP server that Claude Code treats as a custom
+ * channel during research-preview development mode.
+ */
+export async function bootClaudeChannelServer(
+  config: ClaudeChannelServerConfig,
+  deps: ClaudeChannelServerDeps,
+): Promise<Result<ClaudeChannelServerHandle, ClaudeChannelServerBootError>> {
+  if (config.enablePermissionRelay && deps.forwardPermissionRequest === undefined) {
+    return err({
+      _tag: "PermissionRelayRegistrationFailed",
+      cause: "forwardPermissionRequest is required when permission relay is enabled",
+    });
+  }
+
+  const server = new Server<Request, Notification, McpResult>(
+    {
+      name: config.serverName,
+      version: "0.3.0",
+    },
+    {
+      capabilities: {
+        tools: config.enableReplyTool ? {} : undefined,
+        experimental: {
+          "claude/channel": {},
+          ...(config.enablePermissionRelay ? { "claude/channel/permission": {} } : {}),
+        },
+      },
+      instructions: config.instructions,
+    },
+  );
+  let initialized = false;
+  const pendingNotifications: Notification[] = [];
+  server.oninitialized = () => {
+    initialized = true;
+    void flushPendingNotifications(server, pendingNotifications);
+  };
+
+  try {
+    server.setRequestHandler(ListToolsRequestSchema, async () => listTools(config.enableReplyTool));
+    server.setRequestHandler(CallToolRequestSchema, async (request) =>
+      handleToolCall(request.params.name, request.params.arguments, config, deps),
+    );
+  } catch (cause) {
+    return err({
+      _tag: "ReplyToolRegistrationFailed",
+      cause: stringifyCause(cause),
+    });
+  }
+
+  server.fallbackNotificationHandler = async (notification) => {
+    if (!config.enablePermissionRelay || notification.method !== PERMISSION_REQUEST_METHOD) {
+      return;
+    }
+    const parsed = parsePermissionRequest(notification);
+    if (parsed === null) {
+      return;
+    }
+    const forwarded = await deps.forwardPermissionRequest!(parsed);
+    if (forwarded._tag === "Err") {
+      throw new Error(forwarded.error.cause);
+    }
+  };
+
+  const transport = new StdioServerTransport();
+  try {
+    await server.connect(transport);
+  } catch (cause) {
+    return err({
+      _tag: "StdioConnectFailed",
+      cause: stringifyCause(cause),
+    });
+  }
+
+  return ok({
+    push: async (notification) => {
+      try {
+        await emitNotification(server, notification as unknown as Notification, {
+          initialized,
+          pendingNotifications,
+        });
+        return ok(undefined);
+      } catch (cause) {
+        return err({ _tag: "EmitFailed", cause: stringifyCause(cause) });
+      }
+    },
+    pushPermissionVerdict: async (notification) => {
+      if (!config.enablePermissionRelay) {
+        return err({
+          _tag: "EmitFailed",
+          cause: "permission relay is disabled for this channel server",
+        });
+      }
+      try {
+        await emitNotification(server, notification as unknown as Notification, {
+          initialized,
+          pendingNotifications,
+        });
+        return ok(undefined);
+      } catch (cause) {
+        return err({ _tag: "EmitFailed", cause: stringifyCause(cause) });
+      }
+    },
+    stop: async () => {
+      try {
+        await server.close();
+        return ok(undefined);
+      } catch (cause) {
+        return err({ _tag: "StopFailed", cause: stringifyCause(cause) });
+      }
+    },
+  });
+}
+
+const REPLY_TOOL_NAME = "reply";
+const PERMISSION_REQUEST_METHOD = "notifications/claude/channel/permission_request";
+
+function listTools(enableReplyTool: boolean): ListToolsResult {
+  return {
+    tools: enableReplyTool
+      ? [
+          {
+            name: REPLY_TOOL_NAME,
+            description: "Reply into the active MoltZap conversation for this Claude channel.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                conversationId: {
+                  type: "string",
+                  description: "Conversation ID to send the reply into.",
+                },
+                text: {
+                  type: "string",
+                  description: "Reply text to send back over MoltZap.",
+                },
+              },
+              required: ["conversationId", "text"],
+            },
+            annotations: {
+              title: "Reply",
+              readOnlyHint: false,
+              destructiveHint: false,
+              idempotentHint: false,
+              openWorldHint: true,
+            },
+          },
+        ]
+      : [],
+  };
+}
+
+async function handleToolCall(
+  name: string,
+  args: Record<string, unknown> | undefined,
+  config: ClaudeChannelServerConfig,
+  deps: ClaudeChannelServerDeps,
+): Promise<CallToolResult> {
+  if (!config.enableReplyTool) {
+    return toolError("reply tool is disabled");
+  }
+  if (name !== REPLY_TOOL_NAME) {
+    return toolError(`unknown tool: ${name}`);
+  }
+  const parsed = parseReplyArgs(args);
+  if (parsed === null) {
+    return toolError("reply requires string conversationId and non-empty text");
+  }
+  const sent = await deps.sendReply(parsed);
+  if (sent._tag === "Err") {
+    return toolError(sent.error.cause);
+  }
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Reply sent to conversation ${parsed.conversationId as string}.`,
+      },
+    ],
+  };
+}
+
+function parseReplyArgs(
+  args: Record<string, unknown> | undefined,
+): ClaudeChannelReplyArgs | null {
+  if (args === undefined) {
+    return null;
+  }
+  const conversationId =
+    typeof args.conversationId === "string"
+      ? args.conversationId
+      : typeof args.conversation_id === "string"
+        ? args.conversation_id
+        : null;
+  const text = typeof args.text === "string" ? args.text : null;
+  if (conversationId === null || conversationId.trim().length === 0) {
+    return null;
+  }
+  if (text === null || text.trim().length === 0) {
+    return null;
+  }
+  return {
+    conversationId: conversationId as MoltzapConversationId,
+    text,
+  };
+}
+
+function parsePermissionRequest(notification: Notification): ClaudePermissionRequest | null {
+  if (typeof notification.params !== "object" || notification.params === null) {
+    return null;
+  }
+  const params = notification.params as Record<string, unknown>;
+  const requestId =
+    typeof params.request_id === "string"
+      ? params.request_id
+      : typeof params.requestId === "string"
+        ? params.requestId
+        : null;
+  const toolName =
+    typeof params.tool_name === "string"
+      ? params.tool_name
+      : typeof params.toolName === "string"
+        ? params.toolName
+        : null;
+  const description = typeof params.description === "string" ? params.description : "";
+  const inputPreview =
+    typeof params.input_preview === "string"
+      ? params.input_preview
+      : typeof params.inputPreview === "string"
+        ? params.inputPreview
+        : "";
+  if (requestId === null || requestId.trim().length === 0 || toolName === null || toolName.trim().length === 0) {
+    return null;
+  }
+  return {
+    requestId,
+    toolName,
+    description,
+    inputPreview,
+  };
+}
+
+function toolError(message: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: "text", text: message }],
+  };
+}
+
+function stringifyCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+async function emitNotification(
+  server: Server<Request, Notification, McpResult>,
+  notification: Notification,
+  state: {
+    readonly initialized: boolean;
+    readonly pendingNotifications: Notification[];
+  },
+): Promise<void> {
+  if (!state.initialized) {
+    state.pendingNotifications.push(notification);
+    return;
+  }
+  await server.notification(notification);
+}
+
+async function flushPendingNotifications(
+  server: Server<Request, Notification, McpResult>,
+  pendingNotifications: Notification[],
+): Promise<void> {
+  while (pendingNotifications.length > 0) {
+    const notification = pendingNotifications.shift();
+    if (notification === undefined) {
+      return;
+    }
+    await server.notification(notification);
+  }
+}

--- a/v2/moltzap/channel-runtime.ts
+++ b/v2/moltzap/channel-runtime.ts
@@ -1,0 +1,240 @@
+/**
+ * v2/moltzap/channel-runtime — bind a connected session client to the existing
+ * lifecycle, listener, and bridge modules.
+ *
+ * Architect phase only: public surface, no implementation.
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type {
+  DiagnosticSink,
+  MoltzapSender,
+  ReplyArgs,
+  ReplyReceipt,
+} from "./bridge.ts";
+import { reply } from "./bridge.ts";
+import type { LifecycleState, ListenerRegistrationError } from "./lifecycle.ts";
+import { INITIAL, transition } from "./lifecycle.ts";
+import type { DecodeErrorSink, MoltzapRegistrar } from "./listener.ts";
+import { register } from "./listener.ts";
+import type { SessionClientHandle } from "./session-client.ts";
+import type {
+  ListenerHandle,
+  MoltzapConversationId,
+  MoltzapInbound,
+  MoltzapSdkContext,
+  MoltzapSenderId,
+} from "./types.ts";
+
+export interface SessionChannelHandle {
+  readonly role: SessionClientHandle["role"];
+  readonly localSenderId: MoltzapSenderId;
+  readonly state: LifecycleState;
+  readonly stop: () => Promise<Result<void, ChannelRuntimeStopError>>;
+  readonly send: (args: ReplyArgs) => Promise<Result<ReplyReceipt, ChannelRuntimeSendError>>;
+}
+
+export interface SessionChannelDeps {
+  readonly sdkContext: MoltzapSdkContext;
+  readonly registrar: MoltzapRegistrar;
+  readonly sender: MoltzapSender;
+  readonly onInbound: (
+    event: MoltzapInbound,
+  ) => Promise<Result<void, Extract<ChannelRuntimeStartError, { readonly _tag: "InboundRouteFailed" }>>>;
+  readonly decodeDiag: DecodeErrorSink;
+  readonly bridgeDiag: DiagnosticSink;
+  readonly now?: () => number;
+}
+
+export interface DirectMessage {
+  readonly peer: MoltzapSenderId;
+  readonly conversationId: MoltzapConversationId | null;
+  readonly text: string;
+}
+
+export type ChannelRuntimeStartError =
+  | { readonly _tag: "ListenerRejected"; readonly cause: ListenerRegistrationError }
+  | { readonly _tag: "LifecycleFailed"; readonly reason: string }
+  | { readonly _tag: "InboundRouteFailed"; readonly cause: string };
+
+export type ChannelRuntimeSendError =
+  | { readonly _tag: "NotListening"; readonly state: LifecycleState }
+  | { readonly _tag: "OutboundFailed"; readonly cause: string };
+
+export type ChannelRuntimeStopError = {
+  readonly _tag: "StopFailed";
+  readonly cause: string;
+};
+
+/**
+ * Start the shared MoltZap channel runtime for either an orchestrator or a
+ * worker AO session.
+ */
+export async function bootSessionChannelRuntime(
+  client: SessionClientHandle,
+  deps: SessionChannelDeps,
+): Promise<Result<SessionChannelHandle, ChannelRuntimeStartError>> {
+  let currentState: LifecycleState = INITIAL;
+  const advancedToStdio = advance(currentState, { _tag: "StdioConnectStarted" });
+  if (advancedToStdio._tag === "Err") {
+    return advancedToStdio;
+  }
+  currentState = advancedToStdio.value;
+  const stdioReady = advance(currentState, { _tag: "StdioConnected" });
+  if (stdioReady._tag === "Err") {
+    return stdioReady;
+  }
+  currentState = stdioReady.value;
+  const moltzapConnecting = advance(currentState, { _tag: "MoltzapConnectStarted" });
+  if (moltzapConnecting._tag === "Err") {
+    return moltzapConnecting;
+  }
+  currentState = moltzapConnecting.value;
+  const moltzapReady = advance(currentState, { _tag: "MoltzapReady" });
+  if (moltzapReady._tag === "Err") {
+    return moltzapReady;
+  }
+  currentState = moltzapReady.value;
+
+  const listener = await register(
+    currentState,
+    client.sdk,
+    (event) => {
+      void routeInbound(event);
+    },
+    deps.registrar,
+    deps.decodeDiag,
+  );
+  if (listener._tag === "Err") {
+    const failedState = advance(currentState, {
+      _tag: "ListenerFailed",
+      cause: listener.error,
+    });
+    if (failedState._tag === "Ok") {
+      currentState = failedState.value;
+    }
+    return err({ _tag: "ListenerRejected", cause: listener.error });
+  }
+
+  const listening = advance(currentState, {
+    _tag: "ListenerRegistered",
+    handle: listener.value,
+  });
+  if (listening._tag === "Err") {
+    return listening;
+  }
+  currentState = listening.value;
+
+  async function routeInbound(
+    event: MoltzapInbound,
+  ): Promise<void> {
+    try {
+      const result = await deps.onInbound(event);
+      if (result._tag === "Err") {
+        currentState = {
+          _tag: "FAILED",
+          cause: {
+            _tag: "TransportConnectError",
+            cause: result.error.cause,
+          },
+        };
+      }
+    } catch (cause) {
+      currentState = {
+        _tag: "FAILED",
+        cause: {
+          _tag: "TransportConnectError",
+          cause: stringifyCause(cause),
+        },
+      };
+    }
+  }
+
+  return ok({
+    role: client.role,
+    localSenderId: client.localSenderId,
+    get state() {
+      return currentState;
+    },
+    stop: async () => {
+      const draining = transition(currentState, {
+        _tag: "DrainRequested",
+        reason: { _tag: "SigTerm" },
+      });
+      if (draining._tag === "Next") {
+        currentState = draining.state;
+      }
+      const closed = await client.close();
+      if (closed._tag === "Err") {
+        return err({ _tag: "StopFailed", cause: closed.error.cause });
+      }
+      const stopped = transition(currentState, { _tag: "Stopped" });
+      if (stopped._tag === "Illegal") {
+        currentState = { _tag: "STOPPED" };
+      } else {
+        currentState = stopped.state;
+      }
+      return ok(undefined);
+    },
+    send: async (args) => {
+      const result = await reply(
+        currentState,
+        args,
+        deps.sdkContext,
+        deps.sender,
+        deps.now,
+      );
+      if (result._tag === "Err") {
+        switch (result.error._tag) {
+          case "NotListening":
+            return err({
+              _tag: "NotListening",
+              state: result.error.state,
+            });
+          case "OutboundFailed":
+            return err({
+              _tag: "OutboundFailed",
+              cause: stringifyCause(result.error.cause),
+            });
+          case "PreReadyEventDropped":
+            return err({
+              _tag: "OutboundFailed",
+              cause: "outbound send attempted before runtime reached LISTENING",
+            });
+          default:
+            return absurd(result.error);
+        }
+      }
+      return ok(result.value);
+    },
+  });
+}
+
+function advance(
+  state: LifecycleState,
+  event:
+    | { readonly _tag: "StdioConnectStarted" }
+    | { readonly _tag: "StdioConnected" }
+    | { readonly _tag: "MoltzapConnectStarted" }
+    | { readonly _tag: "MoltzapReady" }
+    | { readonly _tag: "ListenerRegistered"; readonly handle: ListenerHandle }
+    | { readonly _tag: "ListenerFailed"; readonly cause: ListenerRegistrationError },
+): Result<LifecycleState, Extract<ChannelRuntimeStartError, { readonly _tag: "LifecycleFailed" }>> {
+  const next = transition(state, event);
+  if (next._tag === "Illegal") {
+    return err({
+      _tag: "LifecycleFailed",
+      reason: `illegal lifecycle transition ${state._tag} -> ${event._tag}`,
+    });
+  }
+  return ok(next.state);
+}
+
+function stringifyCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}

--- a/v2/moltzap/runtime.ts
+++ b/v2/moltzap/runtime.ts
@@ -118,6 +118,7 @@ export async function buildMoltzapSpawnEnv(
 
 interface RegistrationResponse {
   readonly apiKey: string;
+  readonly agentId: string;
 }
 
 async function registerSessionAgent(
@@ -168,30 +169,43 @@ async function registerSessionAgent(
   if (apiKey === null) {
     return err({
       _tag: "MoltzapProvisionFailed",
-      cause: "registration response missing string apiKey.",
+      cause: "registration response missing string apiKey or agentId.",
     });
   }
 
-  return ok(toSpawnEnv(config.serverUrl, apiKey, config.allowlistCsv));
+  return ok(toSpawnEnv(config.serverUrl, apiKey.apiKey, config.allowlistCsv, apiKey.agentId));
 }
 
-function decodeRegistrationResponse(payload: unknown): string | null {
+function decodeRegistrationResponse(
+  payload: unknown,
+): { readonly apiKey: string; readonly agentId: string } | null {
   if (payload === null || typeof payload !== "object") {
     return null;
   }
-  const candidate = (payload as RegistrationResponse).apiKey;
-  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
+  const apiKey = (payload as RegistrationResponse).apiKey;
+  const agentId = (payload as RegistrationResponse).agentId;
+  if (typeof apiKey !== "string" || apiKey.length === 0) {
+    return null;
+  }
+  if (typeof agentId !== "string" || agentId.length === 0) {
+    return null;
+  }
+  return { apiKey, agentId };
 }
 
 function toSpawnEnv(
   serverUrl: string,
   apiKey: string,
   allowlistCsv: string | null,
+  localSenderId?: string,
 ): Record<string, string> {
   const env: Record<string, string> = {
     MOLTZAP_SERVER_URL: serverUrl,
     MOLTZAP_API_KEY: apiKey,
   };
+  if (typeof localSenderId === "string" && localSenderId.length > 0) {
+    env.MOLTZAP_LOCAL_SENDER_ID = localSenderId;
+  }
   if (allowlistCsv !== null) {
     env.MOLTZAP_ALLOWED_SENDERS = allowlistCsv;
   }

--- a/v2/moltzap/session-client.ts
+++ b/v2/moltzap/session-client.ts
@@ -1,0 +1,163 @@
+/**
+ * v2/moltzap/session-client — load `MOLTZAP_*` env inside an AO session and
+ * connect an authenticated MoltZap client.
+ *
+ * Architect phase only: public surface, no implementation.
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type { MoltzapSdkHandle, MoltzapSenderId } from "./types.ts";
+import { asMoltzapSenderId } from "./types.ts";
+
+export type SessionRole = "orchestrator" | "worker";
+
+export interface SessionClientEnv {
+  readonly role: SessionRole;
+  readonly serverUrl: string;
+  readonly apiKey: string;
+  readonly localSenderId: MoltzapSenderId;
+  readonly orchestratorSenderId: MoltzapSenderId | null;
+  readonly allowlistCsv: string | null;
+}
+
+export interface SessionClientHandle {
+  readonly role: SessionRole;
+  readonly normalizedServerUrl: string;
+  readonly sdk: MoltzapSdkHandle;
+  readonly localSenderId: MoltzapSenderId;
+  readonly orchestratorSenderId: MoltzapSenderId | null;
+  readonly close: () => Promise<Result<void, SessionClientDisconnectError>>;
+}
+
+export interface SessionClientConnector {
+  readonly connect: (
+    env: SessionClientEnv,
+  ) => Promise<Result<MoltzapSdkHandle, Extract<SessionClientConnectError, { readonly _tag: "ConnectFailed" }>>>;
+  readonly disconnect: (
+    sdk: MoltzapSdkHandle,
+  ) => Promise<Result<void, SessionClientDisconnectError>>;
+}
+
+export type SessionClientConfigError =
+  | { readonly _tag: "MissingServerUrl" }
+  | { readonly _tag: "MissingApiKey" }
+  | { readonly _tag: "MissingLocalSenderId" }
+  | { readonly _tag: "MissingOrchestratorSenderId"; readonly role: "worker" }
+  | { readonly _tag: "InvalidServerUrl"; readonly value: string };
+
+export type SessionClientConnectError =
+  | { readonly _tag: "ConnectFailed"; readonly cause: string }
+  | { readonly _tag: "IdentityUnavailable"; readonly reason: string };
+
+export type SessionClientDisconnectError = {
+  readonly _tag: "DisconnectFailed";
+  readonly cause: string;
+};
+
+/**
+ * Decode the role-specific `MOLTZAP_*` environment for the current AO session.
+ * `serverUrl` is the base client URL, not the `/ws` transport suffix.
+ */
+export function loadSessionClientEnv(
+  env: Record<string, string | undefined>,
+  role: SessionRole,
+): Result<SessionClientEnv, SessionClientConfigError> {
+  const serverUrl = normalizeEnvVar(env.MOLTZAP_SERVER_URL);
+  if (serverUrl === null) {
+    return err({ _tag: "MissingServerUrl" });
+  }
+  const normalizedServerUrl = normalizeServerUrl(serverUrl);
+  if (normalizedServerUrl === null) {
+    return err({ _tag: "InvalidServerUrl", value: serverUrl });
+  }
+  const apiKey = normalizeEnvVar(env.MOLTZAP_API_KEY);
+  if (apiKey === null) {
+    return err({ _tag: "MissingApiKey" });
+  }
+  const localSenderId = normalizeEnvVar(env.MOLTZAP_LOCAL_SENDER_ID);
+  if (localSenderId === null) {
+    return err({ _tag: "MissingLocalSenderId" });
+  }
+  const orchestratorSenderId = normalizeEnvVar(env.MOLTZAP_ORCHESTRATOR_SENDER_ID);
+  if (role === "worker" && orchestratorSenderId === null) {
+    return err({ _tag: "MissingOrchestratorSenderId", role: "worker" });
+  }
+  return ok({
+    role,
+    serverUrl: normalizedServerUrl,
+    apiKey,
+    localSenderId: asMoltzapSenderId(localSenderId),
+    orchestratorSenderId:
+      orchestratorSenderId === null ? null : asMoltzapSenderId(orchestratorSenderId),
+    allowlistCsv: normalizeCsv(env.MOLTZAP_ALLOWED_SENDERS),
+  });
+}
+
+/**
+ * Connect an authenticated MoltZap client for the current AO session.
+ */
+export async function connectSessionClient(
+  env: SessionClientEnv,
+  connector: SessionClientConnector,
+): Promise<Result<SessionClientHandle, SessionClientConnectError>> {
+  const connected = await connector.connect(env);
+  if (connected._tag === "Err") {
+    return err(connected.error);
+  }
+  if (env.localSenderId.trim().length === 0) {
+    return err({
+      _tag: "IdentityUnavailable",
+      reason: "local sender identity is empty after config decode",
+    });
+  }
+  if (env.role === "worker" && env.orchestratorSenderId === null) {
+    return err({
+      _tag: "IdentityUnavailable",
+      reason: "worker session is missing orchestrator sender identity",
+    });
+  }
+  return ok({
+    role: env.role,
+    normalizedServerUrl: env.serverUrl,
+    sdk: connected.value,
+    localSenderId: env.localSenderId,
+    orchestratorSenderId: env.orchestratorSenderId,
+    close: () => connector.disconnect(connected.value),
+  });
+}
+
+function normalizeEnvVar(raw: string | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeCsv(raw: string | undefined): string | null {
+  const value = normalizeEnvVar(raw);
+  if (value === null) return null;
+  const normalized = value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(",");
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeServerUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (!["ws:", "wss:", "http:", "https:"].includes(url.protocol)) {
+      return null;
+    }
+    if (url.pathname === "/ws" || url.pathname === "/ws/") {
+      url.pathname = "/";
+    } else if (url.pathname.endsWith("/ws")) {
+      url.pathname = url.pathname.slice(0, -3) || "/";
+    }
+    const normalizedPath = url.pathname === "/" ? "" : url.pathname.replace(/\/+$/, "");
+    return `${url.protocol}//${url.host}${normalizedPath}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}

--- a/v2/orchestrator/control-event.ts
+++ b/v2/orchestrator/control-event.ts
@@ -1,0 +1,69 @@
+/**
+ * v2/orchestrator/control-event — shape GitHub-originated control input for the
+ * persistent AO orchestrator session.
+ *
+ * Architect phase only: public surface, no implementation.
+ */
+
+import type {
+  CommentId,
+  DeliveryId,
+  IssueNumber,
+  ProjectName,
+  RepoFullName,
+  Result,
+} from "../types.ts";
+import { err, ok } from "../types.ts";
+
+export interface OrchestratorControlEvent {
+  readonly _tag: "GitHubControlEvent";
+  readonly repo: RepoFullName;
+  readonly projectName: ProjectName;
+  readonly issue: IssueNumber;
+  readonly commentId: CommentId;
+  readonly deliveryId: DeliveryId;
+  readonly commentBody: string;
+  readonly triggeredBy: string;
+}
+
+export interface OrchestratorControlPrompt {
+  readonly title: string;
+  readonly body: string;
+}
+
+export type ControlEventShapeError = { readonly _tag: "PromptShapeInvalid"; readonly reason: string };
+
+/**
+ * Render the thin shim's GitHub control input into the prompt text delivered to
+ * the persistent AO orchestrator session.
+ */
+export function toOrchestratorControlPrompt(
+  event: OrchestratorControlEvent,
+): Result<OrchestratorControlPrompt, ControlEventShapeError> {
+  if (event.triggeredBy.trim().length === 0) {
+    return err({ _tag: "PromptShapeInvalid", reason: "triggeredBy must be a non-empty string" });
+  }
+  if (event.commentBody.trim().length === 0) {
+    return err({ _tag: "PromptShapeInvalid", reason: "commentBody must be a non-empty string" });
+  }
+  return ok({
+    title: `GitHub control for ${event.repo}#${event.issue as number}`,
+    body: [
+      `You are the persistent AO orchestrator for project ${event.projectName as string}.`,
+      `A GitHub control event was accepted by zapbot and must now be handled durably.`,
+      "",
+      `repo: ${event.repo as string}`,
+      `issue: #${event.issue as number}`,
+      `comment_id: ${event.commentId as number}`,
+      `delivery_id: ${event.deliveryId as string}`,
+      `triggered_by: @${event.triggeredBy.trim()}`,
+      "",
+      "Interpret the GitHub message directly. Do not rely on the webhook bridge having pre-classified it into a specific command.",
+      "",
+      "github_comment_body:",
+      event.commentBody,
+      "",
+      "Publish durable artifacts back to GitHub. Use MoltZap only for live coordination.",
+    ].join("\n"),
+  });
+}

--- a/v2/orchestrator/runtime.ts
+++ b/v2/orchestrator/runtime.ts
@@ -1,0 +1,95 @@
+/**
+ * v2/orchestrator/runtime — ensure the persistent AO orchestrator exists and
+ * forward control prompts into it.
+ *
+ * Architect phase only: public surface, no implementation.
+ */
+
+import type { MoltzapSenderId } from "../moltzap/types.ts";
+import type { AoSessionName, ProjectName, Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type { OrchestratorControlPrompt } from "./control-event.ts";
+
+export interface OrchestratorReady {
+  readonly session: AoSessionName;
+  readonly senderId: MoltzapSenderId;
+  readonly mode: "reused" | "started";
+}
+
+export interface OrchestratorForwardReceipt {
+  readonly session: AoSessionName;
+  readonly senderId: MoltzapSenderId;
+}
+
+export type AoControlHostError =
+  | { readonly _tag: "AoStartFailed"; readonly cause: string }
+  | { readonly _tag: "OrchestratorNotFound"; readonly projectName: ProjectName }
+  | { readonly _tag: "OrchestratorNotReady"; readonly projectName: ProjectName; readonly reason: string }
+  | { readonly _tag: "AoSendFailed"; readonly cause: string };
+
+export interface AoControlHost {
+  readonly ensureStarted: (
+    projectName: ProjectName,
+  ) => Promise<Result<void, Extract<AoControlHostError, { readonly _tag: "AoStartFailed" }>>>;
+  readonly resolveReady: (
+    projectName: ProjectName,
+  ) => Promise<
+    Result<
+      OrchestratorReady,
+      | Extract<AoControlHostError, { readonly _tag: "OrchestratorNotFound" }>
+      | Extract<AoControlHostError, { readonly _tag: "OrchestratorNotReady" }>
+    >
+  >;
+  readonly sendPrompt: (
+    session: AoSessionName,
+    prompt: OrchestratorControlPrompt,
+  ) => Promise<Result<void, Extract<AoControlHostError, { readonly _tag: "AoSendFailed" }>>>;
+}
+
+export type EnsureOrchestratorError =
+  | Extract<AoControlHostError, { readonly _tag: "AoStartFailed" }>
+  | Extract<AoControlHostError, { readonly _tag: "OrchestratorNotFound" }>
+  | Extract<AoControlHostError, { readonly _tag: "OrchestratorNotReady" }>;
+
+export type ForwardControlError = EnsureOrchestratorError | Extract<AoControlHostError, { readonly _tag: "AoSendFailed" }>;
+
+/**
+ * Ensure the persistent per-project orchestrator session exists and has a
+ * discoverable MoltZap identity before any control prompt is forwarded.
+ */
+export async function ensureProjectOrchestrator(
+  projectName: ProjectName,
+  host: AoControlHost,
+): Promise<Result<OrchestratorReady, EnsureOrchestratorError>> {
+  const started = await host.ensureStarted(projectName);
+  if (started._tag === "Err") {
+    return err(started.error);
+  }
+  const ready = await host.resolveReady(projectName);
+  if (ready._tag === "Err") {
+    return err(ready.error);
+  }
+  return ok(ready.value);
+}
+
+/**
+ * Deliver a rendered control prompt into the ready orchestrator session.
+ */
+export async function forwardControlPrompt(
+  projectName: ProjectName,
+  prompt: OrchestratorControlPrompt,
+  host: AoControlHost,
+): Promise<Result<OrchestratorForwardReceipt, ForwardControlError>> {
+  const ready = await ensureProjectOrchestrator(projectName, host);
+  if (ready._tag === "Err") {
+    return ready;
+  }
+  const sent = await host.sendPrompt(ready.value.session, prompt);
+  if (sent._tag === "Err") {
+    return err(sent.error);
+  }
+  return ok({
+    session: ready.value.session,
+    senderId: ready.value.senderId,
+  });
+}


### PR DESCRIPTION
## Summary

Implements the approved Claude-first MoltZap channel runtime from #165 / #166 in the new staff modules and the one existing provisioning seam that had to change for the runtime to be reachable.

## What changed

- added the official Claude channel event shaper in `v2/claude-channel/event.ts`
- added the session-local MCP channel server in `v2/claude-channel/server.ts`
- added Claude launch planning for `--mcp-config` + dev/allowlisted channel flags in `v2/ao/claude-channel-launch.ts`
- added in-session MoltZap env decode/bootstrap in `v2/moltzap/session-client.ts`
- added the shared MoltZap channel binder in `v2/moltzap/channel-runtime.ts`
- implemented the orchestrator prompt/runtime helpers in `v2/orchestrator/control-event.ts` and `v2/orchestrator/runtime.ts`
- updated `v2/moltzap/runtime.ts` registration provisioning to surface `MOLTZAP_LOCAL_SENDER_ID`
- added focused tests for all new public surfaces plus a real spawned stdio MCP test for the channel server
- pinned `@modelcontextprotocol/sdk@1.29.0` and `@moltzap/client@2026.414.0`

## Traceability

- Spec: #165
- Architect: #166
- Implement-staff: #168

## Verification

- `bun run test`
- `bun run build`
- `bun run lint` (warnings only, 0 errors)

## Notes

- Per the latest user override, the orchestrator prompt contract now carries the raw GitHub comment body instead of assuming pre-classified `plan_this` / `investigate_this` commands.
- The webhook bridge itself is not rewired to the persistent orchestrator in this PR; this PR delivers the approved Claude/MoltZap runtime surfaces and the runtime assumptions they depend on.
