### PR TITLE
[impl-junior] fix start.sh AO port mismatch

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -32,6 +32,36 @@ fi
 
 BRIDGE_PORT="${ZAPBOT_PORT:-3000}"
 AO_PORT="${ZAPBOT_AO_PORT:-3001}"
+AO_LOG_FILE="/tmp/zapbot-ao.log"
+AO_CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/zapbot-ao-config.XXXXXX.yaml")"
+
+node - "$PROJECT_DIR/agent-orchestrator.yaml" "$AO_CONFIG_FILE" "$AO_PORT" <<'NODE'
+const fs = require("node:fs");
+const [sourcePath, targetPath, desiredPort] = process.argv.slice(2);
+const portLine = `port: ${desiredPort}`;
+const yaml = fs.readFileSync(sourcePath, "utf8");
+const lines = yaml.split(/\r?\n/);
+let replaced = false;
+
+for (let i = 0; i < lines.length; i += 1) {
+  if (/^port:[ \t]*.*$/.test(lines[i])) {
+    lines[i] = portLine;
+    replaced = true;
+    break;
+  }
+}
+
+if (!replaced) {
+  if (lines[0] === "---") {
+    lines.splice(1, 0, portLine);
+  } else {
+    lines.unshift(portLine);
+  }
+}
+
+const output = lines.join("\n") + (yaml.endsWith("\n") ? "\n" : "");
+fs.writeFileSync(targetPath, output);
+NODE
 
 if [ -z "${ZAPBOT_API_KEY:-}" ]; then
   echo "ERROR: ZAPBOT_API_KEY is not set."
@@ -74,16 +104,43 @@ fi
 
 pkill -f "bun.*webhook-bridge.ts" 2>/dev/null || true
 
-echo "Starting agent-orchestrator on port ${AO_PORT}..."
-(cd "$PROJECT_DIR" && PORT=$AO_PORT ao start > /tmp/zapbot-ao.log 2>&1) &
+echo "Starting agent-orchestrator with explicit port ${AO_PORT}..."
+(cd "$PROJECT_DIR" && AO_CONFIG_PATH="$AO_CONFIG_FILE" ao start > "$AO_LOG_FILE" 2>&1) &
 AO_PID=$!
 
+AO_DASHBOARD_PORT=""
 for i in $(seq 1 20); do
-  curl -s "http://localhost:${AO_PORT}" >/dev/null 2>&1 && break
-  [ "$i" -eq 20 ] && { echo "ERROR: AO failed to start. Check /tmp/zapbot-ao.log"; kill $AO_PID 2>/dev/null; exit 1; }
+  AO_DASHBOARD_PORT="$(grep -Eo 'Dashboard starting on http://localhost:[0-9]+' "$AO_LOG_FILE" 2>/dev/null | tail -n 1 | sed -E 's/.*:([0-9]+)$/\1/' || true)"
+  if [ -n "$AO_DASHBOARD_PORT" ]; then
+    break
+  fi
+  if ! kill -0 "$AO_PID" 2>/dev/null; then
+    echo "ERROR: AO failed to start. Check $AO_LOG_FILE"
+    kill "$AO_PID" 2>/dev/null || true
+    exit 1
+  fi
   sleep 1
 done
-echo "AO ready on port ${AO_PORT}"
+
+if [ -z "$AO_DASHBOARD_PORT" ]; then
+  echo "ERROR: AO failed to start. Check $AO_LOG_FILE"
+  kill "$AO_PID" 2>/dev/null || true
+  exit 1
+fi
+
+for i in $(seq 1 20); do
+  if curl -fsS "http://localhost:${AO_DASHBOARD_PORT}/api/observability" 2>/dev/null | grep -q '"overallStatus"'; then
+    break
+  fi
+  if ! kill -0 "$AO_PID" 2>/dev/null; then
+    echo "ERROR: AO exited before the dashboard became ready. Check $AO_LOG_FILE"
+    kill "$AO_PID" 2>/dev/null || true
+    exit 1
+  fi
+  [ "$i" -eq 20 ] && { echo "ERROR: AO failed to become ready. Check $AO_LOG_FILE"; kill "$AO_PID" 2>/dev/null || true; exit 1; }
+  sleep 1
+done
+echo "AO ready on port ${AO_DASHBOARD_PORT}"
 
 echo "Starting webhook bridge on port ${BRIDGE_PORT}..."
 export ZAPBOT_API_KEY
@@ -110,6 +167,7 @@ cleanup() {
     [ -n "$pid" ] && pkill -P "$pid" 2>/dev/null || true
     [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
   done
+  [ -n "${AO_CONFIG_FILE:-}" ] && rm -f "$AO_CONFIG_FILE"
   echo "All processes stopped."
 }
 trap cleanup EXIT INT TERM
@@ -123,7 +181,7 @@ for repo in "${ZAPBOT_REPOS[@]}"; do
 echo "  Repo:      https://github.com/${repo}"
 done
 echo "  Bridge:    http://localhost:${BRIDGE_PORT}"
-echo "  Dashboard: http://localhost:${AO_PORT}"
+echo "  Dashboard: http://localhost:${AO_DASHBOARD_PORT}"
 if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
   echo "  Gateway:   ${ZAPBOT_GATEWAY_URL}"
   [ -n "${ZAPBOT_BRIDGE_URL:-}" ] && echo "  Public:    ${ZAPBOT_BRIDGE_URL}"


### PR DESCRIPTION
## Summary

This is the focused startup-wrapper fix for the bug tracked in <https://github.com/chughtapan/zapbot/issues/186>.

Root cause from <https://github.com/chughtapan/zapbot/issues/187>:
- `start.sh` assumed `PORT=$AO_PORT ao start` controlled AO's dashboard port
- AO actually selects its dashboard/API port from config, not from `PORT`
- the wrapper then polled the requested port with a bare `curl`, which could both fail on the real AO port and false-positive on an unrelated listener

This PR fixes that one-file wrapper behavior by:
- creating a temporary AO config overlay with `port: $AO_PORT`
- launching `ao start` against that explicit config
- waiting for the AO log to report the actual dashboard port
- verifying readiness via `/api/observability` on that exact AO port instead of accepting any open socket
- cleaning up the temporary AO config on shutdown

## Acceptance criteria

This PR satisfies <https://github.com/chughtapan/zapbot/issues/188> by delivering a minimal `start.sh` fix that:
- makes the AO port contract explicit
- prevents the readiness check from accepting unrelated listeners
- keeps scope inside the startup wrapper only

## Scope

Changed files:
- `start.sh`

## Validation

Manual receipts from the live dummy-project repro:
- before the patch, `ZAPBOT_AO_PORT=3101` still produced AO logs on `http://localhost:3000` and `start.sh` failed while polling `3101`
- with this patch applied, `start.sh` brought AO up on `3101`, `http://localhost:3101/api/observability` returned AO-shaped JSON, and the wrapper reported `AO ready on port 3101`
- the bridge also started successfully on `3000` once stale AO dashboard debris from earlier runs was removed

Note: the subsequent GitHub comment-trigger path on the fresh dummy repo still depends on external GitHub App/gateway routing for that repo; this PR does not change that integration surface.

## Traceability

- Epic: <https://github.com/chughtapan/zapbot/issues/186>
- Investigation: <https://github.com/chughtapan/zapbot/issues/187>
- Implement row: <https://github.com/chughtapan/zapbot/issues/188>
- Verify row: <https://github.com/chughtapan/zapbot/issues/189>
