### PR TITLE
[impl-senior] keep project webhook secret ahead of shared env

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -27,8 +27,10 @@ if [ ! -f "$PROJECT_DIR/agent-orchestrator.yaml" ]; then
   exit 1
 fi
 
-[ -f "$PROJECT_DIR/.env" ] && set -a && source "$PROJECT_DIR/.env" && set +a
+# Load shared bootstrap defaults first, then let the project checkout override them.
+# Fresh repos must keep their generated webhook secret even if ~/.zapbot/.env still exists.
 [ -f "$HOME/.zapbot/.env" ] && set -a && source "$HOME/.zapbot/.env" && set +a
+[ -f "$PROJECT_DIR/.env" ] && set -a && source "$PROJECT_DIR/.env" && set +a
 
 BRIDGE_PORT="${ZAPBOT_PORT:-3000}"
 AO_PORT="${ZAPBOT_AO_PORT:-3001}"

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -185,6 +185,20 @@ describe("systemd integration: start.sh guard", () => {
     expect(startSh).toContain("2>&1");
     expect(startSh).toMatch(/systemctl is-active zapbot-bridge.*\n[\s\S]*?exit 1/);
   });
+
+  it("loads shared env before project env so checkout-local secrets win", () => {
+    const startSh = fs.readFileSync(
+      path.join(__dirname, "../start.sh"),
+      "utf-8"
+    );
+
+    const sharedIndex = startSh.indexOf('source "$HOME/.zapbot/.env"');
+    const projectIndex = startSh.indexOf('source "$PROJECT_DIR/.env"');
+
+    expect(sharedIndex).toBeGreaterThanOrEqual(0);
+    expect(projectIndex).toBeGreaterThanOrEqual(0);
+    expect(sharedIndex).toBeLessThan(projectIndex);
+  });
 });
 
 describe("systemd integration: team-init reload", () => {


### PR DESCRIPTION
Closes #197

## What changed
`start.sh` now sources the shared `~/.zapbot/.env` before the project checkout `.env`, so a fresh repo's generated `ZAPBOT_WEBHOOK_SECRET` cannot be overwritten by stale shared state. I also added a regression guard in `test/config-reload.test.ts` that asserts the source order.

## Scope
- Branch: `impl/webhook-secret-drift`
- Files touched: `start.sh`, `test/config-reload.test.ts`
- Fresh dummy-project proof: deferred to verify row #195 as requested

## Local validation
- `bash -n start.sh`
- `npm test -- --run test/config-reload.test.ts`

## Notes
This is the narrow launcher-side fix; the completed live dummy-project proof remains the responsibility of the verify row.