### PR TITLE
[impl-junior] derive a live bridge url before gateway registration

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -37,6 +37,41 @@ AO_PORT="${ZAPBOT_AO_PORT:-3001}"
 AO_LOG_FILE="/tmp/zapbot-ao.log"
 AO_CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/zapbot-ao-config.XXXXXX.yaml")"
 
+resolve_bridge_url() {
+  local configured_url="${ZAPBOT_BRIDGE_URL:-}"
+  local health_check_url=""
+  local metadata_ip=""
+  local host_ip=""
+
+  if [ -n "$configured_url" ]; then
+    health_check_url="${configured_url%/}/healthz"
+    if curl -fsS --max-time 2 "$health_check_url" >/dev/null 2>&1; then
+      echo "$configured_url"
+      return 0
+    fi
+  fi
+
+  metadata_ip="$(curl -fsS --max-time 2 -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" 2>/dev/null || true)"
+  if [ -n "$metadata_ip" ]; then
+    echo "http://${metadata_ip}:${BRIDGE_PORT}"
+    return 0
+  fi
+
+  host_ip="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+  if [ -n "$host_ip" ]; then
+    echo "http://${host_ip}:${BRIDGE_PORT}"
+    return 0
+  fi
+
+  if [ -n "$configured_url" ]; then
+    echo "ERROR: ZAPBOT_BRIDGE_URL is set but unreachable: $configured_url" >&2
+    return 1
+  fi
+
+  return 0
+}
+
 start_ao_once() {
   : > "$AO_LOG_FILE"
   (cd "$PROJECT_DIR" && AO_CONFIG_PATH="$AO_CONFIG_FILE" ao start > "$AO_LOG_FILE" 2>&1) &
@@ -115,6 +150,17 @@ if systemctl is-active zapbot-bridge >/dev/null 2>&1; then
 fi
 
 pkill -f "bun.*webhook-bridge.ts" 2>/dev/null || true
+
+if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
+  RESOLVED_BRIDGE_URL="$(resolve_bridge_url)" || exit 1
+  if [ -z "$RESOLVED_BRIDGE_URL" ]; then
+    echo "ERROR: ZAPBOT_GATEWAY_URL is set but a live bridge URL could not be derived."
+    echo "FIX: Set ZAPBOT_BRIDGE_URL to the current public URL or run on a host that exposes one."
+    exit 1
+  fi
+  ZAPBOT_BRIDGE_URL="$RESOLVED_BRIDGE_URL"
+  export ZAPBOT_BRIDGE_URL
+fi
 
 AO_DASHBOARD_PORT=""
 for attempt in 1 2; do


### PR DESCRIPTION
Closes #203

## What changed
`start.sh` now refuses to carry a stale inherited `ZAPBOT_BRIDGE_URL` into gateway registration. When the gateway path is active, it first tries the configured bridge URL if it is live; otherwise it derives a current public URL from the host metadata or local interface and exports that value for the bridge to register.

## Scope
- Branch: `impl/live-bridge-url`
- Base branch: `impl/duplicate-orchestrator-bootstrap`
- Files touched: `start.sh` only
- Verify row: retains the full end-to-end dummy-project proof

## Local validation
- `bash -n start.sh`
- launcher smoke test with fake `ao`, `bun`, `curl`, `gh`, `tmux`, and `systemctl` stubs

## Notes
This stays inside junior scope and stacks on the current runtime branch so the verify pass can exercise the launcher fixes together.