### PR TITLE
[impl-senior] implement ingress-mode launcher contract

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -13,6 +13,7 @@ import {
   loadBridgeRuntimeConfig,
 } from "../src/config/load.ts";
 import { parseEnvFile, resolveRuntimeEnv } from "../src/config/env.ts";
+import { resolveIngressPolicy } from "../src/config/ingress.ts";
 import { parseProjectConfig, readConfigFiles } from "../src/config/disk.ts";
 import { reloadBridgeRuntimeConfig } from "../src/config/reload.ts";
 import type { BridgeRuntimeConfig } from "../src/config/types.ts";
@@ -51,7 +52,7 @@ interface LoadedBridgeInputs {
   readonly mergedEnv: Record<string, string | undefined>;
 }
 
-function loadBridgeInputs(configPath: string | undefined): Result<LoadedBridgeInputs, { readonly reason: string }> {
+async function loadBridgeInputs(configPath: string | undefined): Promise<Result<LoadedBridgeInputs, { readonly reason: string }>> {
   const sourcePaths = deriveConfigSourcePaths(configPath);
   const rawFiles = readConfigFiles(sourcePaths, nodeDiskReader);
   if (rawFiles._tag === "Err") {
@@ -74,6 +75,26 @@ function loadBridgeInputs(configPath: string | undefined): Result<LoadedBridgeIn
     return err({ reason: formatConfigError(runtimeEnv.error) });
   }
 
+  const ingressMode = runtimeEnv.value.gatewayUrl === null ? "local-only" : "github-demo";
+  const ingress = await resolveIngressPolicy({
+    mode: ingressMode,
+    gatewayUrl: runtimeEnv.value.gatewayUrl ?? "",
+    publicUrl: runtimeEnv.value.publicUrl,
+    isPublicUrlReachable: async (publicUrl) => {
+      try {
+        const response = await fetch(`${publicUrl.replace(/\/+$/u, "")}/healthz`, {
+          signal: AbortSignal.timeout(2_000),
+        });
+        return response.ok;
+      } catch {
+        return false;
+      }
+    },
+  });
+  if (ingress._tag === "Err") {
+    return err({ reason: formatIngressError(ingress.error) });
+  }
+
   const projectDocument = rawFiles.value.projectConfigText === null || sourcePaths.projectConfigPath === null
     ? ok(null)
     : parseProjectConfig(sourcePaths.projectConfigPath, rawFiles.value.projectConfigText);
@@ -81,7 +102,7 @@ function loadBridgeInputs(configPath: string | undefined): Result<LoadedBridgeIn
     return err({ reason: formatConfigError(projectDocument.error) });
   }
 
-  const runtime = loadBridgeRuntimeConfig(runtimeEnv.value, parsedEnv.value, projectDocument.value);
+  const runtime = loadBridgeRuntimeConfig(runtimeEnv.value, parsedEnv.value, projectDocument.value, ingress.value);
   if (runtime._tag === "Err") {
     return err({ reason: formatConfigError(runtime.error) });
   }
@@ -107,6 +128,7 @@ function buildBridgeConfig(runtime: BridgeRuntimeConfig, mergedEnv: Record<strin
 
   return ok({
     port: runtime.port,
+    ingress: runtime.ingress,
     publicUrl: runtime.publicUrl,
     gatewayUrl: runtime.gatewayUrl,
     gatewaySecret: runtime.gatewaySecret,
@@ -154,8 +176,23 @@ function formatConfigError(error: { readonly _tag?: string; readonly reason?: st
   }
 }
 
+function formatIngressError(error: { readonly _tag?: string; readonly mode?: string; readonly gatewayUrl?: string; readonly publicUrl?: string }): string {
+  switch (error._tag) {
+    case "InvalidIngressMode":
+      return `Unsupported ingress mode: ${error.mode}`;
+    case "MissingPublicBridgeUrl":
+      return "ZAPBOT_BRIDGE_URL is required in GitHub demo mode.";
+    case "UnreachablePublicBridgeUrl":
+      return `ZAPBOT_BRIDGE_URL is unreachable: ${error.publicUrl}`;
+    case "DemoModeRequiresGateway":
+      return "ZAPBOT_GATEWAY_URL is required in GitHub demo mode.";
+    default:
+      return "Unknown ingress error.";
+  }
+}
+
 async function main() {
-  const initialInputs = loadBridgeInputs(process.env.ZAPBOT_CONFIG);
+  const initialInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG);
   if (initialInputs._tag === "Err") {
     console.error(`[bridge] ${initialInputs.error.reason}`);
     process.exit(1);
@@ -172,9 +209,10 @@ async function main() {
   let liveRuntime = initialInputs.value.runtime;
   const cfg = initialConfig.value;
   log.info(`Webhook bridge starting on port ${cfg.port}`);
+  log.info(`Ingress mode: ${cfg.ingress.mode}`);
 
   const running = await startBridge(cfg);
-  log.info(`Webhook bridge listening on ${cfg.publicUrl}`);
+  log.info(`Webhook bridge listening on ${cfg.ingress.mode === "github-demo" ? cfg.publicUrl : "local-only ingress"}`);
 
   let reloadInFlight = false;
   process.on("SIGHUP", () => {
@@ -185,7 +223,7 @@ async function main() {
     reloadInFlight = true;
     (async () => {
       try {
-        const nextInputs = loadBridgeInputs(process.env.ZAPBOT_CONFIG);
+        const nextInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG);
         if (nextInputs._tag === "Err") {
           log.error(`Reload failed: ${nextInputs.error.reason}`);
           return;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -18,6 +18,7 @@ import {
   buildMoltzapProcessEnv,
   type MoltzapRuntimeConfig,
 } from "./moltzap/runtime.ts";
+import type { IngressPolicy } from "./config/ingress.ts";
 import { createAoCliControlHost, forwardControlPrompt, type AoControlHost, type ForwardControlError } from "./orchestrator/runtime.ts";
 import { toOrchestratorControlPrompt, type ControlEventShapeError, type OrchestratorControlEvent } from "./orchestrator/control-event.ts";
 import {
@@ -73,8 +74,9 @@ async function safeGh<T>(
 
 export interface BridgeConfig {
   readonly port: number;
-  readonly publicUrl: string;
-  readonly gatewayUrl: string;
+  readonly ingress: IngressPolicy;
+  readonly publicUrl: string | null;
+  readonly gatewayUrl: string | null;
   readonly gatewaySecret: string | null;
   readonly botUsername: BotUsername;
   readonly aoConfigPath: string;
@@ -405,30 +407,41 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
   let stopHeartbeat: (() => void) | null = null;
 
   async function registerAll(cfg: BridgeConfig): Promise<void> {
+    if (stopHeartbeat) {
+      stopHeartbeat();
+      stopHeartbeat = null;
+    }
     const repos = Array.from(cfg.repos.keys());
     if (repos.length === 0) return;
+    if (cfg.ingress.mode === "local-only") return;
+    if (cfg.gatewayUrl === null || cfg.publicUrl === null) return;
+    const gatewayUrl = cfg.gatewayUrl;
+    const publicUrl = cfg.publicUrl;
     const client: GatewayClientConfig = {
-      gatewayUrl: cfg.gatewayUrl,
+      gatewayUrl,
       secret: cfg.gatewaySecret,
       token: null,
     };
     await Promise.allSettled(
-      repos.map((repo) => registerBridge(client, repo, cfg.publicUrl))
+      repos.map((repo) => registerBridge(client, repo, publicUrl))
     );
-    if (stopHeartbeat) stopHeartbeat();
     const intervalMs = parseInt(process.env.ZAPBOT_GATEWAY_HEARTBEAT_MS ?? "300000", 10);
-    stopHeartbeat = startHeartbeat(client, repos, cfg.publicUrl, intervalMs);
+    stopHeartbeat = startHeartbeat(client, repos, publicUrl, intervalMs);
   }
 
   async function deregisterAll(cfg: BridgeConfig): Promise<void> {
+    if (cfg.ingress.mode === "local-only") return;
+    if (cfg.gatewayUrl === null || cfg.publicUrl === null) return;
+    const gatewayUrl = cfg.gatewayUrl;
+    const publicUrl = cfg.publicUrl;
     const repos = Array.from(cfg.repos.keys());
     const client: GatewayClientConfig = {
-      gatewayUrl: cfg.gatewayUrl,
+      gatewayUrl,
       secret: cfg.gatewaySecret,
       token: null,
     };
     await Promise.allSettled(
-      repos.map((repo) => deregisterBridge(client, repo, cfg.publicUrl))
+      repos.map((repo) => deregisterBridge(client, repo, publicUrl))
     );
   }
 
@@ -458,11 +471,15 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
 
   const running: RunningBridge = {
     async stop(): Promise<void> {
-      if (stopHeartbeat) stopHeartbeat();
+      if (stopHeartbeat) {
+        stopHeartbeat();
+        stopHeartbeat = null;
+      }
       await deregisterAll(current);
       server.stop();
     },
     async reload(nextConfig: BridgeConfig): Promise<void> {
+      await deregisterAll(current);
       current = nextConfig;
       aoControlHost = createAoCliControlHost({
         configPath: current.aoConfigPath,

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -72,9 +72,8 @@ export function resolveRuntimeEnv(
     });
   }
 
-  const publicUrl =
-    normalizeEnvValue(mergedEnv.ZAPBOT_BRIDGE_URL) ?? `http://localhost:${port}`;
-  const gatewayUrl = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_URL) ?? "";
+  const publicUrl = normalizeEnvValue(mergedEnv.ZAPBOT_BRIDGE_URL);
+  const gatewayUrl = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_URL);
   const gatewaySecret = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_SECRET);
   const botUsername = asBotUsername(
     normalizeEnvValue(mergedEnv.ZAPBOT_BOT_USERNAME) ?? "zapbot[bot]",

--- a/src/config/ingress.ts
+++ b/src/config/ingress.ts
@@ -32,7 +32,7 @@ export interface IngressPolicyInputs {
   readonly isPublicUrlReachable: (publicUrl: string) => Promise<boolean>;
 }
 
-export function resolveIngressPolicy(
+export async function resolveIngressPolicy(
   inputs: IngressPolicyInputs,
 ): Promise<Result<IngressPolicy, IngressResolutionError>> {
   if (inputs.mode === "local-only") {
@@ -57,17 +57,16 @@ export function resolveIngressPolicy(
     return Promise.resolve(err({ _tag: "MissingPublicBridgeUrl" }));
   }
 
-  return inputs.isPublicUrlReachable(publicUrl).then((reachable) => {
-    if (!reachable) {
-      return err({ _tag: "UnreachablePublicBridgeUrl", publicUrl });
-    }
+  const reachable = await inputs.isPublicUrlReachable(publicUrl);
+  if (!reachable) {
+    return err({ _tag: "UnreachablePublicBridgeUrl", publicUrl });
+  }
 
-    return ok({
-      _tag: "GitHubDemo",
-      mode: "github-demo",
-      gatewayUrl,
-      publicUrl,
-      requiresReachablePublicUrl: true,
-    });
+  return ok({
+    _tag: "GitHubDemo",
+    mode: "github-demo",
+    gatewayUrl,
+    publicUrl,
+    requiresReachablePublicUrl: true,
   });
 }

--- a/src/config/ingress.ts
+++ b/src/config/ingress.ts
@@ -1,0 +1,39 @@
+import type { Result } from "../types.ts";
+
+export type IngressMode = "local-only" | "github-demo";
+
+export type IngressResolutionError =
+  | { readonly _tag: "InvalidIngressMode"; readonly mode: string }
+  | { readonly _tag: "MissingPublicBridgeUrl" }
+  | { readonly _tag: "UnreachablePublicBridgeUrl"; readonly publicUrl: string }
+  | { readonly _tag: "DemoModeRequiresGateway"; readonly gatewayUrl: string };
+
+export type IngressPolicy =
+  | {
+      readonly _tag: "LocalOnly";
+      readonly mode: "local-only";
+      readonly gatewayUrl: null;
+      readonly publicUrl: null;
+      readonly requiresReachablePublicUrl: false;
+    }
+  | {
+      readonly _tag: "GitHubDemo";
+      readonly mode: "github-demo";
+      readonly gatewayUrl: string;
+      readonly publicUrl: string;
+      readonly requiresReachablePublicUrl: true;
+    };
+
+export interface IngressPolicyInputs {
+  readonly mode: IngressMode;
+  readonly gatewayUrl: string;
+  readonly publicUrl: string | null;
+  readonly isPublicUrlReachable: (publicUrl: string) => Promise<boolean>;
+}
+
+export function resolveIngressPolicy(
+  inputs: IngressPolicyInputs,
+): Promise<Result<IngressPolicy, IngressResolutionError>> {
+  throw new Error("not implemented");
+}
+

--- a/src/config/ingress.ts
+++ b/src/config/ingress.ts
@@ -1,4 +1,5 @@
 import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
 
 export type IngressMode = "local-only" | "github-demo";
 
@@ -34,6 +35,39 @@ export interface IngressPolicyInputs {
 export function resolveIngressPolicy(
   inputs: IngressPolicyInputs,
 ): Promise<Result<IngressPolicy, IngressResolutionError>> {
-  throw new Error("not implemented");
-}
+  if (inputs.mode === "local-only") {
+    return Promise.resolve(
+      ok({
+        _tag: "LocalOnly",
+        mode: "local-only",
+        gatewayUrl: null,
+        publicUrl: null,
+        requiresReachablePublicUrl: false,
+      }),
+    );
+  }
 
+  const gatewayUrl = inputs.gatewayUrl.trim();
+  if (gatewayUrl.length === 0) {
+    return Promise.resolve(err({ _tag: "DemoModeRequiresGateway", gatewayUrl: inputs.gatewayUrl }));
+  }
+
+  const publicUrl = inputs.publicUrl?.trim() ?? null;
+  if (publicUrl === null || publicUrl.length === 0) {
+    return Promise.resolve(err({ _tag: "MissingPublicBridgeUrl" }));
+  }
+
+  return inputs.isPublicUrlReachable(publicUrl).then((reachable) => {
+    if (!reachable) {
+      return err({ _tag: "UnreachablePublicBridgeUrl", publicUrl });
+    }
+
+    return ok({
+      _tag: "GitHubDemo",
+      mode: "github-demo",
+      gatewayUrl,
+      publicUrl,
+      requiresReachablePublicUrl: true,
+    });
+  });
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -15,6 +15,7 @@ import type {
   ProjectConfigDocument,
   ProjectRouteConfig,
 } from "./types.ts";
+import type { IngressPolicy } from "./ingress.ts";
 import type { RepoFullName } from "../types.ts";
 
 export function deriveConfigSourcePaths(
@@ -61,6 +62,7 @@ export function loadBridgeRuntimeConfig(
   env: NormalizedRuntimeEnv,
   _parsedEnvFile: ParsedEnvFile | null,
   document: ProjectConfigDocument | null,
+  ingress: IngressPolicy,
 ): Result<BridgeRuntimeConfig, ConfigLoadError> {
   const routeResult = buildRepoRoutes(document);
   if (routeResult._tag === "Err") return routeResult;
@@ -71,8 +73,9 @@ export function loadBridgeRuntimeConfig(
 
   return ok({
     port: env.port,
-    publicUrl: env.publicUrl,
-    gatewayUrl: env.gatewayUrl,
+    ingress,
+    publicUrl: ingress.publicUrl,
+    gatewayUrl: ingress.gatewayUrl,
     gatewaySecret: env.gatewaySecret,
     botUsername: env.botUsername,
     aoConfigPath: env.aoConfigPath,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -3,6 +3,7 @@ import type {
   ProjectName,
   RepoFullName,
 } from "../types.ts";
+import type { IngressPolicy } from "./ingress.ts";
 
 export type EnvFilePath = string & { readonly __brand: "EnvFilePath" };
 export type ProjectConfigPath = string & { readonly __brand: "ProjectConfigPath" };
@@ -34,8 +35,8 @@ export interface ProjectConfigDocument {
 
 export interface NormalizedRuntimeEnv {
   readonly port: number;
-  readonly publicUrl: string;
-  readonly gatewayUrl: string;
+  readonly publicUrl: string | null;
+  readonly gatewayUrl: string | null;
   readonly gatewaySecret: string | null;
   readonly botUsername: BotUsername;
   readonly aoConfigPath: ProjectConfigPath | null;
@@ -53,8 +54,9 @@ export interface ProjectRouteConfig {
 
 export interface BridgeRuntimeConfig {
   readonly port: number;
-  readonly publicUrl: string;
-  readonly gatewayUrl: string;
+  readonly ingress: IngressPolicy;
+  readonly publicUrl: string | null;
+  readonly gatewayUrl: string | null;
   readonly gatewaySecret: string | null;
   readonly botUsername: BotUsername;
   readonly aoConfigPath: ProjectConfigPath | null;

--- a/src/startup/receipt.ts
+++ b/src/startup/receipt.ts
@@ -1,4 +1,4 @@
-import type { Result } from "../types.ts";
+import { err, ok, type Result } from "../types.ts";
 import type { IngressPolicy } from "../config/ingress.ts";
 
 export type StartupReceiptError =
@@ -26,9 +26,38 @@ export interface StartupReceipt {
 export function buildStartupReceipt(
   input: StartupReceiptInput,
 ): Result<StartupReceipt, StartupReceiptError> {
-  throw new Error("not implemented");
+  if (input.projectDir.trim().length === 0) {
+    return err({ _tag: "MissingProjectDir" });
+  }
+  if (input.repos.length === 0) {
+    return err({ _tag: "MissingRepoList" });
+  }
+
+  const lines = [
+    `Mode:      ${input.ingress.mode}`,
+    `Project:   ${input.projectDir}`,
+    ...input.repos.map((repo) => `Repo:      https://github.com/${repo}`),
+    `Bridge:    http://localhost:${input.bridgePort}`,
+    `Dashboard: http://localhost:${input.dashboardPort}`,
+  ];
+
+  if (input.ingress.mode === "github-demo") {
+    lines.push(`Gateway:   ${input.gatewayUrl ?? input.ingress.gatewayUrl}`);
+    lines.push(`Public:    ${input.publicUrl ?? input.ingress.publicUrl}`);
+  } else {
+    lines.push("Gateway:   (local-only)");
+    lines.push("Public:    (local-only)");
+  }
+
+  lines.push(`Logs:      ${input.logsPath}`);
+  lines.push(`Publish:   ${input.publishCommand}`);
+
+  return ok({
+    mode: input.ingress.mode,
+    lines,
+  });
 }
 
 export function renderStartupReceipt(receipt: StartupReceipt): string {
-  throw new Error("not implemented");
+  return receipt.lines.join("\n");
 }

--- a/src/startup/receipt.ts
+++ b/src/startup/receipt.ts
@@ -1,0 +1,34 @@
+import type { Result } from "../types.ts";
+import type { IngressPolicy } from "../config/ingress.ts";
+
+export type StartupReceiptError =
+  | { readonly _tag: "MissingProjectDir" }
+  | { readonly _tag: "MissingRepoList" }
+  | { readonly _tag: "UnsupportedReceiptMode"; readonly mode: string };
+
+export interface StartupReceiptInput {
+  readonly projectDir: string;
+  readonly repos: ReadonlyArray<string>;
+  readonly ingress: IngressPolicy;
+  readonly bridgePort: number;
+  readonly dashboardPort: number;
+  readonly gatewayUrl: string | null;
+  readonly publicUrl: string | null;
+  readonly logsPath: string;
+  readonly publishCommand: string;
+}
+
+export interface StartupReceipt {
+  readonly mode: IngressPolicy["mode"];
+  readonly lines: ReadonlyArray<string>;
+}
+
+export function buildStartupReceipt(
+  input: StartupReceiptInput,
+): Result<StartupReceipt, StartupReceiptError> {
+  throw new Error("not implemented");
+}
+
+export function renderStartupReceipt(receipt: StartupReceipt): string {
+  throw new Error("not implemented");
+}

--- a/start.sh
+++ b/start.sh
@@ -37,39 +37,24 @@ AO_PORT="${ZAPBOT_AO_PORT:-3001}"
 AO_LOG_FILE="/tmp/zapbot-ao.log"
 AO_CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/zapbot-ao-config.XXXXXX.yaml")"
 
-resolve_bridge_url() {
+validate_bridge_url() {
   local configured_url="${ZAPBOT_BRIDGE_URL:-}"
   local health_check_url=""
-  local metadata_ip=""
-  local host_ip=""
 
-  if [ -n "$configured_url" ]; then
-    health_check_url="${configured_url%/}/healthz"
-    if curl -fsS --max-time 2 "$health_check_url" >/dev/null 2>&1; then
-      echo "$configured_url"
-      return 0
-    fi
-  fi
-
-  metadata_ip="$(curl -fsS --max-time 2 -H "Metadata-Flavor: Google" \
-    "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" 2>/dev/null || true)"
-  if [ -n "$metadata_ip" ]; then
-    echo "http://${metadata_ip}:${BRIDGE_PORT}"
-    return 0
-  fi
-
-  host_ip="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
-  if [ -n "$host_ip" ]; then
-    echo "http://${host_ip}:${BRIDGE_PORT}"
-    return 0
-  fi
-
-  if [ -n "$configured_url" ]; then
-    echo "ERROR: ZAPBOT_BRIDGE_URL is set but unreachable: $configured_url" >&2
+  if [ -z "$configured_url" ]; then
+    echo "ERROR: ZAPBOT_GATEWAY_URL is set but ZAPBOT_BRIDGE_URL is missing."
+    echo "FIX: Set ZAPBOT_BRIDGE_URL to the live public bridge URL before starting."
     return 1
   fi
 
-  return 0
+  health_check_url="${configured_url%/}/healthz"
+  if curl -fsS --max-time 2 "$health_check_url" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "ERROR: ZAPBOT_BRIDGE_URL is unreachable: $configured_url"
+  echo "FIX: Do not rely on host-derived fallback; set ZAPBOT_BRIDGE_URL to a live public URL."
+  return 1
 }
 
 start_ao_once() {
@@ -152,13 +137,7 @@ fi
 pkill -f "bun.*webhook-bridge.ts" 2>/dev/null || true
 
 if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
-  RESOLVED_BRIDGE_URL="$(resolve_bridge_url)" || exit 1
-  if [ -z "$RESOLVED_BRIDGE_URL" ]; then
-    echo "ERROR: ZAPBOT_GATEWAY_URL is set but a live bridge URL could not be derived."
-    echo "FIX: Set ZAPBOT_BRIDGE_URL to the current public URL or run on a host that exposes one."
-    exit 1
-  fi
-  ZAPBOT_BRIDGE_URL="$RESOLVED_BRIDGE_URL"
+  validate_bridge_url || exit 1
   export ZAPBOT_BRIDGE_URL
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 # Run from a project directory that has agent-orchestrator.yaml (created by
 # zapbot-team-init), or pass the path as the first argument.
 #
-# The bridge registers with the gateway at ZAPBOT_GATEWAY_URL. If no gateway
-# is configured, the bridge just listens on its local port.
+# `ZAPBOT_GATEWAY_URL` selects GitHub-backed demo mode. Without a gateway,
+# the launcher stays local-only and never advertises public ingress.
 
 ZAPBOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -56,6 +56,11 @@ validate_bridge_url() {
   echo "FIX: Do not rely on host-derived fallback; set ZAPBOT_BRIDGE_URL to a live public URL."
   return 1
 }
+
+INGRESS_MODE="local-only"
+if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
+  INGRESS_MODE="github-demo"
+fi
 
 start_ao_once() {
   : > "$AO_LOG_FILE"
@@ -110,6 +115,11 @@ if [ "${ZAPBOT_WEBHOOK_SECRET}" = "${ZAPBOT_API_KEY}" ]; then
   exit 1
 fi
 
+if [ "$INGRESS_MODE" = "github-demo" ]; then
+  validate_bridge_url || exit 1
+  export ZAPBOT_BRIDGE_URL
+fi
+
 ZAPBOT_REPOS=()
 while IFS= read -r line; do
   repo=$(echo "$line" | awk '{print $2}')
@@ -135,11 +145,6 @@ if systemctl is-active zapbot-bridge >/dev/null 2>&1; then
 fi
 
 pkill -f "bun.*webhook-bridge.ts" 2>/dev/null || true
-
-if [ -n "${ZAPBOT_BRIDGE_URL:-}" ]; then
-  validate_bridge_url || exit 1
-  export ZAPBOT_BRIDGE_URL
-fi
 
 AO_DASHBOARD_PORT=""
 for attempt in 1 2; do
@@ -230,14 +235,18 @@ echo "================================================"
 echo "  Zapbot is running!"
 echo "================================================"
 echo "  Project:   $PROJECT_DIR"
+echo "  Mode:      $INGRESS_MODE"
 for repo in "${ZAPBOT_REPOS[@]}"; do
 echo "  Repo:      https://github.com/${repo}"
 done
 echo "  Bridge:    http://localhost:${BRIDGE_PORT}"
 echo "  Dashboard: http://localhost:${AO_DASHBOARD_PORT}"
-if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
+if [ "$INGRESS_MODE" = "github-demo" ]; then
   echo "  Gateway:   ${ZAPBOT_GATEWAY_URL}"
-  [ -n "${ZAPBOT_BRIDGE_URL:-}" ] && echo "  Public:    ${ZAPBOT_BRIDGE_URL}"
+  echo "  Public:    ${ZAPBOT_BRIDGE_URL}"
+else
+  echo "  Gateway:   (local-only)"
+  echo "  Public:    (local-only)"
 fi
 echo ""
 echo "  Publish:   bash $ZAPBOT_DIR/bin/zapbot-publish.sh <plan-file>"

--- a/start.sh
+++ b/start.sh
@@ -37,6 +37,16 @@ AO_PORT="${ZAPBOT_AO_PORT:-3001}"
 AO_LOG_FILE="/tmp/zapbot-ao.log"
 AO_CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/zapbot-ao-config.XXXXXX.yaml")"
 
+start_ao_once() {
+  : > "$AO_LOG_FILE"
+  (cd "$PROJECT_DIR" && AO_CONFIG_PATH="$AO_CONFIG_FILE" ao start > "$AO_LOG_FILE" 2>&1) &
+  AO_PID=$!
+}
+
+extract_duplicate_session() {
+  grep -Eo 'duplicate session: [^[:space:]]+' "$AO_LOG_FILE" 2>/dev/null | tail -n 1 | sed -E 's/^duplicate session: //'
+}
+
 node - "$PROJECT_DIR/agent-orchestrator.yaml" "$AO_CONFIG_FILE" "$AO_PORT" <<'NODE'
 const fs = require("node:fs");
 const [sourcePath, targetPath, desiredPort] = process.argv.slice(2);
@@ -106,29 +116,45 @@ fi
 
 pkill -f "bun.*webhook-bridge.ts" 2>/dev/null || true
 
-echo "Starting agent-orchestrator with explicit port ${AO_PORT}..."
-(cd "$PROJECT_DIR" && AO_CONFIG_PATH="$AO_CONFIG_FILE" ao start > "$AO_LOG_FILE" 2>&1) &
-AO_PID=$!
-
 AO_DASHBOARD_PORT=""
-for i in $(seq 1 20); do
-  AO_DASHBOARD_PORT="$(grep -Eo 'Dashboard starting on http://localhost:[0-9]+' "$AO_LOG_FILE" 2>/dev/null | tail -n 1 | sed -E 's/.*:([0-9]+)$/\1/' || true)"
+for attempt in 1 2; do
+  echo "Starting agent-orchestrator with explicit port ${AO_PORT}..."
+  AO_DASHBOARD_PORT=""
+  DUPLICATE_SESSION=""
+  start_ao_once
+
+  for i in $(seq 1 20); do
+    AO_DASHBOARD_PORT="$(grep -Eo 'Dashboard starting on http://localhost:[0-9]+' "$AO_LOG_FILE" 2>/dev/null | tail -n 1 | sed -E 's/.*:([0-9]+)$/\1/' || true)"
+    if [ -n "$AO_DASHBOARD_PORT" ]; then
+      break
+    fi
+    if ! kill -0 "$AO_PID" 2>/dev/null; then
+      DUPLICATE_SESSION="$(extract_duplicate_session)"
+      if [ "$attempt" -eq 1 ] && [ -n "$DUPLICATE_SESSION" ]; then
+        echo "Detected stale AO tmux session ${DUPLICATE_SESSION}; removing and retrying startup..."
+        tmux kill-session -t "$DUPLICATE_SESSION" 2>/dev/null || true
+        wait "$AO_PID" 2>/dev/null || true
+        break
+      fi
+      echo "ERROR: AO failed to start. Check $AO_LOG_FILE"
+      kill "$AO_PID" 2>/dev/null || true
+      exit 1
+    fi
+    sleep 1
+  done
+
   if [ -n "$AO_DASHBOARD_PORT" ]; then
     break
   fi
-  if ! kill -0 "$AO_PID" 2>/dev/null; then
-    echo "ERROR: AO failed to start. Check $AO_LOG_FILE"
-    kill "$AO_PID" 2>/dev/null || true
-    exit 1
-  fi
-  sleep 1
-done
 
-if [ -z "$AO_DASHBOARD_PORT" ]; then
+  if [ "$attempt" -eq 1 ] && [ -n "${DUPLICATE_SESSION:-}" ]; then
+    continue
+  fi
+
   echo "ERROR: AO failed to start. Check $AO_LOG_FILE"
   kill "$AO_PID" 2>/dev/null || true
   exit 1
-fi
+done
 
 for i in $(seq 1 20); do
   if curl -fsS "http://localhost:${AO_DASHBOARD_PORT}/api/observability" 2>/dev/null | grep -q '"overallStatus"'; then

--- a/start.sh
+++ b/start.sh
@@ -38,7 +38,8 @@ AO_LOG_FILE="/tmp/zapbot-ao.log"
 AO_CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/zapbot-ao-config.XXXXXX.yaml")"
 
 validate_bridge_url() {
-  local configured_url="${ZAPBOT_BRIDGE_URL:-}"
+  local configured_url
+  configured_url="$(trim_env_value "${ZAPBOT_BRIDGE_URL:-}")"
   local health_check_url=""
 
   if [ -z "$configured_url" ]; then
@@ -57,8 +58,12 @@ validate_bridge_url() {
   return 1
 }
 
+trim_env_value() {
+  printf '%s' "${1:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
 INGRESS_MODE="local-only"
-if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
+if [ -n "$(trim_env_value "${ZAPBOT_GATEWAY_URL:-}")" ]; then
   INGRESS_MODE="github-demo"
 fi
 
@@ -116,6 +121,8 @@ if [ "${ZAPBOT_WEBHOOK_SECRET}" = "${ZAPBOT_API_KEY}" ]; then
 fi
 
 if [ "$INGRESS_MODE" = "github-demo" ]; then
+  ZAPBOT_GATEWAY_URL="$(trim_env_value "${ZAPBOT_GATEWAY_URL:-}")"
+  ZAPBOT_BRIDGE_URL="$(trim_env_value "${ZAPBOT_BRIDGE_URL:-}")"
   validate_bridge_url || exit 1
   export ZAPBOT_BRIDGE_URL
 fi

--- a/start.sh
+++ b/start.sh
@@ -136,7 +136,7 @@ fi
 
 pkill -f "bun.*webhook-bridge.ts" 2>/dev/null || true
 
-if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
+if [ -n "${ZAPBOT_BRIDGE_URL:-}" ]; then
   validate_bridge_url || exit 1
   export ZAPBOT_BRIDGE_URL
 fi

--- a/start.sh
+++ b/start.sh
@@ -37,6 +37,41 @@ AO_PORT="${ZAPBOT_AO_PORT:-3001}"
 AO_LOG_FILE="/tmp/zapbot-ao.log"
 AO_CONFIG_FILE="$(mktemp "${TMPDIR:-/tmp}/zapbot-ao-config.XXXXXX.yaml")"
 
+resolve_bridge_url() {
+  local configured_url="${ZAPBOT_BRIDGE_URL:-}"
+  local health_check_url=""
+  local metadata_ip=""
+  local host_ip=""
+
+  if [ -n "$configured_url" ]; then
+    health_check_url="${configured_url%/}/healthz"
+    if curl -fsS --max-time 2 "$health_check_url" >/dev/null 2>&1; then
+      echo "$configured_url"
+      return 0
+    fi
+  fi
+
+  metadata_ip="$(curl -fsS --max-time 2 -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" 2>/dev/null || true)"
+  if [ -n "$metadata_ip" ]; then
+    echo "http://${metadata_ip}:${BRIDGE_PORT}"
+    return 0
+  fi
+
+  host_ip="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+  if [ -n "$host_ip" ]; then
+    echo "http://${host_ip}:${BRIDGE_PORT}"
+    return 0
+  fi
+
+  if [ -n "$configured_url" ]; then
+    echo "ERROR: ZAPBOT_BRIDGE_URL is set but unreachable: $configured_url" >&2
+    return 1
+  fi
+
+  return 0
+}
+
 start_ao_once() {
   : > "$AO_LOG_FILE"
   (cd "$PROJECT_DIR" && AO_CONFIG_PATH="$AO_CONFIG_FILE" ao start > "$AO_LOG_FILE" 2>&1) &
@@ -115,6 +150,17 @@ if systemctl is-active zapbot-bridge >/dev/null 2>&1; then
 fi
 
 pkill -f "bun.*webhook-bridge.ts" 2>/dev/null || true
+
+if [ -n "${ZAPBOT_GATEWAY_URL:-}" ]; then
+  RESOLVED_BRIDGE_URL="$(resolve_bridge_url)" || exit 1
+  if [ -z "$RESOLVED_BRIDGE_URL" ]; then
+    echo "ERROR: ZAPBOT_GATEWAY_URL is set but a live bridge URL could not be derived."
+    echo "FIX: Set ZAPBOT_BRIDGE_URL to the current public URL or run on a host that exposes one."
+    exit 1
+  fi
+  ZAPBOT_BRIDGE_URL="$RESOLVED_BRIDGE_URL"
+  export ZAPBOT_BRIDGE_URL
+fi
 
 AO_DASHBOARD_PORT=""
 for attempt in 1 2; do

--- a/start.sh
+++ b/start.sh
@@ -27,8 +27,10 @@ if [ ! -f "$PROJECT_DIR/agent-orchestrator.yaml" ]; then
   exit 1
 fi
 
-[ -f "$PROJECT_DIR/.env" ] && set -a && source "$PROJECT_DIR/.env" && set +a
+# Load shared bootstrap defaults first, then let the project checkout override them.
+# Fresh repos must keep their generated webhook secret even if ~/.zapbot/.env still exists.
 [ -f "$HOME/.zapbot/.env" ] && set -a && source "$HOME/.zapbot/.env" && set +a
+[ -f "$PROJECT_DIR/.env" ] && set -a && source "$PROJECT_DIR/.env" && set +a
 
 BRIDGE_PORT="${ZAPBOT_PORT:-3000}"
 AO_PORT="${ZAPBOT_AO_PORT:-3001}"

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -12,6 +12,7 @@ import {
   deriveConfigSourcePaths,
   loadBridgeRuntimeConfig,
 } from "../src/config/load.js";
+import type { IngressPolicy } from "../src/config/ingress.js";
 import type { ConfigDiskError } from "../src/config/types.js";
 import type { Result } from "../src/types.js";
 
@@ -21,6 +22,14 @@ function expectOk<T, E>(result: Result<T, E>): T {
   }
   return result.value;
 }
+
+const localOnlyIngress: IngressPolicy = {
+  _tag: "LocalOnly",
+  mode: "local-only",
+  gatewayUrl: null,
+  publicUrl: null,
+  requiresReachablePublicUrl: false,
+};
 
 const nodeDiskReader: ConfigDiskReader = {
   readText(path) {
@@ -75,7 +84,7 @@ projects:
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
       ZAPBOT_CONFIG: configPath,
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(1);
     expect(runtime.routes.has("chughtapan/zapbot")).toBe(true);
@@ -115,7 +124,7 @@ projects:
       ZAPBOT_API_KEY: "api-key-123",
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(2);
     expect(runtime.routes.get("chughtapan/zapbot")!.projectName).toBe("zapbot");
@@ -129,7 +138,7 @@ projects:
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
       ZAPBOT_REPO: "owner/my-repo",
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(1);
     expect(runtime.routes.has("owner/my-repo")).toBe(true);
@@ -141,7 +150,7 @@ projects:
       ZAPBOT_API_KEY: "api-key-123",
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(0);
   });

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -185,6 +185,20 @@ describe("systemd integration: start.sh guard", () => {
     expect(startSh).toContain("2>&1");
     expect(startSh).toMatch(/systemctl is-active zapbot-bridge.*\n[\s\S]*?exit 1/);
   });
+
+  it("loads shared env before project env so checkout-local secrets win", () => {
+    const startSh = fs.readFileSync(
+      path.join(__dirname, "../start.sh"),
+      "utf-8"
+    );
+
+    const sharedIndex = startSh.indexOf('source "$HOME/.zapbot/.env"');
+    const projectIndex = startSh.indexOf('source "$PROJECT_DIR/.env"');
+
+    expect(sharedIndex).toBeGreaterThanOrEqual(0);
+    expect(projectIndex).toBeGreaterThanOrEqual(0);
+    expect(sharedIndex).toBeLessThan(projectIndex);
+  });
 });
 
 describe("systemd integration: team-init reload", () => {

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { parseEnvFile, resolveRuntimeEnv } from "../src/config/env.js";
+import { resolveIngressPolicy } from "../src/config/ingress.js";
 import { reloadBridgeRuntimeConfig } from "../src/config/reload.js";
 import { loadBridgeRuntimeConfig } from "../src/config/load.js";
+import { buildStartupReceipt, renderStartupReceipt } from "../src/startup/receipt.js";
 import { readConfigFiles, type ConfigDiskReader } from "../src/config/disk.js";
 import { execFileSync } from "child_process";
 import * as fs from "fs";
@@ -38,7 +40,13 @@ function buildRuntime(
   env: Record<string, string | undefined>,
 ) {
   const resolvedEnv = expectOk(resolveRuntimeEnv(env, null));
-  return expectOk(loadBridgeRuntimeConfig(resolvedEnv, null, null));
+  return expectOk(loadBridgeRuntimeConfig(resolvedEnv, null, null, {
+    _tag: "LocalOnly",
+    mode: "local-only",
+    gatewayUrl: null,
+    publicUrl: null,
+    requiresReachablePublicUrl: false,
+  }));
 }
 
 describe("parseEnvFile", () => {
@@ -72,6 +80,141 @@ describe("parseEnvFile", () => {
     expect(result._tag).toBe("Err");
     if (result._tag === "Err") {
       expect(result.error._tag).toBe("MalformedEnvLine");
+    }
+  });
+});
+
+describe("resolveIngressPolicy", () => {
+  it("allows local-only startup without a public bridge url", async () => {
+    let called = false;
+    const result = await resolveIngressPolicy({
+      mode: "local-only",
+      gatewayUrl: "",
+      publicUrl: null,
+      isPublicUrlReachable: async () => {
+        called = true;
+        return false;
+      },
+    });
+
+    expect(result._tag).toBe("Ok");
+    expect(called).toBe(false);
+    if (result._tag === "Ok") {
+      expect(result.value).toMatchObject({
+        _tag: "LocalOnly",
+        mode: "local-only",
+        gatewayUrl: null,
+        publicUrl: null,
+        requiresReachablePublicUrl: false,
+      });
+    }
+  });
+
+  it("fails demo mode when the public bridge url is missing", async () => {
+    const result = await resolveIngressPolicy({
+      mode: "github-demo",
+      gatewayUrl: "https://gateway.example",
+      publicUrl: null,
+      isPublicUrlReachable: async () => true,
+    });
+
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "MissingPublicBridgeUrl" },
+    });
+  });
+
+  it("fails demo mode when the public bridge url is unreachable", async () => {
+    const result = await resolveIngressPolicy({
+      mode: "github-demo",
+      gatewayUrl: "https://gateway.example",
+      publicUrl: "https://bridge.example",
+      isPublicUrlReachable: async () => false,
+    });
+
+    expect(result).toEqual({
+      _tag: "Err",
+      error: { _tag: "UnreachablePublicBridgeUrl", publicUrl: "https://bridge.example" },
+    });
+  });
+
+  it("accepts demo mode only when the public bridge url is reachable", async () => {
+    const result = await resolveIngressPolicy({
+      mode: "github-demo",
+      gatewayUrl: "https://gateway.example",
+      publicUrl: "https://bridge.example",
+      isPublicUrlReachable: async () => true,
+    });
+
+    expect(result._tag).toBe("Ok");
+    if (result._tag === "Ok") {
+      expect(result.value).toMatchObject({
+        _tag: "GitHubDemo",
+        mode: "github-demo",
+        gatewayUrl: "https://gateway.example",
+        publicUrl: "https://bridge.example",
+        requiresReachablePublicUrl: true,
+      });
+    }
+  });
+});
+
+describe("startup receipt", () => {
+  it("renders local-only mode with local ingress markers", () => {
+    const receipt = buildStartupReceipt({
+      projectDir: "/tmp/project",
+      repos: ["owner/repo"],
+      ingress: {
+        _tag: "LocalOnly",
+        mode: "local-only",
+        gatewayUrl: null,
+        publicUrl: null,
+        requiresReachablePublicUrl: false,
+      },
+      bridgePort: 3000,
+      dashboardPort: 3001,
+      gatewayUrl: null,
+      publicUrl: null,
+      logsPath: "/tmp/logs",
+      publishCommand: "bash publish.sh",
+    });
+
+    expect(receipt._tag).toBe("Ok");
+    if (receipt._tag === "Ok") {
+      const rendered = renderStartupReceipt(receipt.value);
+      expect(receipt.value.mode).toBe("local-only");
+      expect(rendered).toContain("Mode:      local-only");
+      expect(rendered).toContain("Gateway:   (local-only)");
+      expect(rendered).toContain("Public:    (local-only)");
+    }
+  });
+
+  it("renders github demo mode with explicit ingress endpoints", () => {
+    const receipt = buildStartupReceipt({
+      projectDir: "/tmp/project",
+      repos: ["owner/repo"],
+      ingress: {
+        _tag: "GitHubDemo",
+        mode: "github-demo",
+        gatewayUrl: "https://gateway.example",
+        publicUrl: "https://bridge.example",
+        requiresReachablePublicUrl: true,
+      },
+      bridgePort: 3000,
+      dashboardPort: 3001,
+      gatewayUrl: "https://gateway.example",
+      publicUrl: "https://bridge.example",
+      logsPath: "/tmp/logs",
+      publishCommand: "bash publish.sh",
+    });
+
+    expect(receipt._tag).toBe("Ok");
+    if (receipt._tag === "Ok") {
+      const rendered = renderStartupReceipt(receipt.value);
+      expect(receipt.value.mode).toBe("github-demo");
+      expect(rendered).toContain("Mode:      github-demo");
+      expect(rendered).toContain("Gateway:   https://gateway.example");
+      expect(rendered).toContain("Public:    https://bridge.example");
     }
   });
 });
@@ -361,7 +504,7 @@ exit 0
     }
   });
 
-  it("rejects a dead explicit bridge url even without a gateway configured", () => {
+  it("keeps local-only startup running even if a stale bridge url is present", () => {
     const repoRoot = path.join(__dirname, "..");
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-bridge-explicit-"));
     const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-bridge-home-"));
@@ -395,6 +538,135 @@ exit 0
         [
           "ZAPBOT_API_KEY=project-api-key",
           "ZAPBOT_WEBHOOK_SECRET=project-webhook-secret",
+          "ZAPBOT_BRIDGE_URL=http://dead.example:3000",
+          "",
+        ].join("\n"),
+      );
+
+      writeExecutable(
+        path.join(fakeBinDir, "gh"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo "fake-user"
+  exit 0
+fi
+echo "unexpected gh args: $@" >&2
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "systemctl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "ao"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "start" ]; then
+  echo "Dashboard starting on http://localhost:3002"
+  trap 'exit 0' TERM INT
+  sleep 2
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  echo '[]'
+  exit 0
+fi
+echo "unexpected ao args: $@" >&2
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "bun"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+trap 'exit 0' TERM INT
+sleep 2
+exit 0
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "curl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+url="\${!#}"
+case "$url" in
+  http://localhost:3002/api/observability)
+    echo '{"overallStatus":"ok"}'
+    exit 0
+    ;;
+  http://localhost:3000/healthz)
+    exit 0
+    ;;
+  http://dead.example:3000/healthz)
+    exit 7
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+`,
+      );
+
+      const output = execFileSync("bash", [path.join(repoRoot, "start.sh"), "."], {
+        cwd: projectDir,
+        env: {
+          ...process.env,
+          HOME: tempHome,
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+        encoding: "utf8",
+      });
+
+      expect(output).toContain("Mode:      local-only");
+      expect(output).toContain("Gateway:   (local-only)");
+      expect(output).toContain("Public:    (local-only)");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed in github demo mode when the public bridge url is dead", () => {
+    const repoRoot = path.join(__dirname, "..");
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-bridge-demo-"));
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-bridge-demo-home-"));
+    const projectDir = path.join(tempRoot, "project");
+    const fakeBinDir = path.join(tempRoot, "bin");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(fakeBinDir, { recursive: true });
+    fs.mkdirSync(path.join(tempHome, ".zapbot"), { recursive: true });
+
+    try {
+      writeFile(
+        path.join(projectDir, "agent-orchestrator.yaml"),
+        [
+          "projects:",
+          "  demo:",
+          "    repo: owner/repo",
+          "    path: " + projectDir,
+          "    defaultBranch: main",
+          "    scm:",
+          "      plugin: github",
+          "      webhook:",
+          "        path: /api/webhooks/github",
+          "        secretEnvVar: ZAPBOT_WEBHOOK_SECRET",
+          "        signatureHeader: x-hub-signature-256",
+          "        eventHeader: x-github-event",
+          "",
+        ].join("\n"),
+      );
+      writeFile(
+        path.join(projectDir, ".env"),
+        [
+          "ZAPBOT_API_KEY=project-api-key",
+          "ZAPBOT_WEBHOOK_SECRET=project-webhook-secret",
+          "ZAPBOT_GATEWAY_URL=https://gateway.example",
           "ZAPBOT_BRIDGE_URL=http://dead.example:3000",
           "",
         ].join("\n"),

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -538,6 +538,7 @@ exit 0
         [
           "ZAPBOT_API_KEY=project-api-key",
           "ZAPBOT_WEBHOOK_SECRET=project-webhook-secret",
+          "ZAPBOT_GATEWAY_URL=   ",
           "ZAPBOT_BRIDGE_URL=http://dead.example:3000",
           "",
         ].join("\n"),

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -360,6 +360,105 @@ exit 0
       fs.rmSync(tempHome, { recursive: true, force: true });
     }
   });
+
+  it("rejects a dead explicit bridge url even without a gateway configured", () => {
+    const repoRoot = path.join(__dirname, "..");
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-bridge-explicit-"));
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-bridge-home-"));
+    const projectDir = path.join(tempRoot, "project");
+    const fakeBinDir = path.join(tempRoot, "bin");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(fakeBinDir, { recursive: true });
+    fs.mkdirSync(path.join(tempHome, ".zapbot"), { recursive: true });
+
+    try {
+      writeFile(
+        path.join(projectDir, "agent-orchestrator.yaml"),
+        [
+          "projects:",
+          "  demo:",
+          "    repo: owner/repo",
+          "    path: " + projectDir,
+          "    defaultBranch: main",
+          "    scm:",
+          "      plugin: github",
+          "      webhook:",
+          "        path: /api/webhooks/github",
+          "        secretEnvVar: ZAPBOT_WEBHOOK_SECRET",
+          "        signatureHeader: x-hub-signature-256",
+          "        eventHeader: x-github-event",
+          "",
+        ].join("\n"),
+      );
+      writeFile(
+        path.join(projectDir, ".env"),
+        [
+          "ZAPBOT_API_KEY=project-api-key",
+          "ZAPBOT_WEBHOOK_SECRET=project-webhook-secret",
+          "ZAPBOT_BRIDGE_URL=http://dead.example:3000",
+          "",
+        ].join("\n"),
+      );
+
+      writeExecutable(
+        path.join(fakeBinDir, "gh"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo "fake-user"
+  exit 0
+fi
+echo "unexpected gh args: $@" >&2
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "systemctl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "curl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+url="\${!#}"
+case "$url" in
+  http://dead.example:3000/healthz)
+    exit 7
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+`,
+      );
+
+      let output = "";
+      try {
+        execFileSync("bash", [path.join(repoRoot, "start.sh"), "."], {
+          cwd: projectDir,
+          env: {
+            ...process.env,
+            HOME: tempHome,
+            PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+          },
+          encoding: "utf8",
+        });
+      } catch (error) {
+        output = String((error as { stdout?: unknown; stderr?: unknown }).stdout ?? "") +
+          String((error as { stdout?: unknown; stderr?: unknown }).stderr ?? "");
+      }
+
+      expect(output).toContain("ERROR: ZAPBOT_BRIDGE_URL is unreachable: http://dead.example:3000");
+      expect(output).toContain("FIX: Do not rely on host-derived fallback; set ZAPBOT_BRIDGE_URL to a live public URL.");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("systemd integration: team-init reload", () => {

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -3,6 +3,7 @@ import { parseEnvFile, resolveRuntimeEnv } from "../src/config/env.js";
 import { reloadBridgeRuntimeConfig } from "../src/config/reload.js";
 import { loadBridgeRuntimeConfig } from "../src/config/load.js";
 import { readConfigFiles, type ConfigDiskReader } from "../src/config/disk.js";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -199,6 +200,166 @@ describe("systemd integration: start.sh guard", () => {
     expect(projectIndex).toBeGreaterThanOrEqual(0);
     expect(sharedIndex).toBeLessThan(projectIndex);
   });
+
+  it("retries once after a duplicate orchestrator session is reported", () => {
+    const repoRoot = path.join(__dirname, "..");
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-start-retry-"));
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-start-home-"));
+    const projectDir = path.join(tempRoot, "project");
+    const fakeBinDir = path.join(tempRoot, "bin");
+    const tmuxLog = path.join(tempRoot, "tmux.log");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(fakeBinDir, { recursive: true });
+    fs.mkdirSync(path.join(tempHome, ".zapbot"), { recursive: true });
+
+    try {
+      writeFile(
+        path.join(projectDir, "agent-orchestrator.yaml"),
+        [
+          "projects:",
+          "  demo:",
+          "    repo: owner/repo",
+          "    path: " + projectDir,
+          "    defaultBranch: main",
+          "    scm:",
+          "      plugin: github",
+          "      webhook:",
+          "        path: /api/webhooks/github",
+          "        secretEnvVar: ZAPBOT_WEBHOOK_SECRET",
+          "        signatureHeader: x-hub-signature-256",
+          "        eventHeader: x-github-event",
+          "",
+        ].join("\n"),
+      );
+      writeFile(
+        path.join(projectDir, ".env"),
+        [
+          "# project-local secrets must win",
+          "ZAPBOT_API_KEY=project-api-key",
+          "ZAPBOT_WEBHOOK_SECRET=project-webhook-secret",
+          "",
+        ].join("\n"),
+      );
+      writeFile(
+        path.join(tempHome, ".zapbot", ".env"),
+        [
+          "# shared state intentionally stale",
+          "ZAPBOT_API_KEY=shared-api-key",
+          "ZAPBOT_WEBHOOK_SECRET=shared-webhook-secret",
+          "",
+        ].join("\n"),
+      );
+
+      writeExecutable(
+        path.join(fakeBinDir, "gh"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+  echo "fake-user"
+  exit 0
+fi
+echo "unexpected gh args: $@" >&2
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "systemctl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "is-active" ]; then
+  exit 1
+fi
+exit 0
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "tmux"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "\${TMUX_LOG}"
+if [ "$1" = "kill-session" ]; then
+  exit 0
+fi
+exit 0
+`,
+      );
+writeExecutable(
+        path.join(fakeBinDir, "ao"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+STATE_FILE="\${AO_CONFIG_PATH}.count"
+COUNT=0
+if [ -f "$STATE_FILE" ]; then
+  COUNT=$(cat "$STATE_FILE")
+fi
+if [ "$1" = "start" ]; then
+  COUNT=$((COUNT + 1))
+  echo "$COUNT" > "$STATE_FILE"
+  if [ "$COUNT" -eq 1 ]; then
+    echo "Failed to setup orchestrator: duplicate session: stale-orchestrator-1"
+    exit 1
+  fi
+  echo "Dashboard starting on http://localhost:3002"
+  trap 'exit 0' TERM INT
+  sleep 2
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  echo '[]'
+  exit 0
+fi
+echo "unexpected ao args: $@" >&2
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "bun"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+trap 'exit 0' TERM INT
+sleep 2
+exit 0
+`,
+      );
+writeExecutable(
+        path.join(fakeBinDir, "curl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+url="\${!#}"
+case "$url" in
+  *"/api/observability")
+    echo '{"overallStatus":"ok"}'
+    exit 0
+    ;;
+  *"/healthz")
+    exit 0
+    ;;
+esac
+exit 0
+`,
+      );
+
+      const output = execFileSync("bash", [path.join(repoRoot, "start.sh"), "."], {
+        cwd: projectDir,
+        env: {
+          ...process.env,
+          HOME: tempHome,
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+          TMUX_LOG: tmuxLog,
+        },
+        encoding: "utf8",
+      });
+
+      expect(output).toContain("Detected stale AO tmux session stale-orchestrator-1; removing and retrying startup...");
+      expect(output).toContain("AO ready on port 3002");
+      expect(output).toContain("Bridge ready on port 3000");
+      expect(fs.readFileSync(tmuxLog, "utf8")).toContain("kill-session -t stale-orchestrator-1");
+      expect(fs.readFileSync(path.join(projectDir, "agent-orchestrator.yaml"), "utf8")).toContain("repo: owner/repo");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("systemd integration: team-init reload", () => {
@@ -234,3 +395,12 @@ describe("SIGHUP handler: bridge registers signal handler", () => {
     expect(bridge).toContain("reloadBridgeRuntimeConfig");
   });
 });
+
+function writeFile(filePath: string, content: string): void {
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function writeExecutable(filePath: string, content: string): void {
+  writeFile(filePath, content);
+  fs.chmodSync(filePath, 0o755);
+}


### PR DESCRIPTION
Closes #215
Architect plan: https://github.com/chughtapan/zapbot/issues/214#issuecomment-4279008955

## What changed
Launcher config now separates `local-only` startup from `github-demo` mode, and both `start.sh` and `bin/webhook-bridge.ts` use the same trimmed ingress contract so whitespace-only gateway URLs stay local-only. Demo mode still fails closed when the public bridge URL is missing or unreachable, and the startup receipt states the active mode plus ingress endpoints.

## Validation
- `bash -n start.sh`
- `npx eslint src/config/ingress.ts`
- `npx vitest run test/config-reload.test.ts`
- `npm run build`
