### PR TITLE
[impl-senior] mirror durable status comments to linked PRs

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -13,7 +13,9 @@
 
 import { verifyAndClassify, registerBridge, deregisterBridge, startHeartbeat } from "./gateway.ts";
 import type { GatewayClientConfig, GatewayWebhookEnvelope, ClassifiedWebhook } from "./gateway.ts";
-import { getIssue } from "./github-state.ts";
+import { getIssue, postComment as postGitHubComment } from "./github-state.ts";
+import { mirrorDurableStatusComment, type DurableStatusComment } from "./github/comment-mirroring.ts";
+import { resolveThreadMirrorTargets, type IssueThreadAnchor } from "./github/thread-links.ts";
 import {
   buildMoltzapProcessEnv,
   type MoltzapRuntimeConfig,
@@ -191,16 +193,23 @@ async function handleMention(
         return err(forwarded.error);
       }
       const session = forwarded.value.session;
-      void ctx.gh.postComment(
-        c.repo,
-        c.issue,
-        `Forwarded control event for @${c.triggeredBy}. Session: \`${session as unknown as string}\`.`
+      await postDurableStatusComment(
+        { repo: c.repo, issue: c.issue },
+        {
+          source: "bridge",
+          body: `Forwarded control event for @${c.triggeredBy}. Session: \`${session as unknown as string}\`.`,
+        },
+        ctx,
       );
       return ok({ kind: "dispatched", repo: c.repo, session });
     }
     case "status": {
       const summary = await summarizeIssue(c.repo, c.issue);
-      void ctx.gh.postComment(c.repo, c.issue, summary);
+      await postDurableStatusComment(
+        { repo: c.repo, issue: c.issue },
+        { source: "bridge", body: summary },
+        ctx,
+      );
       return ok({ kind: "replied", command: "status" });
     }
     case "unknown_command": {
@@ -228,6 +237,46 @@ async function summarizeIssue(repo: RepoFullName, issue: IssueNumber): Promise<s
     `Assignees: ${assignees.length ? assignees.map((a) => `@${a}`).join(", ") : "_(none)_"}`,
   ];
   return lines.join("\n");
+}
+
+async function postDurableStatusComment(
+  anchor: IssueThreadAnchor,
+  comment: DurableStatusComment,
+  ctx: BridgeHandlerContext,
+): Promise<void> {
+  const targets = await resolveThreadMirrorTargets(anchor);
+  if (targets._tag === "Err") {
+    log.warn(
+      `durable_comment_target_lookup_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${targets.error._tag}`,
+    );
+    const fallback = await ctx.gh.postComment(anchor.repo, anchor.issue, comment.body);
+    if (fallback._tag === "Err") {
+      log.warn(
+        `durable_comment_issue_post_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${fallback.error.cause}`,
+      );
+    }
+    return;
+  }
+
+  const receipt = await mirrorDurableStatusComment(
+    targets.value,
+    comment,
+    { postComment: postGitHubComment },
+  );
+  if (receipt._tag === "Err") {
+    const fallback = await ctx.gh.postComment(anchor.repo, anchor.issue, comment.body);
+    if (fallback._tag === "Err") {
+      log.warn(
+        `durable_comment_issue_post_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${receipt.error.cause}`,
+      );
+    }
+    return;
+  }
+  if (receipt.value.linkedPullRequestMirror._tag === "Failed") {
+    log.warn(
+      `durable_comment_pr_mirror_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} linked_pr=${targets.value.linkedPullRequest as unknown as number} cause=${receipt.value.linkedPullRequestMirror.cause}`,
+    );
+  }
 }
 
 // ── Server boot ─────────────────────────────────────────────────────

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -139,6 +139,22 @@ interface IssueCommentPayload {
   readonly sender: { readonly login: string };
 }
 
+interface JsonObject {
+  readonly [key: string]: unknown;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object";
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
 type DecodeResult =
   | { readonly kind: "decoded"; readonly value: IssueCommentPayload }
   | { readonly kind: "invalid"; readonly reason: string }
@@ -154,45 +170,41 @@ function decodeIssueCommentPayload(
   payload: unknown,
   eventType: string
 ): DecodeResult {
-  if (payload === null || typeof payload !== "object") {
+  if (!isJsonObject(payload)) {
     return { kind: "invalid", reason: "payload is not an object" };
   }
   if (eventType !== "issue_comment") {
     return { kind: "other_event", reason: `event ${eventType}` };
   }
-  const p = payload as Record<string, unknown>;
-  const action = p.action;
-  if (typeof action !== "string") {
+  const action = payload.action;
+  if (!isString(action)) {
     return { kind: "invalid", reason: "missing string 'action'" };
   }
   if (action !== "created") {
     return { kind: "other_event", reason: `action ${action}` };
   }
 
-  const comment = p.comment;
-  if (comment === null || typeof comment !== "object") {
+  const comment = payload.comment;
+  if (!isJsonObject(comment)) {
     return { kind: "invalid", reason: "missing 'comment' object" };
   }
-  const c = comment as Record<string, unknown>;
-  if (typeof c.id !== "number" || typeof c.body !== "string") {
+  if (!isNumber(comment.id) || !isString(comment.body)) {
     return { kind: "invalid", reason: "comment.id/body malformed" };
   }
 
-  const issue = p.issue;
-  if (issue === null || typeof issue !== "object") {
+  const issue = payload.issue;
+  if (!isJsonObject(issue)) {
     return { kind: "invalid", reason: "missing 'issue' object" };
   }
-  const i = issue as Record<string, unknown>;
-  if (typeof i.number !== "number") {
+  if (!isNumber(issue.number)) {
     return { kind: "invalid", reason: "issue.number malformed" };
   }
 
-  const sender = p.sender;
-  if (sender === null || typeof sender !== "object") {
+  const sender = payload.sender;
+  if (!isJsonObject(sender)) {
     return { kind: "invalid", reason: "missing 'sender' object" };
   }
-  const s = sender as Record<string, unknown>;
-  if (typeof s.login !== "string") {
+  if (!isString(sender.login)) {
     return { kind: "invalid", reason: "sender.login malformed" };
   }
 
@@ -200,12 +212,12 @@ function decodeIssueCommentPayload(
     kind: "decoded",
     value: {
       action,
-      comment: { id: c.id, body: c.body },
+      comment: { id: comment.id, body: comment.body },
       issue: {
-        number: i.number,
-        isPullRequest: i.pull_request !== undefined && i.pull_request !== null,
+        number: issue.number,
+        isPullRequest: issue.pull_request !== undefined && issue.pull_request !== null,
       },
-      sender: { login: s.login },
+      sender: { login: sender.login },
     },
   };
 }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -212,8 +212,9 @@ function decodeIssueCommentPayload(
 
 /**
  * Verify HMAC, then classify the envelope into either `ignore` or a
- * `mention_command`. Only `issue_comment.created` events whose body mentions
- * the bot can become `mention_command`; everything else resolves to `ignore`.
+ * `mention_command`. Only issue-thread `issue_comment.created` events whose
+ * body mentions the bot can become `mention_command`; PR-thread comments are
+ * canonical-issue misses and are ignored.
  */
 export async function verifyAndClassify(
   envelope: GatewayWebhookEnvelope,
@@ -234,6 +235,9 @@ export async function verifyAndClassify(
   }
 
   const p = decoded.value;
+  if (p.issue.isPullRequest) {
+    return ok({ kind: "ignore", reason: "pull_request_thread" });
+  }
   if (p.sender.login === (botUsername as unknown as string)) {
     return ok({ kind: "ignore", reason: "self-mention" });
   }

--- a/src/github-state.ts
+++ b/src/github-state.ts
@@ -41,6 +41,22 @@ export interface CommentSnapshot {
   readonly createdAt: string;
 }
 
+interface IssueEventSourcePullRequest {
+  readonly number?: number | null;
+}
+
+interface IssueEventSource {
+  readonly type?: string | null;
+  readonly pull_request?: IssueEventSourcePullRequest | null;
+  readonly issue?: { readonly number?: number | null } | null;
+}
+
+interface IssueEventSnapshot {
+  readonly event?: string | null;
+  readonly created_at?: string | null;
+  readonly source?: IssueEventSource | null;
+}
+
 export type Claim =
   | { readonly kind: "unclaimed" }
   | { readonly kind: "claimed"; readonly by: BotUsername };
@@ -159,6 +175,53 @@ export async function postComment(
   } catch (e) {
     return err(toError(repo, issue, e));
   }
+}
+
+export async function getLinkedPullRequest(
+  repo: RepoFullName,
+  issue: IssueNumber
+): Promise<Result<IssueNumber | null, GithubStateError>> {
+  const client = getOctokit();
+  if (client === null) return err({ _tag: "GitHubAuthMissing" });
+  const r = splitRepo(repo);
+  try {
+    const { data } = await client.rest.issues.listEvents({
+      owner: r.owner,
+      repo: r.repo,
+      issue_number: issue as unknown as number,
+      per_page: 100,
+    });
+    return ok(findLinkedPullRequest(data as ReadonlyArray<IssueEventSnapshot>));
+  } catch (e) {
+    return err(toError(repo, issue, e));
+  }
+}
+
+function findLinkedPullRequest(events: ReadonlyArray<IssueEventSnapshot>): IssueNumber | null {
+  let latestAt = Number.NEGATIVE_INFINITY;
+  let linked: IssueNumber | null = null;
+  for (const event of events) {
+    if (event.event !== "cross-referenced") continue;
+    const pullRequest = extractPullRequestNumber(event.source);
+    if (pullRequest === null) continue;
+    const createdAt = event.created_at ? Date.parse(event.created_at) : Number.NaN;
+    if (Number.isNaN(createdAt)) continue;
+    if (createdAt >= latestAt) {
+      latestAt = createdAt;
+      linked = pullRequest;
+    }
+  }
+  return linked;
+}
+
+function extractPullRequestNumber(source: IssueEventSource | null | undefined): IssueNumber | null {
+  if (!source) return null;
+  if (source.type !== undefined && source.type !== null && source.type !== "pull_request") {
+    return null;
+  }
+  const number = source.pull_request?.number ?? source.issue?.number ?? null;
+  if (typeof number !== "number") return null;
+  return asIssueNumber(number);
 }
 
 // ── Octokit wiring ──────────────────────────────────────────────────

--- a/src/github-state.ts
+++ b/src/github-state.ts
@@ -57,6 +57,22 @@ interface IssueEventSnapshot {
   readonly source?: IssueEventSource | null;
 }
 
+interface JsonObject {
+  readonly [key: string]: unknown;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object";
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === "number";
+}
+
 export type Claim =
   | { readonly kind: "unclaimed" }
   | { readonly kind: "claimed"; readonly by: BotUsername };
@@ -185,16 +201,121 @@ export async function getLinkedPullRequest(
   if (client === null) return err({ _tag: "GitHubAuthMissing" });
   const r = splitRepo(repo);
   try {
-    const { data } = await client.rest.issues.listEvents({
-      owner: r.owner,
-      repo: r.repo,
-      issue_number: issue as unknown as number,
-      per_page: 100,
-    });
-    return ok(findLinkedPullRequest(data as ReadonlyArray<IssueEventSnapshot>));
+    const events = await listAllIssueEvents(client, r.owner, r.repo, issue as unknown as number);
+    if (events._tag === "Err") return err(events.error);
+    return ok(findLinkedPullRequest(events.value));
   } catch (e) {
     return err(toError(repo, issue, e));
   }
+}
+
+async function listAllIssueEvents(
+  client: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<Result<ReadonlyArray<IssueEventSnapshot>, GithubStateError>> {
+  const collected: IssueEventSnapshot[] = [];
+  for (let page = 1; ; page += 1) {
+    const response = await client.rest.issues.listEvents({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      per_page: 100,
+      page,
+    });
+    const decoded = decodeIssueEventPage(response.data);
+    if (decoded._tag === "Err") return err(decoded.error);
+    collected.push(...decoded.value);
+    if (response.data.length < 100) break;
+  }
+  return ok(collected);
+}
+
+function decodeIssueEventPage(data: unknown): Result<ReadonlyArray<IssueEventSnapshot>, GithubStateError> {
+  if (!Array.isArray(data)) {
+    return err({ _tag: "GitHubApiFailed", status: -1, message: "issue events payload was not an array" });
+  }
+  const events: IssueEventSnapshot[] = [];
+  for (const entry of data) {
+    const decoded = decodeIssueEvent(entry);
+    if (decoded._tag === "Err") return decoded;
+    events.push(decoded.value);
+  }
+  return ok(events);
+}
+
+function decodeIssueEvent(entry: unknown): Result<IssueEventSnapshot, GithubStateError> {
+  if (!isJsonObject(entry)) {
+    return err({ _tag: "GitHubApiFailed", status: -1, message: "issue event entry was not an object" });
+  }
+  const event = decodeOptionalString(entry.event, "issue event entry had invalid event");
+  if (event._tag === "Err") return event;
+  const createdAt = decodeOptionalString(entry.created_at, "issue event entry had invalid created_at");
+  if (createdAt._tag === "Err") return createdAt;
+  const source = decodeIssueEventSource(entry.source);
+  if (source._tag === "Err") return source;
+  return ok({
+    event: event.value,
+    created_at: createdAt.value,
+    source: source.value,
+  });
+}
+
+function decodeIssueEventSource(value: unknown): Result<IssueEventSource | null, GithubStateError> {
+  if (value === undefined || value === null) {
+    return ok(null);
+  }
+  if (!isJsonObject(value)) {
+    return err({ _tag: "GitHubApiFailed", status: -1, message: "issue event entry had invalid source" });
+  }
+
+  const type = decodeOptionalString(value.type, "issue event source had invalid type");
+  if (type._tag === "Err") return type;
+
+  let issue: { readonly number?: number | null } | undefined = undefined;
+  if (value.issue !== undefined && value.issue !== null) {
+    if (!isJsonObject(value.issue)) {
+      return err({ _tag: "GitHubApiFailed", status: -1, message: "issue event source had invalid issue" });
+    }
+    const number = decodeOptionalNumber(value.issue.number, "issue event source issue had invalid number");
+    if (number._tag === "Err") return number;
+    issue = { number: number.value };
+  }
+
+  let pullRequest: IssueEventSourcePullRequest | undefined = undefined;
+  if (value.pull_request !== undefined && value.pull_request !== null) {
+    if (!isJsonObject(value.pull_request)) {
+      return err({ _tag: "GitHubApiFailed", status: -1, message: "issue event source had invalid pull_request" });
+    }
+    const number = decodeOptionalNumber(value.pull_request.number, "issue event source pull_request had invalid number");
+    if (number._tag === "Err") return number;
+    pullRequest = { number: number.value };
+  }
+
+  return ok({
+    type: type.value,
+    issue,
+    pull_request: pullRequest,
+  });
+}
+
+function decodeOptionalString(
+  value: unknown,
+  message: string,
+): Result<string | null | undefined, GithubStateError> {
+  if (value === undefined || value === null) return ok(value);
+  if (isString(value)) return ok(value);
+  return err({ _tag: "GitHubApiFailed", status: -1, message });
+}
+
+function decodeOptionalNumber(
+  value: unknown,
+  message: string,
+): Result<number | null | undefined, GithubStateError> {
+  if (value === undefined || value === null) return ok(value);
+  if (isNumber(value)) return ok(value);
+  return err({ _tag: "GitHubApiFailed", status: -1, message });
 }
 
 function findLinkedPullRequest(events: ReadonlyArray<IssueEventSnapshot>): IssueNumber | null {

--- a/src/github/comment-mirroring.ts
+++ b/src/github/comment-mirroring.ts
@@ -1,0 +1,94 @@
+/**
+ * github/comment-mirroring — fan out durable status comments to the canonical
+ * issue thread and, when linked, the associated pull request thread.
+ */
+
+import { err, ok } from "../types.ts";
+import type { CommentId, IssueNumber, RepoFullName, Result } from "../types.ts";
+import type { ThreadMirrorTargets } from "./thread-links.ts";
+
+export type DurableStatusCommentSource = "bridge" | "orchestrator";
+
+export interface DurableStatusComment {
+  readonly source: DurableStatusCommentSource;
+  readonly body: string;
+}
+
+export interface CommentMirrorSink {
+  readonly postComment: (
+    repo: RepoFullName,
+    issue: IssueNumber,
+    body: string,
+  ) => Promise<Result<CommentId, unknown>>;
+}
+
+export type LinkedPullRequestMirrorStatus =
+  | { readonly _tag: "Mirrored"; readonly linkedPullRequestCommentId: CommentId }
+  | { readonly _tag: "NotLinked" }
+  | { readonly _tag: "Failed"; readonly cause: string };
+
+export interface CommentMirrorReceipt {
+  readonly issueCommentId: CommentId;
+  readonly linkedPullRequestMirror: LinkedPullRequestMirrorStatus;
+}
+
+export type CommentMirrorError = {
+  readonly _tag: "IssueCommentPostFailed";
+  readonly cause: string;
+};
+
+export async function mirrorDurableStatusComment(
+  targets: ThreadMirrorTargets,
+  comment: DurableStatusComment,
+  sink: CommentMirrorSink,
+): Promise<Result<CommentMirrorReceipt, CommentMirrorError>> {
+  const issueComment = await sink.postComment(targets.repo, targets.issue, comment.body);
+  if (issueComment._tag === "Err") {
+    return err({ _tag: "IssueCommentPostFailed", cause: stringifyError(issueComment.error) });
+  }
+
+  if (targets.linkedPullRequest === null) {
+    return ok({
+      issueCommentId: issueComment.value,
+      linkedPullRequestMirror: { _tag: "NotLinked" },
+    });
+  }
+
+  const linkedPullRequestComment = await sink.postComment(
+    targets.repo,
+    targets.linkedPullRequest,
+    comment.body,
+  );
+  if (linkedPullRequestComment._tag === "Err") {
+    return ok({
+      issueCommentId: issueComment.value,
+      linkedPullRequestMirror: {
+        _tag: "Failed",
+        cause: stringifyError(linkedPullRequestComment.error),
+      },
+    });
+  }
+
+  return ok({
+    issueCommentId: issueComment.value,
+    linkedPullRequestMirror: {
+      _tag: "Mirrored",
+      linkedPullRequestCommentId: linkedPullRequestComment.value,
+    },
+  });
+}
+
+function stringifyError(error: unknown): string {
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object") {
+    const maybeTag = (error as { _tag?: string })._tag;
+    const maybeCause = (error as { cause?: unknown }).cause;
+    if (typeof maybeTag === "string" && maybeCause !== undefined) {
+      return `${maybeTag}: ${String(maybeCause)}`;
+    }
+    if (typeof maybeTag === "string") {
+      return maybeTag;
+    }
+  }
+  return String(error);
+}

--- a/src/github/thread-links.ts
+++ b/src/github/thread-links.ts
@@ -1,0 +1,33 @@
+/**
+ * github/thread-links — resolve a canonical issue-thread anchor into a
+ * durable mirror target set.
+ */
+
+import { getIssue, getLinkedPullRequest } from "../github-state.ts";
+import { err, ok } from "../types.ts";
+import type { GithubStateError, IssueNumber, RepoFullName, Result } from "../types.ts";
+
+export interface IssueThreadAnchor {
+  readonly repo: RepoFullName;
+  readonly issue: IssueNumber;
+}
+
+export interface ThreadMirrorTargets extends IssueThreadAnchor {
+  readonly linkedPullRequest: IssueNumber | null;
+}
+
+export async function resolveThreadMirrorTargets(
+  anchor: IssueThreadAnchor,
+): Promise<Result<ThreadMirrorTargets, GithubStateError>> {
+  const issue = await getIssue(anchor.repo, anchor.issue);
+  if (issue._tag === "Err") return err(issue.error);
+
+  const linkedPullRequest = await getLinkedPullRequest(anchor.repo, anchor.issue);
+  if (linkedPullRequest._tag === "Err") return err(linkedPullRequest.error);
+
+  return ok({
+    repo: anchor.repo,
+    issue: anchor.issue,
+    linkedPullRequest: linkedPullRequest.value,
+  });
+}

--- a/test/bridge.http.test.ts
+++ b/test/bridge.http.test.ts
@@ -218,6 +218,28 @@ describe("bridge fetch handler — webhook route", () => {
     expect(((await r.json()) as { error: { type: string } }).error.type).toBe("invalid_request");
   });
 
+  it("well-signed issue_comment on a PR thread returns 200 with ignored outcome", async () => {
+    const h = makeHandler();
+    const body = JSON.stringify({
+      action: "created",
+      repository: { full_name: "acme/app" },
+      sender: { login: "alice" },
+      issue: { number: 1, pull_request: { url: "https://api.github.com/repos/acme/app/pulls/1" } },
+      comment: { id: 1, body: "@zapbot status" },
+    });
+    const sig = await signPayload(body, WEBHOOK_SECRET);
+    const r = await post(h, "/api/webhooks/github", body, {
+      "x-hub-signature-256": sig,
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "d-1",
+    });
+    expect(r.status).toBe(200);
+    const parsed = (await r.json()) as { ok: boolean; outcome: { kind: string; reason: string } };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.outcome.kind).toBe("ignored");
+    expect(parsed.outcome.reason).toBe("pull_request_thread");
+  });
+
   it("well-signed pull_request event returns 200 with ignored outcome", async () => {
     const h = makeHandler();
     const body = JSON.stringify({

--- a/test/gateway.test.ts
+++ b/test/gateway.test.ts
@@ -76,6 +76,22 @@ describe("verifyAndClassify", () => {
     if (r._tag === "Ok") expect(r.value.kind).toBe("ignore");
   });
 
+  it("ignores issue_comment events opened on pull request threads", async () => {
+    const body = JSON.stringify({
+      action: "created",
+      sender: { login: "alice" },
+      issue: { number: 7, pull_request: { url: "https://api.github.com/repos/acme/app/pulls/7" } },
+      comment: { id: 99, body: "@zapbot status" },
+    });
+    const env = await buildEnvelope(body, secret);
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") {
+      expect(r.value.kind).toBe("ignore");
+      if (r.value.kind === "ignore") expect(r.value.reason).toBe("pull_request_thread");
+    }
+  });
+
   it("ignores self-mentions from the bot", async () => {
     const body = JSON.stringify({
       action: "created",

--- a/test/github-comment-mirroring.test.ts
+++ b/test/github-comment-mirroring.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { mirrorDurableStatusComment, type CommentMirrorSink } from "../src/github/comment-mirroring.ts";
+import { asCommentId, asIssueNumber, asRepoFullName, err, ok } from "../src/types.ts";
+import type { ThreadMirrorTargets } from "../src/github/thread-links.ts";
+
+const repo = asRepoFullName("acme/app");
+const issue = asIssueNumber(42);
+const pr = asIssueNumber(77);
+
+describe("mirrorDurableStatusComment", () => {
+  it("posts to issue and linked PR when both succeed", async () => {
+    const calls: Array<{ repo: string; issue: number; body: string }> = [];
+    const sink: CommentMirrorSink = {
+      postComment: async (repo, issue, body) => {
+        calls.push({ repo: repo as unknown as string, issue: issue as unknown as number, body });
+        return ok(asCommentId(calls.length));
+      },
+    };
+    const targets: ThreadMirrorTargets = { repo, issue, linkedPullRequest: pr };
+    const r = await mirrorDurableStatusComment(
+      targets,
+      { source: "bridge", body: "status update" },
+      sink,
+    );
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") {
+      expect(r.value.linkedPullRequestMirror._tag).toBe("Mirrored");
+      if (r.value.linkedPullRequestMirror._tag === "Mirrored") {
+        expect(r.value.linkedPullRequestMirror.linkedPullRequestCommentId as unknown as number).toBe(2);
+      }
+    }
+    expect(calls).toEqual([
+      { repo: "acme/app", issue: 42, body: "status update" },
+      { repo: "acme/app", issue: 77, body: "status update" },
+    ]);
+  });
+
+  it("records a partial failure when the linked PR post fails", async () => {
+    const sink: CommentMirrorSink = {
+      postComment: async (repo, issue, body) => {
+        if ((issue as unknown as number) === 42) {
+          return ok(asCommentId(1));
+        }
+        return err({ _tag: "GhCallFailed", label: "postComment", cause: "boom" });
+      },
+    };
+    const r = await mirrorDurableStatusComment(
+      { repo, issue, linkedPullRequest: pr },
+      { source: "bridge", body: "status update" },
+      sink,
+    );
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") {
+      expect(r.value.linkedPullRequestMirror._tag).toBe("Failed");
+    }
+  });
+
+  it("fails when the canonical issue post fails", async () => {
+    const sink: CommentMirrorSink = {
+      postComment: async () => err({ _tag: "GhCallFailed", label: "postComment", cause: "offline" }),
+    };
+    const r = await mirrorDurableStatusComment(
+      { repo, issue, linkedPullRequest: null },
+      { source: "bridge", body: "status update" },
+      sink,
+    );
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") {
+      expect(r.error._tag).toBe("IssueCommentPostFailed");
+    }
+  });
+});

--- a/test/github-state.test.ts
+++ b/test/github-state.test.ts
@@ -149,7 +149,8 @@ describe("postComment", () => {
 describe("getLinkedPullRequest", () => {
   it("returns the latest linked pull request number from cross-reference events", async () => {
     installFetchStub((url) => {
-      if (url.includes("/issues/42/events") && new URL(url).searchParams.get("page") === "1") {
+      const parsedUrl = new URL(url);
+      if (parsedUrl.pathname.includes("/issues/42/events") && parsedUrl.searchParams.get("page") === "1") {
         return Response.json([
           {
             event: "cross-referenced",
@@ -163,7 +164,7 @@ describe("getLinkedPullRequest", () => {
           })),
         ]);
       }
-      if (url.includes("/issues/42/events") && url.includes("page=2")) {
+      if (parsedUrl.pathname.includes("/issues/42/events") && parsedUrl.searchParams.get("page") === "2") {
         return Response.json([
           {
             event: "cross-referenced",

--- a/test/github-state.test.ts
+++ b/test/github-state.test.ts
@@ -149,7 +149,7 @@ describe("postComment", () => {
 describe("getLinkedPullRequest", () => {
   it("returns the latest linked pull request number from cross-reference events", async () => {
     installFetchStub((url) => {
-      if (url.includes("/issues/42/events") && url.includes("page=1")) {
+      if (url.includes("/issues/42/events") && new URL(url).searchParams.get("page") === "1") {
         return Response.json([
           {
             event: "cross-referenced",

--- a/test/github-state.test.ts
+++ b/test/github-state.test.ts
@@ -4,6 +4,7 @@ import {
   getAgentClaim,
   listOpenIssuesWithLabel,
   postComment,
+  getLinkedPullRequest,
   __resetForTests,
 } from "../src/github-state.ts";
 import {
@@ -142,5 +143,40 @@ describe("postComment", () => {
     const r = await postComment(repo, issue, "hello");
     expect(r._tag).toBe("Ok");
     if (r._tag === "Ok") expect(r.value as unknown as number).toBe(9999);
+  });
+});
+
+describe("getLinkedPullRequest", () => {
+  it("returns the latest linked pull request number from cross-reference events", async () => {
+    installFetchStub((url) => {
+      if (url.includes("/issues/42/events")) {
+        return Response.json([
+          {
+            event: "cross-referenced",
+            created_at: "2026-04-20T10:00:00Z",
+            source: { type: "pull_request", pull_request: { number: 17 } },
+          },
+          {
+            event: "cross-referenced",
+            created_at: "2026-04-20T11:00:00Z",
+            source: { type: "pull_request", pull_request: { number: 23 } },
+          },
+        ]);
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const r = await getLinkedPullRequest(repo, issue);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") {
+      expect(r.value as unknown as number).toBe(23);
+    }
+  });
+
+  it("returns null when no linked pull request exists", async () => {
+    installFetchStub(() => Response.json([]));
+    const r = await getLinkedPullRequest(repo, issue);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value).toBeNull();
   });
 });

--- a/test/github-state.test.ts
+++ b/test/github-state.test.ts
@@ -149,13 +149,22 @@ describe("postComment", () => {
 describe("getLinkedPullRequest", () => {
   it("returns the latest linked pull request number from cross-reference events", async () => {
     installFetchStub((url) => {
-      if (url.includes("/issues/42/events")) {
+      if (url.includes("/issues/42/events") && url.includes("page=1")) {
         return Response.json([
           {
             event: "cross-referenced",
             created_at: "2026-04-20T10:00:00Z",
             source: { type: "pull_request", pull_request: { number: 17 } },
           },
+          ...Array.from({ length: 99 }, (_, index) => ({
+            event: "labeled",
+            created_at: `2026-04-20T10:${String(index % 60).padStart(2, "0")}:00Z`,
+            source: null,
+          })),
+        ]);
+      }
+      if (url.includes("/issues/42/events") && url.includes("page=2")) {
+        return Response.json([
           {
             event: "cross-referenced",
             created_at: "2026-04-20T11:00:00Z",
@@ -170,6 +179,27 @@ describe("getLinkedPullRequest", () => {
     expect(r._tag).toBe("Ok");
     if (r._tag === "Ok") {
       expect(r.value as unknown as number).toBe(23);
+    }
+  });
+
+  it("rejects malformed issue event payloads at the boundary", async () => {
+    installFetchStub((url) => {
+      if (url.includes("/issues/42/events")) {
+        return Response.json([
+          {
+            event: "cross-referenced",
+            created_at: "2026-04-20T10:00:00Z",
+            source: { type: "pull_request", pull_request: { number: "not-a-number" } },
+          },
+        ]);
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const r = await getLinkedPullRequest(repo, issue);
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") {
+      expect(r.error._tag).toBe("GitHubApiFailed");
     }
   });
 

--- a/test/github-thread-links.test.ts
+++ b/test/github-thread-links.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveThreadMirrorTargets } from "../src/github/thread-links.ts";
+import { __resetForTests } from "../src/github-state.ts";
+import { asIssueNumber, asRepoFullName } from "../src/types.ts";
+
+const repo = asRepoFullName("acme/app");
+const issue = asIssueNumber(42);
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+function installFetchStub(handler: (url: string, init?: RequestInit) => Promise<Response> | Response) {
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    return handler(url, init);
+  }) as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  __resetForTests();
+  process.env = { ...originalEnv };
+  process.env.ZAPBOT_GITHUB_TOKEN = "fake-token";
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.env = { ...originalEnv };
+});
+
+describe("resolveThreadMirrorTargets", () => {
+  it("returns the canonical issue and its linked pull request", async () => {
+    installFetchStub((url) => {
+      if (url.includes("/issues/42") && !url.includes("/events")) {
+        return Response.json({
+          number: 42,
+          state: "open",
+          labels: [],
+          assignees: [],
+          body: "issue body",
+          user: { login: "carol" },
+        });
+      }
+      if (url.includes("/issues/42/events")) {
+        return Response.json([
+          {
+            event: "cross-referenced",
+            created_at: "2026-04-20T10:00:00Z",
+            source: { type: "pull_request", pull_request: { number: 77 } },
+          },
+        ]);
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const r = await resolveThreadMirrorTargets({ repo, issue });
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") {
+      expect(r.value.repo).toBe(repo);
+      expect(r.value.issue as unknown as number).toBe(42);
+      expect(r.value.linkedPullRequest as unknown as number).toBe(77);
+    }
+  });
+});


### PR DESCRIPTION
Closes #220
Architect plan: https://github.com/chughtapan/zapbot/issues/219#issuecomment-4282278383

## What changed
Implemented the current-runtime mirroring lane so issue-thread status comments are canonical, PR-thread `issue_comment` events are ignored, and durable bridge status replies are mirrored to the linked PR when one exists. The bridge resolves current GitHub thread targets and falls back to issue-only posting when lookup is unavailable.

## Plan anchors
| Change | Plan anchor |
|---|---|
| Ignore PR-thread `issue_comment` events in gateway classification | Modules §1, Data flow §2 |
| Add linked-PR lookup on current GitHub state | Modules §2, Interfaces, Errors |
| Resolve canonical issue-thread anchor and linked PR targets | Modules §3, Interfaces |
| Fan out durable status comments with partial-success PR receipts | Modules §4, Interfaces, Errors |
| Route bridge status replies through the mirroring helper | Modules §5, Data flow §§1,3,4,5,7 |

## Scope
- Modules touched: `src/gateway.ts`, `src/github-state.ts`, `src/github/thread-links.ts`, `src/github/comment-mirroring.ts`, `src/bridge.ts`
- Tests added/updated: `test/gateway.test.ts`, `test/github-state.test.ts`, `test/bridge.http.test.ts`, `test/github-thread-links.test.ts`, `test/github-comment-mirroring.test.ts`, `test/bridge.test.ts`
- Tier: senior
- New modules: 2
- New public signatures outside the plan: 0
- New deps: 0

## Tests
- `pnpm exec vitest run test/gateway.test.ts test/github-state.test.ts test/bridge.test.ts test/bridge.http.test.ts test/github-thread-links.test.ts test/github-comment-mirroring.test.ts`
- `pnpm test`
- `pnpm exec eslint src/gateway.ts src/github-state.ts src/github/thread-links.ts src/github/comment-mirroring.ts src/bridge.ts test/gateway.test.ts test/github-state.test.ts test/bridge.test.ts test/bridge.http.test.ts test/github-thread-links.test.ts test/github-comment-mirroring.test.ts`
- `safer-diff-scope --head HEAD` => `{"tier":"senior","files":11,"modules":10,"exports":11,"new_deps":0}`
- `pnpm exec tsc --noEmit` hit an unrelated repo-level missing module in `bin/moltzap-claude-channel.ts` (`@moltzap/protocol`)

## Confidence
HIGH — full Vitest suite passed, targeted lint passed with existing repo warnings only, and the diff is scoped to the approved mirroring lane.
