### PR TITLE
[impl-senior] bounded runtime migration lane

### DIFF
--- a/test/error-response.test.ts
+++ b/test/error-response.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { errorResponse } from "../src/http/error-response.js";
+import { errorResponse } from "../v2/http/error-response.js";
 
 describe("errorResponse", () => {
   it("returns correct status code", async () => {

--- a/test/github-client.test.ts
+++ b/test/github-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { loadPrivateKey, createGitHubClient } from "../src/github/client.js";
+import { loadPrivateKey, createGitHubClient } from "../v2/github/client.js";
 import { generateKeyPairSync } from "crypto";
 import { writeFileSync, mkdtempSync, rmSync } from "fs";
 import { join } from "path";

--- a/test/installation-token.test.ts
+++ b/test/installation-token.test.ts
@@ -3,7 +3,7 @@ import {
   handleInstallationTokenRequest,
   verifyBearer,
   type InstallationTokenDeps,
-} from "../src/http/routes/installation-token.js";
+} from "../v2/http/routes/installation-token.js";
 
 const API_KEY = "test-zapbot-api-key-abcdef0123456789";
 const FAKE_EXPIRES_AT = "2026-04-18T01:00:00Z";

--- a/test/v2-ao-dispatcher.test.ts
+++ b/test/v2-ao-dispatcher.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { dispatch } from "../v2/ao/dispatcher.ts";
+import { fromSenderIds } from "../v2/moltzap/identity-allowlist.ts";
+import { asMoltzapSenderId } from "../v2/moltzap/types.ts";
+import {
+  asIssueNumber,
+  asProjectName,
+  asRepoFullName,
+} from "../v2/types.ts";
+
+const originalPath = process.env.PATH;
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+});
+
+describe("dispatch", () => {
+  it("passes MOLTZAP_* env through to spawned ao sessions", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-dispatch-"));
+    const fakeAoPath = path.join(tempDir, "ao");
+    const captureBase = path.join(tempDir, "ao-config.yaml");
+    fs.writeFileSync(
+      fakeAoPath,
+      `#!/usr/bin/env sh
+out="$AO_CONFIG_PATH.capture"
+{
+  printf '%s\\n' "$AO_PROJECT_ID"
+  printf '%s\\n' "$GH_TOKEN"
+  printf '%s\\n' "$MOLTZAP_SERVER_URL"
+  printf '%s\\n' "$MOLTZAP_API_KEY"
+  printf '%s\\n' "$MOLTZAP_ALLOWED_SENDERS"
+} > "$out"
+exit 0
+`,
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${tempDir}:${originalPath ?? ""}`;
+
+    const result = await dispatch({
+      repo: asRepoFullName("acme/app"),
+      issue: asIssueNumber(42),
+      projectName: asProjectName("app"),
+      configPath: captureBase,
+      installationToken: "gh-installation-token" as never,
+      moltzap: {
+        _tag: "MoltzapStatic",
+        serverUrl: "wss://moltzap.example/ws",
+        apiKey: "moltzap-key",
+        allowlistCsv: "agent-a",
+        allowlist: fromSenderIds([asMoltzapSenderId("agent-a")]),
+      },
+    });
+
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: "app-42",
+    });
+
+    const captured = fs.readFileSync(`${captureBase}.capture`, "utf-8").trim().split("\n");
+    expect(captured).toEqual([
+      "app",
+      "gh-installation-token",
+      "wss://moltzap.example/ws",
+      "moltzap-key",
+      "agent-a",
+    ]);
+  });
+});

--- a/test/v2-bridge.http.test.ts
+++ b/test/v2-bridge.http.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFetchHandler,
+  defaultMintToken,
+  type BridgeConfig,
+  type BridgeHandlerContext,
+  type GhAdapter,
+  type RepoRoute,
+} from "../v2/bridge.ts";
+import {
+  asBotUsername,
+  asProjectName,
+  asRepoFullName,
+  ok,
+} from "../v2/types.ts";
+import type { RepoFullName } from "../v2/types.ts";
+
+// Routes covered here are the HTTP-layer routing of the bridge fetch
+// handler — method + path + pre-auth responses. `handleClassifiedWebhook`
+// is covered separately in test/v2-bridge.test.ts.
+
+const WEBHOOK_SECRET = "a".repeat(64);
+const API_KEY = "b".repeat(64);
+
+async function signPayload(body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(body));
+  return `sha256=${Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+function makeConfig(
+  overrides: { repos?: Map<RepoFullName, RepoRoute>; apiKey?: string; webhookSecret?: string } = {}
+): BridgeConfig {
+  const defaultRepos = new Map<RepoFullName, RepoRoute>();
+  defaultRepos.set(asRepoFullName("acme/app"), {
+    projectName: asProjectName("app"),
+    webhookSecretEnvVar: "ZAPBOT_WEBHOOK_SECRET",
+    defaultBranch: "main",
+  });
+  return {
+    port: 0,
+    publicUrl: "http://localhost:0",
+    gatewayUrl: "",
+    gatewaySecret: null,
+    botUsername: asBotUsername("zapbot[bot]"),
+    aoConfigPath: "",
+    apiKey: overrides.apiKey ?? API_KEY,
+    webhookSecret: overrides.webhookSecret ?? WEBHOOK_SECRET,
+    moltzap: { _tag: "MoltzapDisabled" },
+    repos: overrides.repos ?? defaultRepos,
+  };
+}
+
+function fakeGh(): GhAdapter {
+  return {
+    addReaction: async () => ok(undefined),
+    getUserPermission: async () => ok("write"),
+    postComment: async () => ok(undefined),
+  };
+}
+
+function makeHandler(cfg: BridgeConfig = makeConfig()): (req: Request) => Promise<Response> {
+  const ctx: BridgeHandlerContext = {
+    mintToken: defaultMintToken,
+    gh: fakeGh(),
+    config: cfg,
+  };
+  return buildFetchHandler(() => cfg, ctx);
+}
+
+function get(handler: (r: Request) => Promise<Response>, path: string, headers: Record<string, string> = {}): Promise<Response> {
+  return handler(new Request(`http://localhost${path}`, { method: "GET", headers }));
+}
+
+function post(
+  handler: (r: Request) => Promise<Response>,
+  path: string,
+  body: string,
+  headers: Record<string, string> = {}
+): Promise<Response> {
+  return handler(new Request(`http://localhost${path}`, { method: "POST", body, headers }));
+}
+
+describe("bridge fetch handler — /healthz + catch-all", () => {
+  it("GET /healthz returns 200 'ok'", async () => {
+    const h = makeHandler();
+    const r = await get(h, "/healthz");
+    expect(r.status).toBe(200);
+    expect(await r.text()).toBe("ok");
+  });
+
+  it("GET /unknown returns 404 with typed error body", async () => {
+    const h = makeHandler();
+    const r = await get(h, "/does-not-exist");
+    expect(r.status).toBe(404);
+    const body = (await r.json()) as { error: { type: string } };
+    expect(body.error.type).toBe("not_found");
+  });
+
+  it("GET /api/webhooks/github (wrong method) returns 404", async () => {
+    const h = makeHandler();
+    const r = await get(h, "/api/webhooks/github");
+    expect(r.status).toBe(404);
+  });
+
+  it("POST /api/tokens/installation (wrong method) returns 404", async () => {
+    const h = makeHandler();
+    const r = await post(h, "/api/tokens/installation", "");
+    expect(r.status).toBe(404);
+  });
+});
+
+describe("bridge fetch handler — webhook route", () => {
+  const issuePayload = {
+    action: "created",
+    repository: { full_name: "acme/app" },
+    sender: { login: "alice" },
+    issue: { number: 1 },
+    comment: { id: 1, body: "hi" },
+  };
+
+  it("rejects invalid JSON with 400 invalid_request", async () => {
+    const h = makeHandler();
+    const r = await post(h, "/api/webhooks/github", "not-json-at-all", {
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "d-1",
+    });
+    expect(r.status).toBe(400);
+    expect(((await r.json()) as { error: { type: string } }).error.type).toBe("invalid_request");
+  });
+
+  it("rejects missing signature with 401 signature_error", async () => {
+    const h = makeHandler();
+    const body = JSON.stringify(issuePayload);
+    const r = await post(h, "/api/webhooks/github", body, {
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "d-1",
+    });
+    expect(r.status).toBe(401);
+    expect(((await r.json()) as { error: { type: string } }).error.type).toBe("signature_error");
+  });
+
+  it("rejects bad signature with 401 signature_error", async () => {
+    const h = makeHandler();
+    const body = JSON.stringify(issuePayload);
+    const r = await post(h, "/api/webhooks/github", body, {
+      "x-hub-signature-256": "sha256=deadbeef",
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "d-1",
+    });
+    expect(r.status).toBe(401);
+    expect(((await r.json()) as { error: { type: string } }).error.type).toBe("signature_error");
+  });
+
+  it("collapses unknown-repo into 401 signature_error (pre-auth oracle fix)", async () => {
+    // Body claims a repo the bridge is NOT configured for. Must return 401
+    // — not 403 "not configured" — so callers can't enumerate.
+    const h = makeHandler();
+    const body = JSON.stringify({
+      ...issuePayload,
+      repository: { full_name: "attacker/unknown" },
+    });
+    const sig = await signPayload(body, WEBHOOK_SECRET);
+    const r = await post(h, "/api/webhooks/github", body, {
+      "x-hub-signature-256": sig,
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "d-1",
+    });
+    expect(r.status).toBe(401);
+    const parsed = (await r.json()) as { error: { type: string; message: string } };
+    expect(parsed.error.type).toBe("signature_error");
+    expect(parsed.error.message.toLowerCase()).not.toContain("unknown");
+    expect(parsed.error.message.toLowerCase()).not.toContain("configured");
+  });
+
+  it("400 PayloadShapeInvalid on a well-signed malformed issue_comment", async () => {
+    const h = makeHandler();
+    const body = JSON.stringify({
+      action: "created",
+      repository: { full_name: "acme/app" },
+      sender: { login: "alice" },
+      issue: { number: 1 },
+      // comment: missing — fails schema decode.
+    });
+    const sig = await signPayload(body, WEBHOOK_SECRET);
+    const r = await post(h, "/api/webhooks/github", body, {
+      "x-hub-signature-256": sig,
+      "x-github-event": "issue_comment",
+      "x-github-delivery": "d-1",
+    });
+    expect(r.status).toBe(400);
+    expect(((await r.json()) as { error: { type: string } }).error.type).toBe("invalid_request");
+  });
+
+  it("well-signed pull_request event returns 200 with ignored outcome", async () => {
+    const h = makeHandler();
+    const body = JSON.stringify({
+      action: "opened",
+      repository: { full_name: "acme/app" },
+      sender: { login: "alice" },
+      pull_request: { number: 1 },
+    });
+    const sig = await signPayload(body, WEBHOOK_SECRET);
+    const r = await post(h, "/api/webhooks/github", body, {
+      "x-hub-signature-256": sig,
+      "x-github-event": "pull_request",
+      "x-github-delivery": "d-1",
+    });
+    expect(r.status).toBe(200);
+    const parsed = (await r.json()) as { ok: boolean; outcome: { kind: string } };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.outcome.kind).toBe("ignored");
+  });
+});
+
+describe("bridge fetch handler — installation token broker", () => {
+  it("GET without Authorization returns 401 unauthorized", async () => {
+    const h = makeHandler();
+    const r = await get(h, "/api/tokens/installation");
+    expect(r.status).toBe(401);
+    expect((await r.json()).error).toBe("unauthorized");
+  });
+
+  it("GET with wrong Bearer returns 401 unauthorized", async () => {
+    const h = makeHandler();
+    const r = await get(h, "/api/tokens/installation", {
+      authorization: `Bearer ${"x".repeat(API_KEY.length)}`,
+    });
+    expect(r.status).toBe(401);
+  });
+
+  it("GET with correct Bearer but no GitHub App returns 409 app_not_configured", async () => {
+    const h = makeHandler();
+    const r = await get(h, "/api/tokens/installation", {
+      authorization: `Bearer ${API_KEY}`,
+    });
+    expect(r.status).toBe(409);
+    expect((await r.json()).error).toBe("app_not_configured");
+  });
+
+  it("reads apiKey from BridgeConfig, not process.env (no env-leak)", async () => {
+    const saved = process.env.ZAPBOT_API_KEY;
+    delete process.env.ZAPBOT_API_KEY;
+    try {
+      const h = makeHandler();
+      const r = await get(h, "/api/tokens/installation", {
+        authorization: `Bearer ${API_KEY}`,
+      });
+      // 409 proves Bearer passed. If the bridge read from process.env we'd see 401.
+      expect(r.status).toBe(409);
+    } finally {
+      if (saved !== undefined) process.env.ZAPBOT_API_KEY = saved;
+    }
+  });
+});

--- a/test/v2-bridge.test.ts
+++ b/test/v2-bridge.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  handleClassifiedWebhook,
+  type BridgeConfig,
+  type BridgeHandlerContext,
+  type GhAdapter,
+  type RepoRoute,
+} from "../v2/bridge.ts";
+import type { ClassifiedWebhook } from "../v2/gateway.ts";
+import {
+  asAoSessionName,
+  asBotUsername,
+  asCommentId,
+  asIssueNumber,
+  asProjectName,
+  asRepoFullName,
+  err,
+  ok,
+} from "../v2/types.ts";
+import type {
+  DispatchError,
+  GhCallError,
+  InstallationToken,
+  IssueNumber,
+  RepoFullName,
+  Result,
+} from "../v2/types.ts";
+
+const dispatchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../v2/ao/dispatcher.ts", () => ({
+  dispatch: dispatchMock,
+}));
+
+const repo = asRepoFullName("acme/app");
+const issue = asIssueNumber(42);
+const commentId = asCommentId(7);
+const bot = asBotUsername("zapbot[bot]");
+
+interface FakeGhCalls {
+  addReaction: Array<{ repo: RepoFullName; commentId: number; reaction: string }>;
+  getUserPermission: Array<{ repo: RepoFullName; user: string }>;
+  postComment: Array<{ repo: RepoFullName; issue: IssueNumber; body: string }>;
+}
+
+function makeGh(opts: {
+  permission?: Result<string, GhCallError>;
+  postResult?: Result<void, GhCallError>;
+}): { gh: GhAdapter; calls: FakeGhCalls } {
+  const calls: FakeGhCalls = { addReaction: [], getUserPermission: [], postComment: [] };
+  const gh: GhAdapter = {
+    addReaction: async (repo, cid, reaction) => {
+      calls.addReaction.push({ repo, commentId: cid, reaction });
+      return ok(undefined);
+    },
+    getUserPermission: async (repo, user) => {
+      calls.getUserPermission.push({ repo, user });
+      return opts.permission ?? ok("write");
+    },
+    postComment: async (repo, issue, body) => {
+      calls.postComment.push({ repo, issue, body });
+      return opts.postResult ?? ok(undefined);
+    },
+  };
+  return { gh, calls };
+}
+
+function makeConfig(withRoute = true): BridgeConfig {
+  const repos = new Map<RepoFullName, RepoRoute>();
+  if (withRoute) {
+    repos.set(repo, {
+      projectName: asProjectName("app"),
+      webhookSecretEnvVar: "ZAPBOT_WEBHOOK_SECRET",
+      defaultBranch: "main",
+    });
+  }
+  return {
+    port: 3000,
+    publicUrl: "http://localhost:3000",
+    gatewayUrl: "",
+    gatewaySecret: null,
+    botUsername: bot,
+    aoConfigPath: "",
+    apiKey: "test-broker-key",
+    webhookSecret: "test-webhook-secret",
+    moltzap: { _tag: "MoltzapDisabled" },
+    repos,
+  };
+}
+
+function makeCtx(
+  gh: GhAdapter,
+  opts: {
+    mintToken?: () => Promise<Result<InstallationToken, DispatchError>>;
+    withRoute?: boolean;
+  } = {}
+): BridgeHandlerContext {
+  return {
+    mintToken: opts.mintToken ?? (async () => ok("fake-token" as unknown as InstallationToken)),
+    gh,
+    config: makeConfig(opts.withRoute ?? true),
+  };
+}
+
+function mentionWebhook(command: ClassifiedWebhook extends infer _ ? never : never): never {
+  throw command;
+}
+void mentionWebhook;
+
+function asMention(kind: "plan_this" | "investigate_this" | "status" | "unknown_command", raw?: string): ClassifiedWebhook {
+  const command =
+    kind === "unknown_command"
+      ? { kind: "unknown_command" as const, raw: raw ?? "frobnicate" }
+      : { kind };
+  return {
+    kind: "mention_command",
+    repo,
+    issue,
+    commentId,
+    command,
+    triggeredBy: "carol",
+  };
+}
+
+describe("handleClassifiedWebhook — ignore passthrough", () => {
+  it("echoes the ignore reason without touching gh", async () => {
+    const { gh, calls } = makeGh({});
+    const out = await handleClassifiedWebhook({ kind: "ignore", reason: "self-mention" }, makeCtx(gh));
+    expect(out._tag).toBe("Ok");
+    if (out._tag === "Ok") {
+      expect(out.value.kind).toBe("ignored");
+      if (out.value.kind === "ignored") expect(out.value.reason).toBe("self-mention");
+    }
+    expect(calls.getUserPermission.length).toBe(0);
+    expect(calls.postComment.length).toBe(0);
+  });
+});
+
+describe("handleClassifiedWebhook — permission gate", () => {
+  let gh: GhAdapter;
+  let calls: FakeGhCalls;
+  beforeEach(() => {
+    const made = makeGh({ permission: ok("read") });
+    gh = made.gh;
+    calls = made.calls;
+  });
+
+  it("insufficient permission → unauthorized + comment posted", async () => {
+    const out = await handleClassifiedWebhook(asMention("plan_this"), makeCtx(gh));
+    expect(out._tag).toBe("Ok");
+    if (out._tag === "Ok") {
+      expect(out.value.kind).toBe("unauthorized");
+      if (out.value.kind === "unauthorized") {
+        expect(out.value.actor).toBe("carol");
+        expect(out.value.reason).toBe("insufficient_permission");
+      }
+    }
+    expect(calls.postComment.length).toBe(1);
+    expect(calls.postComment[0].body).toContain("write access");
+  });
+
+  it("gh.getUserPermission failure → unauthorized with permission_check_failed", async () => {
+    const made = makeGh({
+      permission: err({ _tag: "GhCallFailed", label: "getUserPermission", cause: "network" }),
+    });
+    const out = await handleClassifiedWebhook(asMention("plan_this"), makeCtx(made.gh));
+    expect(out._tag).toBe("Ok");
+    if (out._tag === "Ok" && out.value.kind === "unauthorized") {
+      expect(out.value.reason).toBe("permission_check_failed");
+    }
+    expect(made.calls.postComment.length).toBe(1);
+    expect(made.calls.postComment[0].body).toContain("couldn't verify");
+  });
+});
+
+describe("handleClassifiedWebhook — plan_this / investigate_this", () => {
+  beforeEach(() => {
+    dispatchMock.mockReset();
+    dispatchMock.mockResolvedValue(ok(asAoSessionName("app-42")));
+  });
+
+  it("project not configured → ProjectNotConfigured error", async () => {
+    const { gh } = makeGh({});
+    const out = await handleClassifiedWebhook(
+      asMention("plan_this"),
+      makeCtx(gh, { withRoute: false })
+    );
+    expect(out._tag).toBe("Err");
+    if (out._tag === "Err") expect(out.error._tag).toBe("ProjectNotConfigured");
+  });
+
+  it("token mint failure → TokenMintFailed bubbles up", async () => {
+    const { gh } = makeGh({});
+    const out = await handleClassifiedWebhook(
+      asMention("plan_this"),
+      makeCtx(gh, {
+        mintToken: async () => err({ _tag: "TokenMintFailed", cause: "no app" }),
+      })
+    );
+    expect(out._tag).toBe("Err");
+    if (out._tag === "Err") expect(out.error._tag).toBe("TokenMintFailed");
+  });
+
+  it("happy path → dispatched outcome + confirmation comment", async () => {
+    const { gh, calls } = makeGh({});
+    const out = await handleClassifiedWebhook(
+      asMention("investigate_this"),
+      makeCtx(gh)
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(out._tag).toBe("Ok");
+    if (out._tag === "Ok") {
+      expect(out.value.kind).toBe("dispatched");
+      if (out.value.kind === "dispatched") {
+        expect(out.value.session).toBe(asAoSessionName("app-42"));
+      }
+    }
+    expect(calls.postComment.length).toBe(1);
+    expect(calls.postComment[0].body).toContain("Dispatching agent");
+  });
+});
+
+describe("handleClassifiedWebhook — status command", () => {
+  it("returns replied outcome tagged with 'status' and posts a summary", async () => {
+    // getIssue() will fail in test env (no GitHub creds). summarizeIssue
+    // returns a "Could not fetch" string, which is still posted. The outcome
+    // must be `replied` with command: "status" — not `ignored`.
+    const { gh, calls } = makeGh({});
+    const out = await handleClassifiedWebhook(asMention("status"), makeCtx(gh));
+    expect(out._tag).toBe("Ok");
+    if (out._tag === "Ok") {
+      expect(out.value.kind).toBe("replied");
+      if (out.value.kind === "replied") expect(out.value.command).toBe("status");
+    }
+    // Post fired (possibly after the summary fetch — either way, called exactly once).
+    expect(calls.postComment.length).toBe(1);
+  });
+});
+
+describe("handleClassifiedWebhook — unknown_command", () => {
+  it("returns replied outcome and posts a help comment citing the raw command", async () => {
+    const { gh, calls } = makeGh({});
+    const out = await handleClassifiedWebhook(asMention("unknown_command", "frobnicate"), makeCtx(gh));
+    expect(out._tag).toBe("Ok");
+    if (out._tag === "Ok") {
+      expect(out.value.kind).toBe("replied");
+      if (out.value.kind === "replied") expect(out.value.command).toBe("unknown_command");
+    }
+    expect(calls.postComment.length).toBe(1);
+    expect(calls.postComment[0].body).toContain("frobnicate");
+    expect(calls.postComment[0].body).toContain("plan this");
+  });
+});
+
+describe("handleClassifiedWebhook — eyes reaction", () => {
+  it("fires addReaction on any mention_command (fire-and-forget)", async () => {
+    const { gh, calls } = makeGh({});
+    await handleClassifiedWebhook(asMention("status"), makeCtx(gh));
+    // addReaction runs async and fire-and-forget — give it a microtask to resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calls.addReaction.length).toBe(1);
+    expect(calls.addReaction[0].reaction).toBe("eyes");
+  });
+});
+
+// Satisfy the unused-import lint for asAoSessionName in case of future
+// type-narrowing use.
+void asAoSessionName;

--- a/test/v2-bridge.test.ts
+++ b/test/v2-bridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   handleClassifiedWebhook,
+  startBridge,
   type BridgeConfig,
   type BridgeHandlerContext,
   type GhAdapter,
@@ -27,10 +28,24 @@ import type {
 } from "../v2/types.ts";
 
 const dispatchMock = vi.hoisted(() => vi.fn());
+const registerBridgeMock = vi.hoisted(() => vi.fn());
+const deregisterBridgeMock = vi.hoisted(() => vi.fn());
+const startHeartbeatMock = vi.hoisted(() => vi.fn());
+const serverStopMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../v2/ao/dispatcher.ts", () => ({
   dispatch: dispatchMock,
 }));
+
+vi.mock("../v2/gateway.ts", async () => {
+  const actual = await vi.importActual<typeof import("../v2/gateway.ts")>("../v2/gateway.ts");
+  return {
+    ...actual,
+    registerBridge: registerBridgeMock,
+    deregisterBridge: deregisterBridgeMock,
+    startHeartbeat: startHeartbeatMock,
+  };
+});
 
 const repo = asRepoFullName("acme/app");
 const issue = asIssueNumber(42);
@@ -177,6 +192,14 @@ describe("handleClassifiedWebhook — plan_this / investigate_this", () => {
   beforeEach(() => {
     dispatchMock.mockReset();
     dispatchMock.mockResolvedValue(ok(asAoSessionName("app-42")));
+    registerBridgeMock.mockReset();
+    registerBridgeMock.mockResolvedValue(ok(undefined));
+    deregisterBridgeMock.mockReset();
+    deregisterBridgeMock.mockResolvedValue(ok(undefined));
+    startHeartbeatMock.mockReset();
+    startHeartbeatMock.mockReturnValue(serverStopMock);
+    serverStopMock.mockReset();
+    vi.unstubAllGlobals();
   });
 
   it("project not configured → ProjectNotConfigured error", async () => {
@@ -267,3 +290,45 @@ describe("handleClassifiedWebhook — eyes reaction", () => {
 // Satisfy the unused-import lint for asAoSessionName in case of future
 // type-narrowing use.
 void asAoSessionName;
+
+describe("startBridge.reload — repo deregistration", () => {
+  it("deregisters repos removed by config reload and replaces the heartbeat set", async () => {
+    const heartbeatStop = vi.fn();
+    const serverStop = vi.fn();
+    startHeartbeatMock.mockReturnValue(heartbeatStop);
+    vi.stubGlobal("Bun", {
+      serve: vi.fn(() => ({ stop: serverStop })),
+    });
+
+    const initial = makeConfig(true);
+    const removedRepo = asRepoFullName("acme/old");
+    const initialRepos = new Map(initial.repos);
+    initialRepos.set(removedRepo, {
+      projectName: asProjectName("old"),
+      webhookSecretEnvVar: "ZAPBOT_WEBHOOK_SECRET",
+      defaultBranch: "main",
+    });
+    const running = await startBridge({ ...initial, repos: initialRepos });
+
+    const nextRepos = new Map(initial.repos);
+    const nextConfig = { ...initial, repos: nextRepos };
+
+    await running.reload(nextConfig);
+
+    expect(heartbeatStop).toHaveBeenCalledTimes(1);
+    expect(deregisterBridgeMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      removedRepo,
+      initial.publicUrl
+    );
+    expect(deregisterBridgeMock).toHaveBeenCalledTimes(1);
+    expect(registerBridgeMock.mock.calls.map(([, repo]) => repo)).toEqual([
+      repo,
+      removedRepo,
+      repo,
+    ]);
+
+    await running.stop();
+    expect(serverStop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/v2-gateway.test.ts
+++ b/test/v2-gateway.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { verifyAndClassify, type GatewayWebhookEnvelope } from "../v2/gateway.ts";
+import { asBotUsername, asDeliveryId, asRepoFullName } from "../v2/types.ts";
+
+const bot = asBotUsername("zapbot[bot]");
+
+async function signPayload(body: string, secret: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(body));
+  return `sha256=${Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+async function buildEnvelope(
+  body: string,
+  secret: string,
+  overrides?: Partial<GatewayWebhookEnvelope>
+): Promise<GatewayWebhookEnvelope> {
+  return {
+    rawBody: body,
+    signature: await signPayload(body, secret),
+    eventType: "issue_comment",
+    deliveryId: asDeliveryId("d-1"),
+    repo: asRepoFullName("acme/app"),
+    payload: JSON.parse(body),
+    ...overrides,
+  };
+}
+
+describe("verifyAndClassify", () => {
+  const secret = "s3cr3t";
+
+  it("returns SecretMissing when resolveSecret returns null", async () => {
+    const env = await buildEnvelope(JSON.stringify({ action: "created" }), secret);
+    const r = await verifyAndClassify(env, () => null, bot);
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") expect(r.error._tag).toBe("SecretMissing");
+  });
+
+  it("returns SignatureMismatch on bad signature", async () => {
+    const body = JSON.stringify({ action: "created" });
+    const env: GatewayWebhookEnvelope = {
+      rawBody: body,
+      signature: "sha256=deadbeef",
+      eventType: "issue_comment",
+      deliveryId: asDeliveryId("d-1"),
+      repo: asRepoFullName("acme/app"),
+      payload: JSON.parse(body),
+    };
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") expect(r.error._tag).toBe("SignatureMismatch");
+  });
+
+  it("ignores non-issue_comment events", async () => {
+    const body = JSON.stringify({ action: "opened" });
+    const env = await buildEnvelope(body, secret, { eventType: "pull_request" });
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value.kind).toBe("ignore");
+  });
+
+  it("ignores non-created issue_comment actions", async () => {
+    const body = JSON.stringify({ action: "edited" });
+    const env = await buildEnvelope(body, secret);
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value.kind).toBe("ignore");
+  });
+
+  it("ignores self-mentions from the bot", async () => {
+    const body = JSON.stringify({
+      action: "created",
+      sender: { login: "zapbot[bot]" },
+      issue: { number: 1 },
+      comment: { id: 99, body: "@zapbot plan this" },
+    });
+    const env = await buildEnvelope(body, secret);
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value.kind).toBe("ignore");
+  });
+
+  it("ignores comments with no bot mention", async () => {
+    const body = JSON.stringify({
+      action: "created",
+      sender: { login: "alice" },
+      issue: { number: 1 },
+      comment: { id: 99, body: "no mention" },
+    });
+    const env = await buildEnvelope(body, secret);
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value.kind).toBe("ignore");
+  });
+
+  it("rejects a malformed issue_comment.created payload with PayloadShapeInvalid", async () => {
+    // eventType=issue_comment, action=created, but `comment` object missing.
+    const body = JSON.stringify({
+      action: "created",
+      sender: { login: "alice" },
+      issue: { number: 7 },
+      // comment: missing
+    });
+    const env = await buildEnvelope(body, secret);
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") {
+      expect(r.error._tag).toBe("PayloadShapeInvalid");
+      if (r.error._tag === "PayloadShapeInvalid") {
+        expect(r.error.reason).toContain("comment");
+      }
+    }
+  });
+
+  it("ignores non-object payloads without surfacing an error", async () => {
+    const body = "null";
+    const env = await buildEnvelope(body, secret);
+    const r = await verifyAndClassify(env, () => secret, bot);
+    // null is structurally invalid for issue_comment but we don't want to
+    // 400 on it — gateway treats as decode failure → PayloadShapeInvalid.
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") expect(r.error._tag).toBe("PayloadShapeInvalid");
+  });
+
+  it("classifies a plan_this mention", async () => {
+    const body = JSON.stringify({
+      action: "created",
+      sender: { login: "alice" },
+      issue: { number: 7 },
+      comment: { id: 1234, body: "@zapbot plan this" },
+    });
+    const env = await buildEnvelope(body, secret);
+    const r = await verifyAndClassify(env, () => secret, bot);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok" && r.value.kind === "mention_command") {
+      expect(r.value.command).toEqual({ kind: "plan_this" });
+      expect(r.value.triggeredBy).toBe("alice");
+      expect(r.value.issue as unknown as number).toBe(7);
+      expect(r.value.commentId as unknown as number).toBe(1234);
+    } else {
+      throw new Error("expected mention_command");
+    }
+  });
+});

--- a/test/v2-github-state.test.ts
+++ b/test/v2-github-state.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  getIssue,
+  getAgentClaim,
+  listOpenIssuesWithLabel,
+  postComment,
+  __resetForTests,
+} from "../v2/github-state.ts";
+import {
+  asBotUsername,
+  asIssueNumber,
+  asRepoFullName,
+} from "../v2/types.ts";
+
+const repo = asRepoFullName("acme/app");
+const issue = asIssueNumber(42);
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+function installFetchStub(handler: (url: string, init?: RequestInit) => Promise<Response> | Response) {
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    return handler(url, init);
+  }) as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  __resetForTests();
+  process.env = { ...originalEnv };
+  process.env.ZAPBOT_GITHUB_TOKEN = "fake-token";
+  delete process.env.GITHUB_APP_ID;
+  delete process.env.GITHUB_APP_INSTALLATION_ID;
+  delete process.env.GITHUB_APP_PRIVATE_KEY;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.env = { ...originalEnv };
+});
+
+describe("getIssue", () => {
+  it("returns a mapped snapshot on 200", async () => {
+    installFetchStub(() =>
+      Response.json({
+        number: 42,
+        state: "open",
+        labels: [{ name: "bug" }, "docs"],
+        assignees: [{ login: "zapbot[bot]" }, { login: "alice" }],
+        body: "hi",
+        user: { login: "carol" },
+      })
+    );
+    const r = await getIssue(repo, issue);
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") {
+      expect(r.value.state).toBe("open");
+      expect([...r.value.labels]).toEqual(["bug", "docs"]);
+      expect([...r.value.assignees]).toEqual(["zapbot[bot]", "alice"]);
+      expect(r.value.author).toBe("carol");
+    }
+  });
+
+  it("returns IssueNotFound on 404", async () => {
+    installFetchStub(() => new Response(JSON.stringify({ message: "not found" }), { status: 404 }));
+    const r = await getIssue(repo, issue);
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") expect(r.error._tag).toBe("IssueNotFound");
+  });
+
+  it("returns GitHubAuthMissing when no auth is configured", async () => {
+    delete process.env.ZAPBOT_GITHUB_TOKEN;
+    __resetForTests();
+    const r = await getIssue(repo, issue);
+    expect(r._tag).toBe("Err");
+    if (r._tag === "Err") expect(r.error._tag).toBe("GitHubAuthMissing");
+  });
+});
+
+describe("getAgentClaim", () => {
+  it("returns claimed when bot is assigned and issue is open", async () => {
+    installFetchStub(() =>
+      Response.json({
+        number: 42,
+        state: "open",
+        labels: [],
+        assignees: [{ login: "zapbot[bot]" }],
+        body: "",
+        user: { login: "carol" },
+      })
+    );
+    const r = await getAgentClaim(repo, issue, asBotUsername("zapbot[bot]"));
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value.kind).toBe("claimed");
+  });
+
+  it("returns unclaimed when issue is closed", async () => {
+    installFetchStub(() =>
+      Response.json({
+        number: 42,
+        state: "closed",
+        labels: [],
+        assignees: [{ login: "zapbot[bot]" }],
+        body: "",
+        user: { login: "carol" },
+      })
+    );
+    const r = await getAgentClaim(repo, issue, asBotUsername("zapbot[bot]"));
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value.kind).toBe("unclaimed");
+  });
+});
+
+describe("listOpenIssuesWithLabel", () => {
+  it("filters out pull requests", async () => {
+    installFetchStub(() =>
+      Response.json([
+        { number: 1, state: "open", labels: ["bug"], assignees: [], body: "", user: { login: "a" } },
+        {
+          number: 2,
+          state: "open",
+          labels: ["bug"],
+          assignees: [],
+          body: "",
+          user: { login: "b" },
+          pull_request: { url: "..." },
+        },
+      ])
+    );
+    const r = await listOpenIssuesWithLabel(repo, "bug");
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") {
+      expect(r.value.length).toBe(1);
+      expect(r.value[0].number as unknown as number).toBe(1);
+    }
+  });
+});
+
+describe("postComment", () => {
+  it("returns the created comment id", async () => {
+    installFetchStub(() => Response.json({ id: 9999 }, { status: 201 }));
+    const r = await postComment(repo, issue, "hello");
+    expect(r._tag).toBe("Ok");
+    if (r._tag === "Ok") expect(r.value as unknown as number).toBe(9999);
+  });
+});

--- a/test/v2-mention-parser.test.ts
+++ b/test/v2-mention-parser.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { parseMention, stripQuotedContent } from "../v2/mention-parser.ts";
+import { asBotUsername } from "../v2/types.ts";
+
+const bot = asBotUsername("zapbot[bot]");
+
+describe("stripQuotedContent", () => {
+  it("strips fenced code blocks", () => {
+    expect(stripQuotedContent("before\n```\n@zapbot plan this\n```\nafter")).not.toContain("@zapbot");
+  });
+
+  it("strips inline code", () => {
+    expect(stripQuotedContent("see `@zapbot plan this` please")).not.toContain("@zapbot");
+  });
+
+  it("strips blockquote lines", () => {
+    expect(stripQuotedContent("> @zapbot plan this\nhi")).not.toContain("@zapbot");
+  });
+});
+
+describe("parseMention", () => {
+  it("returns null without mention", () => {
+    expect(parseMention("just a comment", bot)).toBeNull();
+  });
+
+  it("parses plan_this", () => {
+    expect(parseMention("@zapbot plan this", bot)).toEqual({ kind: "plan_this" });
+  });
+
+  it("parses triage this as plan_this", () => {
+    expect(parseMention("@zapbot triage this", bot)).toEqual({ kind: "plan_this" });
+  });
+
+  it("parses investigate_this", () => {
+    expect(parseMention("@zapbot investigate this", bot)).toEqual({ kind: "investigate_this" });
+  });
+
+  it("parses bare investigate as investigate_this", () => {
+    expect(parseMention("@zapbot investigate", bot)).toEqual({ kind: "investigate_this" });
+  });
+
+  it("parses status", () => {
+    expect(parseMention("@zapbot status", bot)).toEqual({ kind: "status" });
+  });
+
+  it("returns unknown_command for unrecognized text", () => {
+    expect(parseMention("@zapbot yodel", bot)).toEqual({ kind: "unknown_command", raw: "yodel" });
+  });
+
+  it("returns unknown_command with empty raw when mention has no tail", () => {
+    expect(parseMention("@zapbot", bot)).toEqual({ kind: "unknown_command", raw: "" });
+  });
+
+  it("ignores quoted mentions", () => {
+    expect(parseMention("> @zapbot plan this", bot)).toBeNull();
+  });
+
+  it("accepts @zapbot (without [bot] suffix)", () => {
+    expect(parseMention("@zapbot status", bot)).toEqual({ kind: "status" });
+  });
+
+  it("is case-insensitive on the command", () => {
+    expect(parseMention("@zapbot STATUS", bot)).toEqual({ kind: "status" });
+  });
+});

--- a/test/v2-moltzap-identity-allowlist.test.ts
+++ b/test/v2-moltzap-identity-allowlist.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  fromSenderIds,
+  gateInbound,
+} from "../v2/moltzap/identity-allowlist.ts";
+import {
+  asMoltzapConversationId,
+  asMoltzapMessageId,
+  asMoltzapSenderId,
+  type MoltzapInbound,
+} from "../v2/moltzap/types.ts";
+
+function makeEvent(senderId: string): MoltzapInbound {
+  return {
+    messageId: asMoltzapMessageId("msg-1"),
+    conversationId: asMoltzapConversationId("conv-1"),
+    senderId: asMoltzapSenderId(senderId),
+    bodyText: "hello",
+    receivedAtMs: 1_700_000_000_000,
+  };
+}
+
+describe("identity-allowlist", () => {
+  it("allows configured sender IDs through unchanged", () => {
+    const allowlist = fromSenderIds([asMoltzapSenderId("agent-a")]);
+    const event = makeEvent("agent-a");
+    const result = gateInbound(allowlist, event);
+    expect(result).toEqual({ _tag: "Ok", value: event });
+  });
+
+  it("rejects sender IDs outside the allowlist with SenderNotAllowed", () => {
+    const allowlist = fromSenderIds([asMoltzapSenderId("agent-a")]);
+    const event = makeEvent("agent-b");
+    const result = gateInbound(allowlist, event);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("SenderNotAllowed");
+    expect(result.error.senderId).toBe("agent-b");
+    expect(result.error.event).toEqual({
+      messageId: asMoltzapMessageId("msg-1"),
+      conversationId: asMoltzapConversationId("conv-1"),
+      senderId: asMoltzapSenderId("agent-b"),
+      receivedAtMs: 1_700_000_000_000,
+    });
+    expect("bodyText" in result.error.event).toBe(false);
+  });
+
+  it("empty allowlist rejects all inbound senders", () => {
+    const allowlist = fromSenderIds([]);
+    const result = gateInbound(allowlist, makeEvent("agent-z"));
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("SenderNotAllowed");
+  });
+});

--- a/test/v2-moltzap-runtime.test.ts
+++ b/test/v2-moltzap-runtime.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildMoltzapSpawnEnv,
+  loadMoltzapRuntimeConfig,
+  type MoltzapRuntimeConfig,
+} from "../v2/moltzap/runtime.ts";
+import {
+  asAoSessionName,
+  asIssueNumber,
+  asProjectName,
+  asRepoFullName,
+} from "../v2/types.ts";
+import { gateInbound } from "../v2/moltzap/identity-allowlist.ts";
+import {
+  asMoltzapConversationId,
+  asMoltzapMessageId,
+  asMoltzapSenderId,
+} from "../v2/moltzap/types.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const spawnContext = {
+  repo: asRepoFullName("acme/app"),
+  issue: asIssueNumber(42),
+  projectName: asProjectName("app"),
+  session: asAoSessionName("app-42"),
+} as const;
+
+describe("moltzap runtime / loadMoltzapRuntimeConfig", () => {
+  it("returns MoltzapDisabled when no MoltZap env is configured", () => {
+    const result = loadMoltzapRuntimeConfig({});
+    expect(result).toEqual({ _tag: "Ok", value: { _tag: "MoltzapDisabled" } });
+  });
+
+  it("rejects auth config without a server URL", () => {
+    const result = loadMoltzapRuntimeConfig({
+      ZAPBOT_MOLTZAP_API_KEY: "mz-key",
+    });
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error.reason).toContain("ZAPBOT_MOLTZAP_SERVER_URL");
+  });
+
+  it("loads static API-key mode", () => {
+    const result = loadMoltzapRuntimeConfig({
+      ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+      ZAPBOT_MOLTZAP_API_KEY: "mz-key",
+    });
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value).toMatchObject({
+      _tag: "MoltzapStatic",
+      serverUrl: "wss://moltzap.example/ws",
+      apiKey: "mz-key",
+      allowlistCsv: null,
+    });
+  });
+
+  it("loads registration mode and builds a sender allowlist from CSV", () => {
+    const result = loadMoltzapRuntimeConfig({
+      ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+      ZAPBOT_MOLTZAP_REGISTRATION_SECRET: "reg-secret",
+      ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "agent-a, agent-b ",
+    });
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value._tag).toBe("MoltzapRegistration");
+    if (result.value._tag !== "MoltzapRegistration") return;
+    expect(result.value.allowlistCsv).toBe("agent-a,agent-b");
+    const gate = gateInbound(result.value.allowlist, {
+      messageId: asMoltzapMessageId("m-1"),
+      conversationId: asMoltzapConversationId("conv-1"),
+      senderId: asMoltzapSenderId("agent-b"),
+      bodyText: "hello",
+      receivedAtMs: 1,
+    });
+    expect(gate._tag).toBe("Ok");
+  });
+});
+
+describe("moltzap runtime / buildMoltzapSpawnEnv", () => {
+  it("returns an empty env map when MoltZap is disabled", async () => {
+    const result = await buildMoltzapSpawnEnv({ _tag: "MoltzapDisabled" }, spawnContext);
+    expect(result).toEqual({ _tag: "Ok", value: {} });
+  });
+
+  it("returns static MOLTZAP_* env when using a pre-provisioned API key", async () => {
+    const config: MoltzapRuntimeConfig = {
+      _tag: "MoltzapStatic",
+      serverUrl: "wss://moltzap.example/ws",
+      apiKey: "mz-key",
+      allowlistCsv: "agent-a,agent-b",
+      allowlist: loadMoltzapRuntimeConfig({
+        ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+        ZAPBOT_MOLTZAP_API_KEY: "mz-key",
+        ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "agent-a,agent-b",
+      })._tag === "Ok"
+        ? (loadMoltzapRuntimeConfig({
+            ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+            ZAPBOT_MOLTZAP_API_KEY: "mz-key",
+            ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "agent-a,agent-b",
+          }) as Extract<
+            ReturnType<typeof loadMoltzapRuntimeConfig>,
+            { readonly _tag: "Ok" }
+          >).value.allowlist
+        : (() => {
+            throw new Error("unreachable");
+          })(),
+    };
+    const result = await buildMoltzapSpawnEnv(config, spawnContext);
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: {
+        MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+        MOLTZAP_API_KEY: "mz-key",
+        MOLTZAP_ALLOWED_SENDERS: "agent-a,agent-b",
+      },
+    });
+  });
+
+  it("registers a fresh agent when a registration secret is configured", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ apiKey: "registered-key" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const configResult = loadMoltzapRuntimeConfig({
+      ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+      ZAPBOT_MOLTZAP_REGISTRATION_SECRET: "reg-secret",
+      ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "agent-a",
+    });
+    expect(configResult._tag).toBe("Ok");
+    if (configResult._tag !== "Ok" || configResult.value._tag !== "MoltzapRegistration") return;
+
+    const result = await buildMoltzapSpawnEnv(configResult.value, spawnContext);
+    expect(result).toEqual({
+      _tag: "Ok",
+      value: {
+        MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+        MOLTZAP_API_KEY: "registered-key",
+        MOLTZAP_ALLOWED_SENDERS: "agent-a",
+      },
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://moltzap.example/api/v1/auth/register");
+    expect(init?.method).toBe("POST");
+    const parsedBody = JSON.parse(String(init?.body)) as {
+      name: string;
+      description: string;
+      inviteCode: string;
+    };
+    expect(parsedBody.inviteCode).toBe("reg-secret");
+    expect(parsedBody.description).toContain("app-42");
+    expect(parsedBody.name).toMatch(/^[a-z0-9][a-z0-9_-]{1,30}[a-z0-9]$/);
+  });
+
+  it("returns MoltzapProvisionFailed when registration fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("forbidden", { status: 403 }));
+    const configResult = loadMoltzapRuntimeConfig({
+      ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+      ZAPBOT_MOLTZAP_REGISTRATION_SECRET: "reg-secret",
+    });
+    expect(configResult._tag).toBe("Ok");
+    if (configResult._tag !== "Ok" || configResult.value._tag !== "MoltzapRegistration") return;
+
+    const result = await buildMoltzapSpawnEnv(configResult.value, spawnContext);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("MoltzapProvisionFailed");
+    expect(result.error.cause).toContain("403");
+  });
+});

--- a/test/verify-signature.property.test.ts
+++ b/test/verify-signature.property.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from "vitest";
 import * as fc from "fast-check";
-import { verifySignature } from "../src/http/verify-signature.js";
+import { verifySignature } from "../v2/http/verify-signature.js";
 import { sign } from "./helpers/sign.ts";
 
-const RUNS = 200;
+const RUNS = 100;
 
 // Non-empty secret so the HMAC key is well-defined across both sides.
 const arbSecret = fc.string({ minLength: 1, maxLength: 64 });
 const arbBody = fc.string({ maxLength: 512 });
+const arbSuffix = fc.string({ minLength: 1, maxLength: 512 });
 
 describe("verifySignature (property)", () => {
   it("accepts any correctly-signed payload", async () => {
@@ -50,9 +51,8 @@ describe("verifySignature (property)", () => {
       fc.asyncProperty(
         arbSecret,
         arbBody,
-        arbBody,
+        arbSuffix,
         async (secret, body, suffix) => {
-          fc.pre(suffix.length > 0); // ensure the body actually changes
           const originalSig = await sign(body, secret);
           const mutatedBody = body + suffix;
           return (

--- a/test/verify-signature.test.ts
+++ b/test/verify-signature.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { verifySignature } from "../src/http/verify-signature.js";
+import { verifySignature } from "../v2/http/verify-signature.js";
 
 // Helper: compute a valid sha256 HMAC signature the same way GitHub does
 async function sign(payload: string, secret: string): Promise<string> {

--- a/v2/ao/dispatcher.ts
+++ b/v2/ao/dispatcher.ts
@@ -1,0 +1,157 @@
+/**
+ * v2/ao/dispatcher — shell out to `ao spawn <issue>`.
+ *
+ * Principle 5: one responsibility — translate a dispatch intent into a
+ * spawned `ao` process with the right env. No DB, no role-rules copy.
+ */
+
+import { spawn } from "node:child_process";
+import {
+  asAoSessionName,
+  err,
+  ok,
+} from "../types.ts";
+import { buildMoltzapSpawnEnv, type MoltzapRuntimeConfig } from "../moltzap/runtime.ts";
+import type {
+  AoSessionName,
+  DispatchError,
+  InstallationToken,
+  IssueNumber,
+  ProjectName,
+  RepoFullName,
+  Result,
+} from "../types.ts";
+
+export interface DispatchContext {
+  readonly repo: RepoFullName;
+  readonly issue: IssueNumber;
+  readonly projectName: ProjectName;
+  readonly configPath: string;
+  readonly installationToken: InstallationToken;
+  readonly moltzap: MoltzapRuntimeConfig;
+}
+
+/**
+ * Parent-process env vars `ao` inherits. Intentionally narrow: the
+ * bridge holds the broker key + installation PEM; the child only needs
+ * the shell basics to run `gh`, `git`, and `ao` itself. Anything not
+ * listed here is stripped before spawn.
+ *
+ * Adding to this list is a trust-boundary decision — justify in review.
+ */
+const AO_ENV_ALLOWLIST: ReadonlyArray<string> = [
+  "PATH",
+  "HOME",
+  "USER",
+  "LOGNAME",
+  "SHELL",
+  "LANG",
+  "LC_ALL",
+  "TERM",
+  "TMPDIR",
+  "TZ",
+] as const;
+
+function buildSpawnEnv(ctx: DispatchContext): Record<string, string> {
+  return {
+    ...buildBaseSpawnEnv(ctx),
+    AO_CONFIG_PATH: ctx.configPath,
+    AO_PROJECT_ID: ctx.projectName as unknown as string,
+    GH_TOKEN: ctx.installationToken as unknown as string,
+  };
+}
+
+function buildBaseSpawnEnv(ctx: DispatchContext): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const key of AO_ENV_ALLOWLIST) {
+    const v = process.env[key];
+    if (typeof v === "string") env[key] = v;
+  }
+  return env;
+}
+
+/**
+ * Invoke `ao spawn <issue>` with env `AO_CONFIG_PATH`, `AO_PROJECT_ID`,
+ * `GH_TOKEN` plus the `AO_ENV_ALLOWLIST`. Returns the ao session name on
+ * success.
+ *
+ * Env posture: the spawned child does NOT inherit the bridge's full env.
+ * Secrets the bridge holds (ZAPBOT_API_KEY, ZAPBOT_WEBHOOK_SECRET,
+ * GITHUB_APP_PRIVATE_KEY, etc.) are never visible to `ao` or its
+ * descendants — the installation token is the only credential passed.
+ *
+ * No retry — the legacy retry loop was coupled to DB rows; callers that want
+ * retry wrap this themselves.
+ */
+export async function dispatch(
+  ctx: DispatchContext
+): Promise<Result<AoSessionName, DispatchError>> {
+  const session = asAoSessionName(`${ctx.projectName as unknown as string}-${ctx.issue}`);
+  const spawnEnv = buildSpawnEnv(ctx);
+  const moltzapEnv = await buildMoltzapSpawnEnv(ctx.moltzap, {
+    repo: ctx.repo,
+    issue: ctx.issue,
+    projectName: ctx.projectName,
+    session,
+  });
+  if (moltzapEnv._tag === "Err") {
+    return err({ _tag: "MoltzapProvisionFailed", cause: moltzapEnv.error.cause });
+  }
+
+  const spawnResult = await runAoSpawn(ctx.issue, { ...spawnEnv, ...moltzapEnv.value });
+  if (spawnResult._tag === "Err") {
+    return spawnResult;
+  }
+
+  // Session name convention: `<projectName>-<issue>`. `ao` itself assigns it;
+  // we reconstruct it here rather than parsing stdout for testability.
+  return ok(session);
+}
+
+function runAoSpawn(
+  issue: IssueNumber,
+  env: Record<string, string>,
+): Promise<Result<void, DispatchError>> {
+  return new Promise((resolve) => {
+    let stderr = "";
+    let settled = false;
+    try {
+      const proc = spawn("ao", ["spawn", String(issue)], {
+        env,
+        stdio: ["ignore", "ignore", "pipe"],
+      });
+      proc.stderr?.setEncoding("utf8");
+      proc.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      proc.once("error", (cause) => {
+        if (settled) return;
+        settled = true;
+        resolve(err({
+          _tag: "AoSpawnFailed",
+          exitCode: -1,
+          stderr: cause instanceof Error ? cause.message : String(cause),
+        }));
+      });
+      proc.once("close", (exitCode) => {
+        if (settled) return;
+        settled = true;
+        if (exitCode === 0) {
+          resolve(ok(undefined));
+          return;
+        }
+        resolve(err({
+          _tag: "AoSpawnFailed",
+          exitCode: exitCode ?? -1,
+          stderr,
+        }));
+      });
+    } catch (cause) {
+      resolve(err({
+        _tag: "AoSpawnFailed",
+        exitCode: -1,
+        stderr: cause instanceof Error ? cause.message : String(cause),
+      }));
+    }
+  });
+}

--- a/v2/bridge.ts
+++ b/v2/bridge.ts
@@ -1,0 +1,452 @@
+/**
+ * v2/bridge — thinned HTTP bridge.
+ *
+ * Responsibilities (only):
+ *   - Boot HTTP server on configured port.
+ *   - Register/deregister with gateway; periodic heartbeat.
+ *   - Verify HMAC + classify webhook → dispatch.
+ *   - SIGHUP reload + graceful shutdown.
+ *
+ * Everything the legacy bridge had beyond this list is deleted (state machine, SQLite,
+ * plannotator, workflow/agent HTTP APIs, progress poller, cleanup sweep).
+ */
+
+import { verifyAndClassify, registerBridge, deregisterBridge, startHeartbeat } from "./gateway.ts";
+import type { GatewayClientConfig, GatewayWebhookEnvelope, ClassifiedWebhook } from "./gateway.ts";
+import { dispatch } from "./ao/dispatcher.ts";
+import { getIssue } from "./github-state.ts";
+import type { MoltzapRuntimeConfig } from "./moltzap/runtime.ts";
+import {
+  absurd,
+  asAoSessionName,
+  asDeliveryId,
+  asRepoFullName,
+  err,
+  ok,
+} from "./types.ts";
+import type {
+  BotUsername,
+  DispatchError,
+  GhCallError,
+  HandleOutcome,
+  InstallationToken,
+  IssueNumber,
+  ProjectName,
+  RepoFullName,
+  Result,
+} from "./types.ts";
+import { createGitHubClient, getInstallationToken } from "./github/client.ts";
+import { createLogger } from "./logger.ts";
+import { errorResponse } from "./http/error-response.ts";
+import {
+  handleInstallationTokenRequest,
+  type InstallationTokenStatus,
+} from "./http/routes/installation-token.ts";
+
+const WRITE_PERMISSIONS = new Set(["write", "maintain", "admin"]);
+const log = createLogger("v2/bridge");
+
+// ── Typed wrapper around gh.* calls that still throw ────────────────
+
+/**
+ * Call an async function from the GitHub client and map thrown errors into
+ * a typed `GhCallError`. The bridge never re-throws across a module boundary.
+ * Failures are logged at `warn` so silent catches do not hide regressions.
+ */
+async function safeGh<T>(
+  label: string,
+  fn: () => Promise<T>
+): Promise<Result<T, GhCallError>> {
+  try {
+    return ok(await fn());
+  } catch (e) {
+    const cause = e instanceof Error ? e.message : String(e);
+    log.warn(`gh_call_failed label=${label} cause=${cause}`);
+    return err({ _tag: "GhCallFailed", label, cause });
+  }
+}
+
+// ── Boot config ─────────────────────────────────────────────────────
+
+export interface BridgeConfig {
+  readonly port: number;
+  readonly publicUrl: string;
+  readonly gatewayUrl: string;
+  readonly gatewaySecret: string | null;
+  readonly botUsername: BotUsername;
+  readonly aoConfigPath: string;
+  /** Bearer for the loopback broker route (GET /api/tokens/installation). */
+  readonly apiKey: string;
+  /** HMAC-SHA256 secret for GitHub webhooks. Must differ from `apiKey`. */
+  readonly webhookSecret: string;
+  readonly moltzap: MoltzapRuntimeConfig;
+  readonly repos: ReadonlyMap<RepoFullName, RepoRoute>;
+}
+
+export interface RepoRoute {
+  readonly projectName: ProjectName;
+  readonly webhookSecretEnvVar: string;
+  readonly defaultBranch: string;
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────
+
+export interface RunningBridge {
+  readonly stop: () => Promise<void>;
+  readonly reload: (nextConfig: BridgeConfig) => Promise<void>;
+}
+
+export interface BridgeHandlerContext {
+  readonly mintToken: () => Promise<Result<InstallationToken, DispatchError>>;
+  readonly gh: GhAdapter;
+  readonly config: BridgeConfig;
+}
+
+export interface GhAdapter {
+  readonly addReaction: (repo: RepoFullName, commentId: number, reaction: string) => Promise<Result<void, GhCallError>>;
+  readonly getUserPermission: (repo: RepoFullName, user: string) => Promise<Result<string, GhCallError>>;
+  readonly postComment: (repo: RepoFullName, issue: IssueNumber, body: string) => Promise<Result<void, GhCallError>>;
+}
+
+export type { HandleOutcome } from "./types.ts";
+
+// ── Handler ─────────────────────────────────────────────────────────
+
+/**
+ * Dispatch a classified webhook. Pure over the handler context; no access
+ * to server globals. Returns an outcome or a `DispatchError`.
+ */
+export async function handleClassifiedWebhook(
+  classified: ClassifiedWebhook,
+  ctx: BridgeHandlerContext
+): Promise<Result<HandleOutcome, DispatchError>> {
+  if (classified.kind === "ignore") {
+    return { _tag: "Ok", value: { kind: "ignored", reason: classified.reason } };
+  }
+  if (classified.kind === "mention_command") {
+    return handleMention(classified, ctx);
+  }
+  return absurd(classified);
+}
+
+async function handleMention(
+  c: Extract<ClassifiedWebhook, { kind: "mention_command" }>,
+  ctx: BridgeHandlerContext
+): Promise<Result<HandleOutcome, DispatchError>> {
+  // Eyes reaction for immediate UX feedback (best-effort; log on failure, never bubble).
+  void ctx.gh.addReaction(c.repo, c.commentId as unknown as number, "eyes");
+
+  const permResult = await ctx.gh.getUserPermission(c.repo, c.triggeredBy);
+  if (permResult._tag === "Err") {
+    void ctx.gh.postComment(
+      c.repo,
+      c.issue,
+      `Sorry @${c.triggeredBy}, I couldn't verify your permissions right now. Please try again in a moment.`
+    );
+    return ok({ kind: "unauthorized", actor: c.triggeredBy, reason: "permission_check_failed" });
+  }
+  if (!WRITE_PERMISSIONS.has(permResult.value)) {
+    void ctx.gh.postComment(
+      c.repo,
+      c.issue,
+      `Sorry @${c.triggeredBy}, you need write access to this repo to use commands.`
+    );
+    return ok({ kind: "unauthorized", actor: c.triggeredBy, reason: "insufficient_permission" });
+  }
+
+  const cmd = c.command;
+  switch (cmd.kind) {
+    case "plan_this":
+    case "investigate_this": {
+      const route = ctx.config.repos.get(c.repo);
+      if (route === undefined) {
+        return err({ _tag: "ProjectNotConfigured", repo: c.repo });
+      }
+      const tokenResult = await ctx.mintToken();
+      if (tokenResult._tag === "Err") return tokenResult;
+      const dispatched = await dispatch({
+        repo: c.repo,
+        issue: c.issue,
+        projectName: route.projectName,
+        configPath: ctx.config.aoConfigPath,
+        installationToken: tokenResult.value,
+        moltzap: ctx.config.moltzap,
+      });
+      if (dispatched._tag === "Err") return dispatched;
+      const session = asAoSessionName(dispatched.value as unknown as string);
+      void ctx.gh.postComment(
+        c.repo,
+        c.issue,
+        `Dispatching agent for @${c.triggeredBy}. Session: \`${session as unknown as string}\`.`
+      );
+      return ok({ kind: "dispatched", repo: c.repo, session });
+    }
+    case "status": {
+      const summary = await summarizeIssue(c.repo, c.issue);
+      void ctx.gh.postComment(c.repo, c.issue, summary);
+      return ok({ kind: "replied", command: "status" });
+    }
+    case "unknown_command": {
+      void ctx.gh.postComment(
+        c.repo,
+        c.issue,
+        `@${c.triggeredBy} I don't recognize the command \`${cmd.raw}\`. Try \`plan this\`, \`investigate this\`, or \`status\`.`
+      );
+      return ok({ kind: "replied", command: "unknown_command" });
+    }
+    default:
+      return absurd(cmd);
+  }
+}
+
+async function summarizeIssue(repo: RepoFullName, issue: IssueNumber): Promise<string> {
+  const snap = await getIssue(repo, issue);
+  if (snap._tag === "Err") {
+    return `Could not fetch issue state (${snap.error._tag}).`;
+  }
+  const { state, labels, assignees } = snap.value;
+  const lines = [
+    `**Status for #${issue as unknown as number}**`,
+    `State: \`${state}\`; labels: ${labels.length ? labels.map((l) => `\`${l}\``).join(", ") : "_(none)_"}`,
+    `Assignees: ${assignees.length ? assignees.map((a) => `@${a}`).join(", ") : "_(none)_"}`,
+  ];
+  return lines.join("\n");
+}
+
+// ── Server boot ─────────────────────────────────────────────────────
+
+/**
+ * Build the default `GhAdapter` that wraps `createGitHubClient()` with
+ * `safeGh`. Client construction is lazy — we do not instantiate the
+ * Octokit until the first call, so `startBridge` boots cleanly in
+ * environments (tests, cold installs) where no GitHub credentials are
+ * configured yet. Construction failure is mapped to a typed `GhCallError`
+ * rather than a boot-time throw.
+ *
+ * Tests substitute their own adapter via `BridgeHandlerContext`.
+ */
+export function buildDefaultGhAdapter(): GhAdapter {
+  let cached: ReturnType<typeof createGitHubClient> | null = null;
+  async function lazy<T>(label: string, fn: (gh: ReturnType<typeof createGitHubClient>) => Promise<T>): Promise<Result<T, GhCallError>> {
+    if (cached === null) {
+      try {
+        cached = createGitHubClient();
+      } catch (e) {
+        const cause = e instanceof Error ? e.message : String(e);
+        log.warn(`gh_call_failed label=${label} cause=${cause}`);
+        return err({ _tag: "GhCallFailed", label, cause });
+      }
+    }
+    return safeGh(label, () => fn(cached!));
+  }
+  return {
+    addReaction: (repo, commentId, reaction) =>
+      lazy("addReaction", (gh) => gh.addReaction(repo as unknown as string, commentId, reaction)),
+    getUserPermission: (repo, user) =>
+      lazy("getUserPermission", (gh) => gh.getUserPermission(repo as unknown as string, user)),
+    postComment: (repo, issue, body) =>
+      lazy("postComment", async (gh) => {
+        await gh.postComment(repo as unknown as string, issue as unknown as number, body);
+      }),
+  };
+}
+
+/**
+ * Pure request router. Extracted from `startBridge` so tests can exercise
+ * the HTTP surface without booting `Bun.serve`. `getConfig` is a getter
+ * so SIGHUP reload is visible to the handler without re-building the
+ * closure.
+ */
+export function buildFetchHandler(
+  getConfig: () => BridgeConfig,
+  ctx: BridgeHandlerContext
+): (req: Request) => Promise<Response> {
+  return async (req: Request): Promise<Response> => {
+    const current = getConfig();
+    const url = new URL(req.url);
+    const pathname = url.pathname;
+
+    if (pathname === "/healthz") {
+      return new Response("ok", { status: 200 });
+    }
+
+    // Installation token broker (paired with safer-by-default#50).
+    // Thin wrapper around getInstallationToken() — no new mint path.
+    if (pathname === "/api/tokens/installation" && req.method === "GET") {
+      const result: InstallationTokenStatus = await handleInstallationTokenRequest(req, {
+        mintToken: getInstallationToken,
+        apiKey: current.apiKey,
+      });
+      const clientIp = req.headers.get("x-forwarded-for") ?? "local";
+      log.info(`installation_token.request status=${result.status} client_ip=${clientIp}`);
+      return Response.json(result.body, { status: result.status });
+    }
+
+    if (pathname === "/api/webhooks/github" && req.method === "POST") {
+      const body = await req.text();
+      const signature = req.headers.get("x-hub-signature-256");
+      const eventType = req.headers.get("x-github-event") ?? "";
+      const deliveryId = req.headers.get("x-github-delivery") ?? "";
+
+      let payload: unknown;
+      try {
+        payload = JSON.parse(body);
+      } catch {
+        return errorResponse(400, "invalid_request", "Request body is not valid JSON.");
+      }
+
+      const repoName =
+        (payload as { repository?: { full_name?: string } })?.repository?.full_name ?? "";
+      const repo = asRepoFullName(repoName);
+
+      // Repo enumeration pre-auth oracle: don't distinguish unknown-repo
+      // from bad signature. `verifyAndClassify` will fail HMAC on secret
+      // mismatch regardless; we also refuse unknown repos up front with
+      // the same 401 body so the two states are indistinguishable to an
+      // unauthenticated caller.
+      const configuredAndUnknown =
+        current.repos.size > 0 && repoName !== "" && !current.repos.has(repo);
+
+      const envelope: GatewayWebhookEnvelope = {
+        rawBody: body,
+        signature,
+        eventType,
+        deliveryId: asDeliveryId(deliveryId),
+        repo,
+        payload,
+      };
+
+      const classified = await verifyAndClassify(
+        envelope,
+        (r) => resolveSecret(r, current),
+        current.botUsername
+      );
+
+      if (configuredAndUnknown) {
+        return errorResponse(401, "signature_error", "Webhook signature verification failed.");
+      }
+      if (classified._tag === "Err") {
+        const e = classified.error;
+        switch (e._tag) {
+          case "SignatureMismatch":
+          case "SecretMissing":
+            return errorResponse(401, "signature_error", "Webhook signature verification failed.");
+          case "PayloadShapeInvalid":
+            return errorResponse(400, "invalid_request", `Malformed issue_comment payload: ${e.reason}.`);
+          default:
+            return absurd(e);
+        }
+      }
+
+      const outcome = await handleClassifiedWebhook(classified.value, ctx);
+      if (outcome._tag === "Err") {
+        const e = outcome.error;
+        switch (e._tag) {
+          case "AoSpawnFailed":
+            return errorResponse(502, "dispatch_failed", `ao spawn failed (exit ${e.exitCode}).`);
+          case "MoltzapProvisionFailed":
+            return errorResponse(503, "dispatch_unavailable", "MoltZap session provisioning failed.");
+          case "TokenMintFailed":
+            return errorResponse(503, "auth_unavailable", "Installation token unavailable.");
+          case "ProjectNotConfigured":
+            return errorResponse(403, "configuration_error", `Repo '${e.repo as unknown as string}' not routed.`);
+          default:
+            return absurd(e);
+        }
+      }
+
+      return Response.json({ ok: true, outcome: outcome.value });
+    }
+
+    return errorResponse(404, "not_found", "Resource not found.");
+  };
+}
+
+/**
+ * Default `mintToken` implementation — delegates to the shared singleton
+ * `getInstallationToken` and maps `null`/throw into `DispatchError`.
+ */
+export async function defaultMintToken(): Promise<Result<InstallationToken, DispatchError>> {
+  try {
+    const t = await getInstallationToken();
+    if (!t) return err({ _tag: "TokenMintFailed", cause: "no installation token available" });
+    return ok(t.token as unknown as InstallationToken);
+  } catch (e) {
+    const cause = e instanceof Error ? e.message : String(e);
+    return err({ _tag: "TokenMintFailed", cause });
+  }
+}
+
+/**
+ * Boot the HTTP server, register every configured repo with the gateway,
+ * start heartbeats, install SIGHUP → reload. Returns a handle for stop/reload.
+ */
+export async function startBridge(config: BridgeConfig): Promise<RunningBridge> {
+  let current = config;
+  let stopHeartbeat: (() => void) | null = null;
+
+  async function registerAll(cfg: BridgeConfig): Promise<void> {
+    const repos = Array.from(cfg.repos.keys());
+    if (repos.length === 0) return;
+    const client: GatewayClientConfig = {
+      gatewayUrl: cfg.gatewayUrl,
+      secret: cfg.gatewaySecret,
+      token: null,
+    };
+    await Promise.allSettled(
+      repos.map((repo) => registerBridge(client, repo, cfg.publicUrl))
+    );
+    if (stopHeartbeat) stopHeartbeat();
+    const intervalMs = parseInt(process.env.ZAPBOT_GATEWAY_HEARTBEAT_MS ?? "300000", 10);
+    stopHeartbeat = startHeartbeat(client, repos, cfg.publicUrl, intervalMs);
+  }
+
+  async function deregisterAll(cfg: BridgeConfig): Promise<void> {
+    const repos = Array.from(cfg.repos.keys());
+    const client: GatewayClientConfig = {
+      gatewayUrl: cfg.gatewayUrl,
+      secret: cfg.gatewaySecret,
+      token: null,
+    };
+    await Promise.allSettled(
+      repos.map((repo) => deregisterBridge(client, repo, cfg.publicUrl))
+    );
+  }
+
+  const ghAdapter = buildDefaultGhAdapter();
+  const ctx: BridgeHandlerContext = {
+    mintToken: defaultMintToken,
+    gh: ghAdapter,
+    get config() {
+      return current;
+    },
+  };
+
+  const handler = buildFetchHandler(() => current, ctx);
+  const server = Bun.serve({ port: current.port, fetch: handler });
+
+  await registerAll(current);
+
+  const running: RunningBridge = {
+    async stop(): Promise<void> {
+      if (stopHeartbeat) stopHeartbeat();
+      await deregisterAll(current);
+      server.stop();
+    },
+    async reload(nextConfig: BridgeConfig): Promise<void> {
+      current = nextConfig;
+      await registerAll(current);
+    },
+  };
+  return running;
+}
+
+function resolveSecret(repo: RepoFullName, cfg: BridgeConfig): string | null {
+  const route = cfg.repos.get(repo);
+  if (!route) {
+    return cfg.webhookSecret;
+  }
+  const perRepo = process.env[route.webhookSecretEnvVar];
+  if (perRepo) return perRepo;
+  return cfg.webhookSecret;
+}

--- a/v2/bridge.ts
+++ b/v2/bridge.ts
@@ -387,6 +387,10 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
 
   async function registerAll(cfg: BridgeConfig): Promise<void> {
     const repos = Array.from(cfg.repos.keys());
+    if (stopHeartbeat) {
+      stopHeartbeat();
+      stopHeartbeat = null;
+    }
     if (repos.length === 0) return;
     const client: GatewayClientConfig = {
       gatewayUrl: cfg.gatewayUrl,
@@ -401,8 +405,7 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
     stopHeartbeat = startHeartbeat(client, repos, cfg.publicUrl, intervalMs);
   }
 
-  async function deregisterAll(cfg: BridgeConfig): Promise<void> {
-    const repos = Array.from(cfg.repos.keys());
+  async function deregisterRepos(cfg: BridgeConfig, repos: ReadonlyArray<RepoFullName>): Promise<void> {
     const client: GatewayClientConfig = {
       gatewayUrl: cfg.gatewayUrl,
       secret: cfg.gatewaySecret,
@@ -411,6 +414,10 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
     await Promise.allSettled(
       repos.map((repo) => deregisterBridge(client, repo, cfg.publicUrl))
     );
+  }
+
+  async function deregisterAll(cfg: BridgeConfig): Promise<void> {
+    await deregisterRepos(cfg, Array.from(cfg.repos.keys()));
   }
 
   const ghAdapter = buildDefaultGhAdapter();
@@ -434,6 +441,14 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
       server.stop();
     },
     async reload(nextConfig: BridgeConfig): Promise<void> {
+      const removedRepos = Array.from(current.repos.keys()).filter(
+        (repo) => !nextConfig.repos.has(repo)
+      );
+      if (stopHeartbeat) {
+        stopHeartbeat();
+        stopHeartbeat = null;
+      }
+      await deregisterRepos(current, removedRepos);
       current = nextConfig;
       await registerAll(current);
     },

--- a/v2/gateway.ts
+++ b/v2/gateway.ts
@@ -1,0 +1,252 @@
+/**
+ * v2/gateway — the bridge's view of the gateway service.
+ *
+ * Two responsibilities:
+ *   1. Register/deregister/heartbeat with the gateway service.
+ *   2. Verify HMAC on a forwarded webhook envelope and classify it
+ *      into a `ClassifiedWebhook` the bridge can act on.
+ */
+
+import { verifySignature } from "./http/verify-signature.ts";
+import { parseMention } from "./mention-parser.ts";
+import {
+  asCommentId,
+  asIssueNumber,
+  err,
+  ok,
+} from "./types.ts";
+import type {
+  BotUsername,
+  CommentId,
+  DeliveryId,
+  GatewayError,
+  IssueNumber,
+  MentionCommand,
+  RepoFullName,
+  Result,
+  WebhookIntakeError,
+} from "./types.ts";
+
+// ── Bridge → gateway registration ───────────────────────────────────
+
+export interface GatewayClientConfig {
+  readonly gatewayUrl: string;
+  readonly secret: string | null;
+  readonly token: string | null;
+}
+
+function authToken(config: GatewayClientConfig): string | null {
+  return config.token ?? config.secret ?? null;
+}
+
+async function postRegistration(
+  config: GatewayClientConfig,
+  method: "POST" | "DELETE",
+  body: Record<string, unknown>
+): Promise<Result<void, GatewayError>> {
+  const token = authToken(config);
+  if (!token) return err({ _tag: "GatewayAuthMissing" });
+  const url = `${config.gatewayUrl}/api/bridges/register`;
+  try {
+    const resp = await fetch(url, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => "");
+      return err({ _tag: "GatewayRejected", status: resp.status, body: text });
+    }
+    return ok(undefined);
+  } catch (e) {
+    return err({ _tag: "GatewayUnreachable", cause: String(e) });
+  }
+}
+
+/**
+ * Register this bridge with the gateway for the given repo. Idempotent:
+ * re-registering overwrites the previous `bridgeUrl` mapping.
+ */
+export function registerBridge(
+  config: GatewayClientConfig,
+  repo: RepoFullName,
+  bridgeUrl: string
+): Promise<Result<void, GatewayError>> {
+  return postRegistration(config, "POST", { repo, bridgeUrl });
+}
+
+export function deregisterBridge(
+  config: GatewayClientConfig,
+  repo: RepoFullName,
+  _bridgeUrl: string
+): Promise<Result<void, GatewayError>> {
+  return postRegistration(config, "DELETE", { repo });
+}
+
+/**
+ * Start a periodic re-registration loop. Returns a disposer that stops the
+ * loop.
+ */
+export function startHeartbeat(
+  config: GatewayClientConfig,
+  repos: ReadonlyArray<RepoFullName>,
+  bridgeUrl: string,
+  intervalMs: number
+): () => void {
+  const timer = setInterval(() => {
+    for (const repo of repos) {
+      // Fire-and-forget; gateway tolerates duplicate registrations.
+      void registerBridge(config, repo, bridgeUrl);
+    }
+  }, intervalMs);
+  return () => clearInterval(timer);
+}
+
+// ── Webhook intake contract ─────────────────────────────────────────
+
+export interface GatewayWebhookEnvelope {
+  readonly rawBody: string;
+  readonly signature: string | null;
+  readonly eventType: string;
+  readonly deliveryId: DeliveryId;
+  readonly repo: RepoFullName;
+  readonly payload: unknown;
+}
+
+export type ClassifiedWebhook =
+  | { readonly kind: "ignore"; readonly reason: string }
+  | {
+      readonly kind: "mention_command";
+      readonly repo: RepoFullName;
+      readonly issue: IssueNumber;
+      readonly commentId: CommentId;
+      readonly command: MentionCommand;
+      readonly triggeredBy: string;
+    };
+
+// ── Boundary schema: issue_comment payload ──────────────────────────
+
+interface IssueCommentPayload {
+  readonly action: string;
+  readonly comment: { readonly id: number; readonly body: string };
+  readonly issue: { readonly number: number; readonly isPullRequest: boolean };
+  readonly sender: { readonly login: string };
+}
+
+type DecodeResult =
+  | { readonly kind: "decoded"; readonly value: IssueCommentPayload }
+  | { readonly kind: "invalid"; readonly reason: string }
+  | { readonly kind: "other_event"; readonly reason: string };
+
+/**
+ * Validate the shape of an issue_comment webhook payload. Returns `decoded`
+ * on success, `other_event` when the payload is structurally valid JSON that
+ * isn't an issue_comment we care about (→ caller should ignore), or `invalid`
+ * when the shape is wrong (→ caller should reject).
+ */
+function decodeIssueCommentPayload(
+  payload: unknown,
+  eventType: string
+): DecodeResult {
+  if (payload === null || typeof payload !== "object") {
+    return { kind: "invalid", reason: "payload is not an object" };
+  }
+  if (eventType !== "issue_comment") {
+    return { kind: "other_event", reason: `event ${eventType}` };
+  }
+  const p = payload as Record<string, unknown>;
+  const action = p.action;
+  if (typeof action !== "string") {
+    return { kind: "invalid", reason: "missing string 'action'" };
+  }
+  if (action !== "created") {
+    return { kind: "other_event", reason: `action ${action}` };
+  }
+
+  const comment = p.comment;
+  if (comment === null || typeof comment !== "object") {
+    return { kind: "invalid", reason: "missing 'comment' object" };
+  }
+  const c = comment as Record<string, unknown>;
+  if (typeof c.id !== "number" || typeof c.body !== "string") {
+    return { kind: "invalid", reason: "comment.id/body malformed" };
+  }
+
+  const issue = p.issue;
+  if (issue === null || typeof issue !== "object") {
+    return { kind: "invalid", reason: "missing 'issue' object" };
+  }
+  const i = issue as Record<string, unknown>;
+  if (typeof i.number !== "number") {
+    return { kind: "invalid", reason: "issue.number malformed" };
+  }
+
+  const sender = p.sender;
+  if (sender === null || typeof sender !== "object") {
+    return { kind: "invalid", reason: "missing 'sender' object" };
+  }
+  const s = sender as Record<string, unknown>;
+  if (typeof s.login !== "string") {
+    return { kind: "invalid", reason: "sender.login malformed" };
+  }
+
+  return {
+    kind: "decoded",
+    value: {
+      action,
+      comment: { id: c.id, body: c.body },
+      issue: {
+        number: i.number,
+        isPullRequest: i.pull_request !== undefined && i.pull_request !== null,
+      },
+      sender: { login: s.login },
+    },
+  };
+}
+
+/**
+ * Verify HMAC, then classify the envelope into either `ignore` or a
+ * `mention_command`. Only `issue_comment.created` events whose body mentions
+ * the bot can become `mention_command`; everything else resolves to `ignore`.
+ */
+export async function verifyAndClassify(
+  envelope: GatewayWebhookEnvelope,
+  resolveSecret: (repo: RepoFullName) => string | null,
+  botUsername: BotUsername
+): Promise<Result<ClassifiedWebhook, WebhookIntakeError>> {
+  const secret = resolveSecret(envelope.repo);
+  if (secret === null) return err({ _tag: "SecretMissing", repo: envelope.repo });
+  const verified = await verifySignature(envelope.rawBody, envelope.signature, secret);
+  if (!verified) return err({ _tag: "SignatureMismatch" });
+
+  const decoded = decodeIssueCommentPayload(envelope.payload, envelope.eventType);
+  if (decoded.kind === "invalid") {
+    return err({ _tag: "PayloadShapeInvalid", reason: decoded.reason });
+  }
+  if (decoded.kind === "other_event") {
+    return ok({ kind: "ignore", reason: decoded.reason });
+  }
+
+  const p = decoded.value;
+  if (p.sender.login === (botUsername as unknown as string)) {
+    return ok({ kind: "ignore", reason: "self-mention" });
+  }
+
+  const command = parseMention(p.comment.body, botUsername);
+  if (command === null) {
+    return ok({ kind: "ignore", reason: "no bot mention" });
+  }
+
+  return ok({
+    kind: "mention_command",
+    repo: envelope.repo,
+    issue: asIssueNumber(p.issue.number),
+    commentId: asCommentId(p.comment.id),
+    command,
+    triggeredBy: p.sender.login,
+  });
+}

--- a/v2/github-state.ts
+++ b/v2/github-state.ts
@@ -1,0 +1,207 @@
+/**
+ * v2/github-state — read durable workflow state from GitHub via Octokit.
+ *
+ * Architect Open Question 2 default B: Octokit directly, not the `gh` CLI.
+ */
+
+import { Octokit } from "@octokit/rest";
+import { createAppAuth } from "@octokit/auth-app";
+import { readFileSync } from "fs";
+import {
+  asCommentId,
+  asIssueNumber,
+  err,
+  ok,
+} from "./types.ts";
+import type {
+  BotUsername,
+  CommentId,
+  GithubStateError,
+  IssueNumber,
+  RepoFullName,
+  Result,
+} from "./types.ts";
+
+export type IssueState = "open" | "closed";
+
+export interface IssueSnapshot {
+  readonly repo: RepoFullName;
+  readonly number: IssueNumber;
+  readonly state: IssueState;
+  readonly labels: ReadonlyArray<string>;
+  readonly assignees: ReadonlyArray<string>;
+  readonly body: string;
+  readonly author: string;
+}
+
+export interface CommentSnapshot {
+  readonly id: CommentId;
+  readonly author: string;
+  readonly body: string;
+  readonly createdAt: string;
+}
+
+export type Claim =
+  | { readonly kind: "unclaimed" }
+  | { readonly kind: "claimed"; readonly by: BotUsername };
+
+function splitRepo(repo: RepoFullName): { owner: string; repo: string } {
+  const [owner, name] = (repo as unknown as string).split("/");
+  return { owner, repo: name };
+}
+
+function toError(repo: RepoFullName, issue: IssueNumber, e: unknown): GithubStateError {
+  const anyErr = e as { status?: number; message?: string };
+  if (anyErr?.status === 404) return { _tag: "IssueNotFound", repo, issue };
+  return { _tag: "GitHubApiFailed", status: anyErr?.status ?? -1, message: anyErr?.message ?? String(e) };
+}
+
+function extractLabels(labels: Array<string | { name?: string | null }>): string[] {
+  return labels
+    .map((l) => (typeof l === "string" ? l : l.name ?? ""))
+    .filter((s) => s !== "");
+}
+
+function extractAssignees(assignees: Array<{ login: string } | null> | null): string[] {
+  return (assignees ?? [])
+    .map((a) => a?.login ?? "")
+    .filter((s) => s !== "");
+}
+
+export async function getIssue(
+  repo: RepoFullName,
+  issue: IssueNumber
+): Promise<Result<IssueSnapshot, GithubStateError>> {
+  const client = getOctokit();
+  if (client === null) return err({ _tag: "GitHubAuthMissing" });
+  const r = splitRepo(repo);
+  try {
+    const { data } = await client.rest.issues.get({
+      owner: r.owner,
+      repo: r.repo,
+      issue_number: issue as unknown as number,
+    });
+    return ok({
+      repo,
+      number: issue,
+      state: data.state === "closed" ? "closed" : "open",
+      labels: extractLabels(data.labels ?? []),
+      assignees: extractAssignees(data.assignees ?? null),
+      body: data.body ?? "",
+      author: data.user?.login ?? "",
+    });
+  } catch (e) {
+    return err(toError(repo, issue, e));
+  }
+}
+
+export async function getAgentClaim(
+  repo: RepoFullName,
+  issue: IssueNumber,
+  bot: BotUsername
+): Promise<Result<Claim, GithubStateError>> {
+  const snap = await getIssue(repo, issue);
+  if (snap._tag === "Err") return snap;
+  const botStr = bot as unknown as string;
+  const claimed = snap.value.assignees.includes(botStr) && snap.value.state === "open";
+  if (claimed) return ok({ kind: "claimed", by: bot });
+  return ok({ kind: "unclaimed" });
+}
+
+export async function listOpenIssuesWithLabel(
+  repo: RepoFullName,
+  label: string
+): Promise<Result<ReadonlyArray<IssueSnapshot>, GithubStateError>> {
+  const client = getOctokit();
+  if (client === null) return err({ _tag: "GitHubAuthMissing" });
+  const r = splitRepo(repo);
+  try {
+    const { data } = await client.rest.issues.listForRepo({
+      owner: r.owner,
+      repo: r.repo,
+      state: "open",
+      labels: label,
+      per_page: 100,
+    });
+    const snaps: IssueSnapshot[] = data
+      .filter((row) => !row.pull_request)
+      .map((row) => ({
+        repo,
+        number: asIssueNumber(row.number),
+        state: (row.state === "closed" ? "closed" : "open") as IssueState,
+        labels: extractLabels(row.labels ?? []),
+        assignees: extractAssignees(row.assignees ?? null),
+        body: row.body ?? "",
+        author: row.user?.login ?? "",
+      }));
+    return ok(snaps);
+  } catch (e) {
+    return err(toError(repo, asIssueNumber(-1), e));
+  }
+}
+
+export async function postComment(
+  repo: RepoFullName,
+  issue: IssueNumber,
+  body: string
+): Promise<Result<CommentId, GithubStateError>> {
+  const client = getOctokit();
+  if (client === null) return err({ _tag: "GitHubAuthMissing" });
+  const r = splitRepo(repo);
+  try {
+    const { data } = await client.rest.issues.createComment({
+      owner: r.owner,
+      repo: r.repo,
+      issue_number: issue as unknown as number,
+      body,
+    });
+    return ok(asCommentId(data.id));
+  } catch (e) {
+    return err(toError(repo, issue, e));
+  }
+}
+
+// ── Octokit wiring ──────────────────────────────────────────────────
+
+let _client: Octokit | null = null;
+
+function getOctokit(): Octokit | null {
+  if (_client !== null) return _client;
+  _client = buildOctokit();
+  return _client;
+}
+
+function buildOctokit(): Octokit | null {
+  const appId = process.env.GITHUB_APP_ID;
+  if (appId) {
+    const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+    if (!installationId) return null;
+    const privateKey = loadPrivateKey();
+    if (privateKey === null) return null;
+    return new Octokit({
+      authStrategy: createAppAuth,
+      auth: { appId, privateKey, installationId },
+    });
+  }
+  const pat = process.env.ZAPBOT_GITHUB_TOKEN;
+  if (pat) return new Octokit({ auth: pat });
+  return null;
+}
+
+function loadPrivateKey(): string | null {
+  const keyOrPath = process.env.GITHUB_APP_PRIVATE_KEY;
+  if (!keyOrPath) return null;
+  if (keyOrPath.startsWith("-----BEGIN")) return keyOrPath;
+  try {
+    return readFileSync(keyOrPath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Test-only: reset the memoized client. Not part of the public API.
+ */
+export function __resetForTests(): void {
+  _client = null;
+}

--- a/v2/github/client.ts
+++ b/v2/github/client.ts
@@ -1,0 +1,265 @@
+import { Octokit } from "@octokit/rest";
+import { createAppAuth } from "@octokit/auth-app";
+import { readFileSync } from "fs";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("github");
+
+export interface GitHubClient {
+  addLabel(repo: string, issueNumber: number, label: string): Promise<void>;
+  removeLabel(repo: string, issueNumber: number, label: string): Promise<void>;
+  postComment(repo: string, issueNumber: number, body: string): Promise<{ id: number }>;
+  updateComment(repo: string, commentId: number, body: string): Promise<void>;
+  closeIssue(repo: string, issueNumber: number): Promise<void>;
+  createIssue(repo: string, title: string, body: string, labels: string[]): Promise<string>;
+  editIssue(repo: string, issueNumber: number, updates: Record<string, unknown>): Promise<void>;
+  convertPrToDraft(repo: string, prNumber: number): Promise<void>;
+  addReaction(repo: string, commentId: number, reaction: string): Promise<void>;
+  addIssueReaction(repo: string, issueNumber: number, reaction: string): Promise<void>;
+  assignIssue(repo: string, issueNumber: number, assignees: string[]): Promise<void>;
+  getIssue(repo: string, issueNumber: number): Promise<{ state: "open" | "closed"; body: string }>;
+  getIssueState(repo: string, issueNumber: number): Promise<"open" | "closed">;
+  getIssueBody(repo: string, issueNumber: number): Promise<string>;
+  getUserPermission(repo: string, username: string): Promise<string>;
+  listWebhooks(repo: string): Promise<Array<{ id: number; config: { url?: string } }>>;
+  createWebhook(repo: string, config: WebhookConfig): Promise<number>;
+  updateWebhook(repo: string, hookId: number, config: Partial<WebhookConfig>): Promise<void>;
+  deactivateWebhook(repo: string, hookId: number): Promise<void>;
+}
+
+export interface WebhookConfig {
+  url: string;
+  content_type: string;
+  secret: string;
+  events: string[];
+  active: boolean;
+}
+
+function splitRepo(repo: string): { owner: string; repo: string } {
+  const [owner, name] = repo.split("/");
+  return { owner, repo: name };
+}
+
+/**
+ * Load a PEM private key from env var. The value can be either:
+ * - The PEM content directly (starts with "-----BEGIN")
+ * - A file path to a .pem file
+ */
+export function loadPrivateKey(): string {
+  const keyOrPath = process.env.GITHUB_APP_PRIVATE_KEY;
+  if (!keyOrPath) throw new Error("GITHUB_APP_PRIVATE_KEY is required for GitHub App auth");
+
+  if (keyOrPath.startsWith("-----BEGIN")) return keyOrPath;
+
+  try {
+    return readFileSync(keyOrPath, "utf-8");
+  } catch (err) {
+    throw new Error(`Cannot read private key file: ${keyOrPath}: ${err}`);
+  }
+}
+
+function wrapOctokit(octokit: Octokit): GitHubClient {
+  return {
+    async addLabel(repo, issueNumber, label) {
+      const r = splitRepo(repo);
+      log.debug(`Adding label '${label}' to #${issueNumber}`, { repo, issueNumber, label });
+      await octokit.rest.issues.addLabels({ ...r, issue_number: issueNumber, labels: [label] });
+    },
+
+    async removeLabel(repo, issueNumber, label) {
+      const r = splitRepo(repo);
+      log.debug(`Removing label '${label}' from #${issueNumber}`, { repo, issueNumber, label });
+      try {
+        await octokit.rest.issues.removeLabel({ ...r, issue_number: issueNumber, name: label });
+      } catch (err: any) {
+        if (err.status === 404) return;
+        throw err;
+      }
+    },
+
+    async postComment(repo, issueNumber, body) {
+      const r = splitRepo(repo);
+      log.debug(`Posting comment on #${issueNumber}`, { repo, issueNumber });
+      const { data } = await octokit.rest.issues.createComment({ ...r, issue_number: issueNumber, body });
+      return { id: data.id };
+    },
+
+    async updateComment(repo, commentId, body) {
+      const r = splitRepo(repo);
+      log.debug(`Updating comment ${commentId}`, { repo, commentId });
+      await octokit.rest.issues.updateComment({ ...r, comment_id: commentId, body });
+    },
+
+    async closeIssue(repo, issueNumber) {
+      const r = splitRepo(repo);
+      log.debug(`Closing issue #${issueNumber}`, { repo, issueNumber });
+      await octokit.rest.issues.update({ ...r, issue_number: issueNumber, state: "closed" });
+    },
+
+    async createIssue(repo, title, body, labels) {
+      const r = splitRepo(repo);
+      log.debug(`Creating issue`, { repo, title });
+      const { data } = await octokit.rest.issues.create({ ...r, title, body, labels });
+      return data.html_url;
+    },
+
+    async editIssue(repo, issueNumber, updates) {
+      const r = splitRepo(repo);
+      log.debug(`Editing issue #${issueNumber}`, { repo, issueNumber });
+      await octokit.rest.issues.update({ ...r, issue_number: issueNumber, ...updates } as any);
+    },
+
+    async convertPrToDraft(repo, prNumber) {
+      const r = splitRepo(repo);
+      log.debug(`Converting PR #${prNumber} to draft via GraphQL`, { repo, prNumber });
+      const { data: pr } = await octokit.rest.pulls.get({ ...r, pull_number: prNumber });
+      await octokit.graphql(`mutation($id: ID!) { convertPullRequestToDraft(input: {pullRequestId: $id}) { pullRequest { isDraft } } }`, {
+        id: pr.node_id,
+      });
+    },
+
+    async addReaction(repo, commentId, reaction) {
+      const r = splitRepo(repo);
+      log.debug(`Adding '${reaction}' reaction to comment ${commentId}`, { repo, commentId });
+      await octokit.rest.reactions.createForIssueComment({ ...r, comment_id: commentId, content: reaction as any });
+    },
+
+    async addIssueReaction(repo, issueNumber, reaction) {
+      const r = splitRepo(repo);
+      log.debug(`Adding '${reaction}' reaction to issue #${issueNumber}`, { repo, issueNumber });
+      await octokit.rest.reactions.createForIssue({ ...r, issue_number: issueNumber, content: reaction as any });
+    },
+
+    async assignIssue(repo, issueNumber, assignees) {
+      const r = splitRepo(repo);
+      log.debug(`Assigning ${assignees.join(", ")} to #${issueNumber}`, { repo, issueNumber });
+      await octokit.rest.issues.addAssignees({ ...r, issue_number: issueNumber, assignees });
+    },
+
+    async getIssue(repo, issueNumber) {
+      const r = splitRepo(repo);
+      const { data } = await octokit.rest.issues.get({ ...r, issue_number: issueNumber });
+      return { state: data.state === "closed" ? "closed" as const : "open" as const, body: data.body || "" };
+    },
+
+    async getIssueState(repo, issueNumber) {
+      return (await this.getIssue(repo, issueNumber)).state;
+    },
+
+    async getIssueBody(repo, issueNumber) {
+      return (await this.getIssue(repo, issueNumber)).body;
+    },
+
+    async getUserPermission(repo, username) {
+      const r = splitRepo(repo);
+      log.debug(`Checking permission for ${username}`, { repo, username });
+      const { data } = await octokit.rest.repos.getCollaboratorPermissionLevel({ ...r, username });
+      return data.permission;
+    },
+
+    async listWebhooks(repo) {
+      const r = splitRepo(repo);
+      const { data } = await octokit.rest.repos.listWebhooks({ ...r });
+      return data.map((h) => ({ id: h.id, config: { url: h.config.url } }));
+    },
+
+    async createWebhook(repo, config) {
+      const r = splitRepo(repo);
+      const { data } = await octokit.rest.repos.createWebhook({
+        ...r,
+        config: { url: config.url, content_type: config.content_type, secret: config.secret },
+        events: config.events,
+        active: config.active,
+      });
+      return data.id;
+    },
+
+    async updateWebhook(repo, hookId, config) {
+      const r = splitRepo(repo);
+      const payload: any = { ...r, hook_id: hookId };
+      if (config.url || config.content_type || config.secret) {
+        payload.config = {
+          ...(config.url && { url: config.url }),
+          ...(config.content_type && { content_type: config.content_type }),
+          ...(config.secret && { secret: config.secret }),
+        };
+      }
+      if (config.active !== undefined) payload.active = config.active;
+      await octokit.rest.repos.updateWebhook(payload);
+    },
+
+    async deactivateWebhook(repo, hookId) {
+      const r = splitRepo(repo);
+      await octokit.rest.repos.updateWebhook({ ...r, hook_id: hookId, active: false });
+    },
+  };
+}
+
+// ── Installation token for agent sessions ──────────────────────────
+
+let _authInstance: ReturnType<typeof createAppAuth> | null = null;
+
+/**
+ * Installation token plus the real `expiresAt` returned by
+ * `@octokit/auth-app`. Callers that need the raw token (legacy bridge paths,
+ * `ao spawn` env) can destructure `.token`; callers that broker the token
+ * across a trust boundary (HTTP) propagate `.expiresAt` so downstream
+ * caches refresh on the real GitHub expiry, not a wall-clock guess.
+ */
+export interface InstallationTokenPair {
+  readonly token: string;
+  readonly expiresAt: string;
+}
+
+/**
+ * Get a fresh GitHub App installation token. Agents use this as GH_TOKEN
+ * so gh CLI and git operations run as the bot, not the user.
+ * Returns null if not using GitHub App auth (PAT mode).
+ */
+export async function getInstallationToken(): Promise<InstallationTokenPair | null> {
+  if (!_authInstance) {
+    const appId = process.env.GITHUB_APP_ID;
+    if (!appId) return null;
+    const privateKey = loadPrivateKey();
+    const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+    if (!installationId) return null;
+    _authInstance = createAppAuth({ appId, privateKey, installationId });
+  }
+  const auth = await _authInstance({ type: "installation" });
+  return { token: auth.token, expiresAt: auth.expiresAt };
+}
+
+// ── Factory ─────────────────────────────────────────────────────────
+
+export function createGitHubClient(): GitHubClient {
+  // Priority 1: GitHub App auth (recommended)
+  const appId = process.env.GITHUB_APP_ID;
+  if (appId) {
+    const privateKey = loadPrivateKey();
+    const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+    if (!installationId) {
+      throw new Error("GITHUB_APP_INSTALLATION_ID is required when using GitHub App auth");
+    }
+    log.info("Using GitHub App for API calls", { appId, installationId });
+    const octokit = new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        appId,
+        privateKey,
+        installationId,
+      },
+    });
+    return wrapOctokit(octokit);
+  }
+
+  // Priority 2: Personal access token
+  const token = process.env.ZAPBOT_GITHUB_TOKEN;
+  if (token) {
+    log.info("Using personal access token for GitHub API calls");
+    return wrapOctokit(new Octokit({ auth: token }));
+  }
+
+  throw new Error(
+    "No GitHub credentials configured. Set GITHUB_APP_ID (recommended) or ZAPBOT_GITHUB_TOKEN in your .env"
+  );
+}

--- a/v2/http/error-response.ts
+++ b/v2/http/error-response.ts
@@ -1,0 +1,6 @@
+/**
+ * Build a structured JSON error response.
+ */
+export function errorResponse(status: number, type: string, message: string): Response {
+  return Response.json({ error: { type, message, status } }, { status });
+}

--- a/v2/http/routes/installation-token.ts
+++ b/v2/http/routes/installation-token.ts
@@ -1,0 +1,174 @@
+/**
+ * Token-broker endpoint: GET /api/tokens/installation
+ *
+ * Thin wrapper around the existing _authInstance singleton at
+ * v2/github/client.ts (getInstallationToken). No new mint path.
+ *
+ * Auth: Authorization: Bearer $ZAPBOT_API_KEY. Bearer match is constant-time
+ * (timingSafeEqual). No JWT, no Supabase — this endpoint is local-only on the
+ * bridge loopback listener.
+ *
+ * Invariants:
+ *   - One mint path. All tokens originate from getInstallationToken().
+ *   - No token written to disk. Handler holds the token in-memory only for
+ *     the duration of the response.
+ *   - `expires_at` is the real value returned by `@octokit/auth-app`, not a
+ *     wall-clock guess. Propagating the truth lets downstream caches refresh
+ *     at the actual GitHub expiry.
+ *   - 409 app_not_configured when getInstallationToken() returns null
+ *     (GITHUB_APP_ID or GITHUB_APP_INSTALLATION_ID unset).
+ */
+
+import { timingSafeEqual } from "node:crypto";
+
+// ── Branded types ──────────────────────────────────────────────────
+
+/** Opaque GitHub App installation token. Do not log, do not persist. */
+export type InstallationToken = string & { readonly __brand: "InstallationToken" };
+
+/** ISO-8601 timestamp. Narrower than raw string at public surface. */
+export type Iso8601 = string & { readonly __brand: "Iso8601" };
+
+// ── Response schema ────────────────────────────────────────────────
+
+export interface InstallationTokenOk {
+  readonly token: InstallationToken;
+  readonly expires_at: Iso8601;
+}
+
+export type InstallationTokenError =
+  | { readonly error: "unauthorized"; readonly message: string }
+  | { readonly error: "app_not_configured"; readonly message: string }
+  | { readonly error: "internal_error"; readonly message: string };
+
+export type InstallationTokenResponse = InstallationTokenOk | InstallationTokenError;
+
+export type InstallationTokenStatus =
+  | { readonly status: 200; readonly body: InstallationTokenOk }
+  | { readonly status: 401; readonly body: Extract<InstallationTokenError, { error: "unauthorized" }> }
+  | { readonly status: 409; readonly body: Extract<InstallationTokenError, { error: "app_not_configured" }> }
+  | { readonly status: 500; readonly body: Extract<InstallationTokenError, { error: "internal_error" }> };
+
+// ── Handler dependencies ───────────────────────────────────────────
+
+/**
+ * Minted token + real GitHub App installation expiry (ISO-8601 UTC from
+ * `@octokit/auth-app`). Callers at the bridge edge pass this through to the
+ * broker response body.
+ */
+export interface MintedInstallationToken {
+  readonly token: string;
+  readonly expiresAt: Iso8601;
+}
+
+export interface InstallationTokenDeps {
+  readonly mintToken: () => Promise<MintedInstallationToken | null>;
+  readonly apiKey: string;
+}
+
+// ── Exhaustiveness helper ──────────────────────────────────────────
+
+function absurd(x: never): never {
+  throw new Error(`unreachable installation-token status: ${JSON.stringify(x)}`);
+}
+
+// ── Bearer auth middleware ─────────────────────────────────────────
+
+const BEARER_PREFIX = "Bearer ";
+
+function unauthorized(
+  message: string,
+): Extract<InstallationTokenError, { error: "unauthorized" }> {
+  return { error: "unauthorized", message };
+}
+
+export function verifyBearer(
+  authHeader: string | null,
+  expected: string,
+): null | Extract<InstallationTokenError, { error: "unauthorized" }> {
+  if (authHeader === null || authHeader === "") {
+    return unauthorized("Missing Authorization header.");
+  }
+  if (!authHeader.startsWith(BEARER_PREFIX)) {
+    return unauthorized("Authorization header must use Bearer scheme.");
+  }
+  const provided = authHeader.slice(BEARER_PREFIX.length);
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) {
+    return unauthorized("Invalid Bearer credentials.");
+  }
+  return timingSafeEqual(a, b) ? null : unauthorized("Invalid Bearer credentials.");
+}
+
+// ── Handler ────────────────────────────────────────────────────────
+
+export async function handleInstallationTokenRequest(
+  req: Request,
+  deps: InstallationTokenDeps,
+): Promise<InstallationTokenStatus> {
+  const authFailure = verifyBearer(req.headers.get("authorization"), deps.apiKey);
+  if (authFailure !== null) {
+    return { status: 401, body: authFailure };
+  }
+
+  let minted: MintedInstallationToken | null;
+  try {
+    minted = await deps.mintToken();
+  } catch {
+    // Exception body omitted on purpose — may include PEM fragments on misconfig.
+    return {
+      status: 500,
+      body: { error: "internal_error", message: "Failed to mint installation token." },
+    };
+  }
+
+  if (minted === null) {
+    return {
+      status: 409,
+      body: {
+        error: "app_not_configured",
+        message:
+          "GitHub App is not configured on the bridge (GITHUB_APP_ID and GITHUB_APP_INSTALLATION_ID required).",
+      },
+    };
+  }
+
+  const token = minted.token as InstallationToken;
+  const expires_at = minted.expiresAt as Iso8601;
+  return { status: 200, body: { token, expires_at } };
+}
+
+// ── Bun.serve adapter ──────────────────────────────────────────────
+
+function toResponse(result: InstallationTokenStatus): Response {
+  switch (result.status) {
+    case 200:
+      return Response.json(result.body, { status: 200 });
+    case 401:
+      return Response.json(result.body, { status: 401 });
+    case 409:
+      return Response.json(result.body, { status: 409 });
+    case 500:
+      return Response.json(result.body, { status: 500 });
+    default:
+      return absurd(result);
+  }
+}
+
+export function installationTokenRoute(
+  deps: InstallationTokenDeps,
+): (req: Request) => Promise<Response> {
+  return async (req: Request) => {
+    const result = await handleInstallationTokenRequest(req, deps);
+    const clientIp = req.headers.get("x-forwarded-for") ?? "local";
+    console.log(
+      JSON.stringify({
+        event: "installation_token.request",
+        status: result.status,
+        client_ip: clientIp,
+      }),
+    );
+    return toResponse(result);
+  };
+}

--- a/v2/http/verify-signature.ts
+++ b/v2/http/verify-signature.ts
@@ -1,0 +1,28 @@
+/**
+ * Verify a GitHub webhook HMAC-SHA256 signature.
+ * Returns true when the signature matches, false otherwise.
+ */
+export async function verifySignature(
+  payload: string,
+  signature: string | null,
+  secret: string
+): Promise<boolean> {
+  if (!signature) return false;
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
+  const expected = `sha256=${Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")}`;
+
+  // Constant-time comparison to prevent timing attacks
+  if (expected.length !== signature.length) return false;
+  return Buffer.from(expected).equals(Buffer.from(signature));
+}

--- a/v2/logger.ts
+++ b/v2/logger.ts
@@ -1,0 +1,87 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+const LOG_DIR = path.join(os.homedir(), ".zapbot", "logs");
+
+function ensureLogDir(): void {
+  if (!fs.existsSync(LOG_DIR)) {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+  }
+}
+
+function getLogFilePath(): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return path.join(LOG_DIR, `bridge-${date}.log`);
+}
+
+function formatKv(kv: Record<string, unknown>): string {
+  const parts = Object.entries(kv)
+    .filter(([, v]) => v !== undefined && v !== null)
+    .map(([k, v]) => `${k}=${v}`);
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
+}
+
+function getMinLevel(): LogLevel {
+  const env = process.env.ZAPBOT_LOG_LEVEL?.toLowerCase();
+  if (env && env in LEVEL_ORDER) return env as LogLevel;
+  return "info";
+}
+
+class Logger {
+  readonly component: string;
+
+  constructor(component: string) {
+    this.component = component;
+  }
+
+  private log(level: LogLevel, message: string, kv: Record<string, unknown> = {}): void {
+    if (LEVEL_ORDER[level] < LEVEL_ORDER[getMinLevel()]) return;
+
+    const timestamp = new Date().toISOString();
+    const line = `${timestamp} ${level.toUpperCase().padEnd(5)} [${this.component}] ${message}${formatKv(kv)}`;
+
+    // Write to stdout
+    const stream = level === "error" ? process.stderr : process.stdout;
+    stream.write(line + "\n");
+
+    // Append to log file (async, non-blocking)
+    try {
+      ensureLogDir();
+      fs.appendFile(getLogFilePath(), line + "\n", (err) => {
+        if (err) process.stderr.write(`[log write failed: ${err.message}]\n`);
+      });
+    } catch (err: any) {
+      process.stderr.write(`[log init failed: ${err.message}]\n`);
+    }
+  }
+
+  debug(message: string, kv?: Record<string, unknown>): void {
+    this.log("debug", message, kv);
+  }
+
+  info(message: string, kv?: Record<string, unknown>): void {
+    this.log("info", message, kv);
+  }
+
+  warn(message: string, kv?: Record<string, unknown>): void {
+    this.log("warn", message, kv);
+  }
+
+  error(message: string, kv?: Record<string, unknown>): void {
+    this.log("error", message, kv);
+  }
+}
+
+export function createLogger(component: string): Logger {
+  return new Logger(component);
+}

--- a/v2/mention-parser.ts
+++ b/v2/mention-parser.ts
@@ -1,0 +1,60 @@
+/**
+ * v2/mention-parser — parse `@zapbot <command>` from a comment body.
+ */
+
+import type { BotUsername, MentionCommand } from "./types.ts";
+
+/**
+ * Strip fenced code blocks, inline code, and blockquote lines so quoted
+ * mentions are not treated as commands.
+ */
+export function stripQuotedContent(body: string): string {
+  let stripped = body.replace(/```[\s\S]*?```/g, "");
+  stripped = stripped.replace(/`[^`]+`/g, "");
+  stripped = stripped
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith(">"))
+    .join("\n");
+  return stripped;
+}
+
+function buildMentionRegex(botUsername: string): RegExp {
+  const baseName = botUsername.replace(/\[bot\]$/, "");
+  const escaped = baseName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`@${escaped}(?:\\[bot\\])?`, "i");
+}
+
+function classify(raw: string): MentionCommand {
+  const lower = raw.toLowerCase().trim();
+  if (lower === "plan this" || lower === "triage this") {
+    return { kind: "plan_this" };
+  }
+  if (lower === "investigate this" || lower === "investigate") {
+    return { kind: "investigate_this" };
+  }
+  if (lower === "status") {
+    return { kind: "status" };
+  }
+  return { kind: "unknown_command", raw };
+}
+
+/**
+ * Returns the parsed command if the body contains an `@<botUsername>` mention
+ * on a line that is not inside a code fence or blockquote. Returns `null` if
+ * no bot mention is present at all.
+ */
+export function parseMention(
+  body: string,
+  botUsername: BotUsername
+): MentionCommand | null {
+  const cleaned = stripQuotedContent(body);
+  const mentionRe = buildMentionRegex(botUsername as unknown as string);
+  const match = cleaned.match(mentionRe);
+  if (!match || match.index === undefined) return null;
+  const afterMention = cleaned.slice(match.index + match[0].length);
+  const firstLine = afterMention.split("\n")[0].trim();
+  if (!firstLine) {
+    return { kind: "unknown_command", raw: "" };
+  }
+  return classify(firstLine);
+}

--- a/v2/moltzap/identity-allowlist.ts
+++ b/v2/moltzap/identity-allowlist.ts
@@ -1,0 +1,90 @@
+/**
+ * v2/moltzap/identity-allowlist — sender-identity gate (I1).
+ *
+ * Anchors: spec moltzap-channel-v1 §4 I1, §5.1 AC1.2, §5.2 AC2.2; sub-issue
+ * zap#133 architect decision (option b).
+ *
+ * The bridge's LISTENING gate (v2/moltzap/bridge.onInbound) closes I3
+ * (presence). It does NOT close I1 (sender-authenticated inbound). Spec I1
+ * names an ungated path as a prompt-injection vector; AC1.2 requires a
+ * sender-identity allowlist check. This module is that gate, separate from
+ * the lifecycle gate by design — two invariants, two gates.
+ *
+ * Composition: plugin boot calls `gateInbound` before `bridge.onInbound`.
+ * Non-allowlisted events return `SenderNotAllowed` and are dropped with a
+ * diagnostic at the caller. No turn in the Claude session, no transcript
+ * side effect (AC1.2).
+ */
+
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+import type {
+  MoltzapInbound,
+  MoltzapInboundMeta,
+  MoltzapSenderId,
+} from "./types.ts";
+
+// ── Allowlist handle ────────────────────────────────────────────────
+//
+// Opaque branded type. Constructed once at plugin boot from a configured set
+// of sender IDs (config source is impl-junior's choice — env, JSON, etc. —
+// per OQ1). Frozen for the lifetime of the plugin process; reload requires
+// restart (OQ3). The caller never mutates or inspects the underlying set;
+// only `fromSenderIds` constructs and `gateInbound` checks.
+
+export interface SenderAllowlist {
+  readonly __brand: "SenderAllowlist";
+}
+
+const ALLOWLIST = Symbol("SenderAllowlist.values");
+type SenderAllowlistInternal = SenderAllowlist & {
+  readonly [ALLOWLIST]: ReadonlySet<string>;
+};
+
+/** Construct a frozen allowlist from a configured set of sender IDs. */
+export function fromSenderIds(ids: readonly MoltzapSenderId[]): SenderAllowlist {
+  return Object.freeze({
+    __brand: "SenderAllowlist",
+    [ALLOWLIST]: new Set(ids),
+  }) as SenderAllowlist;
+}
+
+// ── Error channel ───────────────────────────────────────────────────
+
+export type AllowlistError = {
+  readonly _tag: "SenderNotAllowed";
+  readonly senderId: MoltzapSenderId;
+  readonly event: MoltzapInboundMeta;
+};
+
+// ── Gate ────────────────────────────────────────────────────────────
+
+/**
+ * Check an inbound event against the configured allowlist.
+ *
+ * Ok(event)            — sender is on the allowlist; caller forwards to
+ *                         `bridge.onInbound`.
+ * Err(SenderNotAllowed) — sender is NOT on the allowlist; caller drops
+ *                         (logs a diagnostic, does not forward to bridge).
+ *
+ * Pure; synchronous; O(1) set membership. No side effects.
+ */
+export function gateInbound(
+  allowlist: SenderAllowlist,
+  event: MoltzapInbound,
+): Result<MoltzapInbound, AllowlistError> {
+  const values = (allowlist as SenderAllowlistInternal)[ALLOWLIST];
+  if (values.has(event.senderId)) {
+    return ok(event);
+  }
+  return err({
+    _tag: "SenderNotAllowed",
+    senderId: event.senderId,
+    event: {
+      messageId: event.messageId,
+      conversationId: event.conversationId,
+      senderId: event.senderId,
+      receivedAtMs: event.receivedAtMs,
+    },
+  });
+}

--- a/v2/moltzap/runtime.ts
+++ b/v2/moltzap/runtime.ts
@@ -1,0 +1,268 @@
+/**
+ * v2/moltzap/runtime — zapbot-side MoltZap config + session provisioning.
+ *
+ * This module owns two boundaries only:
+ *   1. Decode zapbot env/config into a typed MoltZap runtime config.
+ *   2. Materialize the `MOLTZAP_*` env a spawned `ao` session should receive.
+ *
+ * Implementation lands in the implement-* phase. Architect stage exports the
+ * public shape only.
+ */
+
+import { err, ok } from "../types.ts";
+import type {
+  AoSessionName,
+  IssueNumber,
+  ProjectName,
+  RepoFullName,
+  Result,
+} from "../types.ts";
+import { fromSenderIds, type SenderAllowlist } from "./identity-allowlist.ts";
+import { asMoltzapSenderId } from "./types.ts";
+
+export interface MoltzapSpawnContext {
+  readonly repo: RepoFullName;
+  readonly issue: IssueNumber;
+  readonly projectName: ProjectName;
+  readonly session: AoSessionName;
+}
+
+export type MoltzapRuntimeConfig =
+  | { readonly _tag: "MoltzapDisabled" }
+  | {
+      readonly _tag: "MoltzapStatic";
+      readonly serverUrl: string;
+      readonly apiKey: string;
+      readonly allowlistCsv: string | null;
+      readonly allowlist: SenderAllowlist;
+    }
+  | {
+      readonly _tag: "MoltzapRegistration";
+      readonly serverUrl: string;
+      readonly registrationSecret: string;
+      readonly allowlistCsv: string | null;
+      readonly allowlist: SenderAllowlist;
+    };
+
+export type MoltzapConfigError = {
+  readonly _tag: "MoltzapConfigInvalid";
+  readonly reason: string;
+};
+
+export type MoltzapProvisionError = {
+  readonly _tag: "MoltzapProvisionFailed";
+  readonly cause: string;
+};
+
+export function loadMoltzapRuntimeConfig(
+  env: Record<string, string | undefined>,
+): Result<MoltzapRuntimeConfig, MoltzapConfigError> {
+  const serverUrl = normalizeEnvVar(env.ZAPBOT_MOLTZAP_SERVER_URL);
+  const apiKey = normalizeEnvVar(env.ZAPBOT_MOLTZAP_API_KEY);
+  const registrationSecret = normalizeEnvVar(env.ZAPBOT_MOLTZAP_REGISTRATION_SECRET);
+  const allowlistCsv = normalizeCsv(env.ZAPBOT_MOLTZAP_ALLOWED_SENDERS);
+  const allowlist = fromSenderIds(parseAllowlist(allowlistCsv));
+
+  if (serverUrl === null) {
+    if (apiKey !== null || registrationSecret !== null) {
+      return err({
+        _tag: "MoltzapConfigInvalid",
+        reason: "ZAPBOT_MOLTZAP_SERVER_URL is required when MoltZap auth is configured.",
+      });
+    }
+    return ok({ _tag: "MoltzapDisabled" });
+  }
+
+  if (registrationSecret !== null) {
+    return ok({
+      _tag: "MoltzapRegistration",
+      serverUrl,
+      registrationSecret,
+      allowlistCsv,
+      allowlist,
+    });
+  }
+
+  if (apiKey !== null) {
+    return ok({
+      _tag: "MoltzapStatic",
+      serverUrl,
+      apiKey,
+      allowlistCsv,
+      allowlist,
+    });
+  }
+
+  return err({
+    _tag: "MoltzapConfigInvalid",
+    reason:
+      "Set either ZAPBOT_MOLTZAP_API_KEY or ZAPBOT_MOLTZAP_REGISTRATION_SECRET when ZAPBOT_MOLTZAP_SERVER_URL is configured.",
+  });
+}
+
+export async function buildMoltzapSpawnEnv(
+  config: MoltzapRuntimeConfig,
+  ctx: MoltzapSpawnContext,
+): Promise<Result<Record<string, string>, MoltzapProvisionError>> {
+  switch (config._tag) {
+    case "MoltzapDisabled":
+      return ok({});
+    case "MoltzapStatic":
+      return ok(toSpawnEnv(config.serverUrl, config.apiKey, config.allowlistCsv));
+    case "MoltzapRegistration":
+      return registerSessionAgent(config, ctx);
+    default:
+      return absurd(config);
+  }
+}
+
+interface RegistrationResponse {
+  readonly apiKey: string;
+}
+
+async function registerSessionAgent(
+  config: Extract<MoltzapRuntimeConfig, { readonly _tag: "MoltzapRegistration" }>,
+  ctx: MoltzapSpawnContext,
+): Promise<Result<Record<string, string>, MoltzapProvisionError>> {
+  const agentName = buildAgentName(ctx);
+  let response: Response;
+  try {
+    response = await fetch(`${toHttpBaseUrl(config.serverUrl)}/api/v1/auth/register`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: agentName,
+        description: `zapbot ao session ${ctx.session as unknown as string}`,
+        inviteCode: config.registrationSecret,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (cause) {
+    return err({
+      _tag: "MoltzapProvisionFailed",
+      cause: `registration request failed: ${stringifyCause(cause)}`,
+    });
+  }
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    return err({
+      _tag: "MoltzapProvisionFailed",
+      cause: `registration failed (${response.status}): ${body || "empty response"}`,
+    });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    return err({
+      _tag: "MoltzapProvisionFailed",
+      cause: `registration returned invalid JSON: ${stringifyCause(cause)}`,
+    });
+  }
+
+  const apiKey = decodeRegistrationResponse(payload);
+  if (apiKey === null) {
+    return err({
+      _tag: "MoltzapProvisionFailed",
+      cause: "registration response missing string apiKey.",
+    });
+  }
+
+  return ok(toSpawnEnv(config.serverUrl, apiKey, config.allowlistCsv));
+}
+
+function decodeRegistrationResponse(payload: unknown): string | null {
+  if (payload === null || typeof payload !== "object") {
+    return null;
+  }
+  const candidate = (payload as RegistrationResponse).apiKey;
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
+}
+
+function toSpawnEnv(
+  serverUrl: string,
+  apiKey: string,
+  allowlistCsv: string | null,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    MOLTZAP_SERVER_URL: serverUrl,
+    MOLTZAP_API_KEY: apiKey,
+  };
+  if (allowlistCsv !== null) {
+    env.MOLTZAP_ALLOWED_SENDERS = allowlistCsv;
+  }
+  return env;
+}
+
+function parseAllowlist(allowlistCsv: string | null) {
+  if (allowlistCsv === null) return [];
+  return allowlistCsv
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    .map((value) => asMoltzapSenderId(value));
+}
+
+function normalizeEnvVar(raw: string | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeCsv(raw: string | undefined): string | null {
+  const trimmed = normalizeEnvVar(raw);
+  if (trimmed === null) return null;
+  const parts = trimmed
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return parts.length > 0 ? parts.join(",") : null;
+}
+
+function toHttpBaseUrl(serverUrl: string): string {
+  const url = new URL(serverUrl);
+  if (url.protocol === "wss:") url.protocol = "https:";
+  if (url.protocol === "ws:") url.protocol = "http:";
+  url.search = "";
+  url.hash = "";
+
+  // MoltZap sessions connect over `/ws`, but registration is exposed from the
+  // HTTP API root. Keep the websocket URL for spawned sessions and strip only
+  // the transport endpoint when calling the auth API.
+  url.pathname = url.pathname.replace(/\/ws\/?$/, "/");
+
+  return url.toString().replace(/\/+$/, "");
+}
+
+function buildAgentName(ctx: MoltzapSpawnContext): string {
+  const raw = `zb-${ctx.projectName as unknown as string}-${ctx.issue}-${shortSuffix()}`.toLowerCase();
+  const sanitized = raw
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/[-_]{2,}/g, "-")
+    .replace(/^[^a-z0-9]+/, "")
+    .replace(/[^a-z0-9]+$/, "");
+  const maxLength = 32;
+  const trimmed = sanitized.slice(0, maxLength).replace(/[^a-z0-9]+$/, "");
+  if (trimmed.length >= 3 && /^[a-z0-9]/.test(trimmed) && /[a-z0-9]$/.test(trimmed)) {
+    return trimmed;
+  }
+  return `zb-${shortSuffix()}`;
+}
+
+function shortSuffix(): string {
+  return `${Date.now().toString(36)}${Math.floor(Math.random() * 1_679_616).toString(36)}`.slice(
+    -6,
+  );
+}
+
+function stringifyCause(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}

--- a/v2/moltzap/types.ts
+++ b/v2/moltzap/types.ts
@@ -1,0 +1,67 @@
+/**
+ * v2/moltzap/types — shared types for the moltzap Channels bridge.
+ *
+ * Anchors: sbd#108 architect plan §3 Interfaces; spec moltzap-channel-v1 §4 (I6, I7).
+ *
+ * Conventions mirror v2/types.ts: branded IDs, discriminated unions, tagged
+ * errors, `absurd` helper for exhaustiveness. Plain Promise + Result is used
+ * throughout per the architect plan's note: "If the repo's existing convention
+ * is plain Promise + tagged union, impl may substitute."
+ */
+
+// ── Branded identifiers ─────────────────────────────────────────────
+
+export type MoltzapMessageId = string & { readonly __brand: "MoltzapMessageId" };
+export type MoltzapConversationId = string & { readonly __brand: "MoltzapConversationId" };
+export type MoltzapSenderId = string & { readonly __brand: "MoltzapSenderId" };
+export type ListenerHandle = { readonly __brand: "ListenerHandle" };
+
+export function asMoltzapMessageId(s: string): MoltzapMessageId {
+  return s as MoltzapMessageId;
+}
+export function asMoltzapConversationId(s: string): MoltzapConversationId {
+  return s as MoltzapConversationId;
+}
+export function asMoltzapSenderId(s: string): MoltzapSenderId {
+  return s as MoltzapSenderId;
+}
+
+// ── Inbound event shape ─────────────────────────────────────────────
+
+export interface MoltzapInbound {
+  readonly messageId: MoltzapMessageId;
+  readonly conversationId: MoltzapConversationId;
+  readonly senderId: MoltzapSenderId;
+  readonly bodyText: string;
+  readonly receivedAtMs: number;
+}
+
+export type MoltzapInboundMeta = Pick<
+  MoltzapInbound,
+  "messageId" | "conversationId" | "senderId" | "receivedAtMs"
+>;
+
+// ── Opaque SDK / MCP handles ────────────────────────────────────────
+//
+// Per architect plan §3: "Opaque to this plugin. Impl picks the exact SDK
+// type at impl time." The concrete shape is injected at the plugin boot
+// boundary; the bridge modules never import `@moltzap/app-sdk` or
+// `@modelcontextprotocol/sdk` directly.
+
+export interface MoltzapSdkHandle {
+  readonly __brand: "MoltzapSdkHandle";
+}
+
+export interface McpContext {
+  readonly __brand: "McpContext";
+}
+
+export interface MoltzapSdkContext {
+  readonly __brand: "MoltzapSdkContext";
+}
+
+// ── Exhaustiveness helper (mirrors v2/types.ts) ─────────────────────
+
+export function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}

--- a/v2/types.ts
+++ b/v2/types.ts
@@ -1,0 +1,116 @@
+/**
+ * v2 shared types — branded IDs, discriminated command shapes, typed error tags.
+ */
+
+// ── Branded identifiers ─────────────────────────────────────────────
+
+export type RepoFullName = string & { readonly __brand: "RepoFullName" };
+export type IssueNumber = number & { readonly __brand: "IssueNumber" };
+export type CommentId = number & { readonly __brand: "CommentId" };
+export type DeliveryId = string & { readonly __brand: "DeliveryId" };
+export type ProjectName = string & { readonly __brand: "ProjectName" };
+export type InstallationToken = string & { readonly __brand: "InstallationToken" };
+export type AoSessionName = string & { readonly __brand: "AoSessionName" };
+export type BotUsername = string & { readonly __brand: "BotUsername" };
+
+// ── Result type (discriminated; errors are typed, not thrown) ───────
+
+export type Ok<T> = { readonly _tag: "Ok"; readonly value: T };
+export type Err<E> = { readonly _tag: "Err"; readonly error: E };
+export type Result<T, E> = Ok<T> | Err<E>;
+
+export function ok<T>(value: T): Ok<T> {
+  return { _tag: "Ok", value };
+}
+export function err<E>(error: E): Err<E> {
+  return { _tag: "Err", error };
+}
+
+// ── Mention command (discriminated union) ───────────────────────────
+
+export type MentionCommand =
+  | { readonly kind: "plan_this" }
+  | { readonly kind: "investigate_this" }
+  | { readonly kind: "status" }
+  | { readonly kind: "unknown_command"; readonly raw: string };
+
+/**
+ * Typed outcome for `handleClassifiedWebhook` — one tag per observable branch.
+ * `replied` covers status and unknown_command (bridge posted a comment, no
+ * dispatch). `ignored` is reserved for classify passthrough.
+ */
+export type HandleOutcome =
+  | { readonly kind: "ignored"; readonly reason: string }
+  | {
+      readonly kind: "dispatched";
+      readonly repo: RepoFullName;
+      readonly session: AoSessionName;
+    }
+  | { readonly kind: "unauthorized"; readonly actor: string; readonly reason: string }
+  | { readonly kind: "replied"; readonly command: MentionCommand["kind"] };
+
+// ── Errors surfaced across module boundaries ────────────────────────
+
+export type GatewayError =
+  | { readonly _tag: "GatewayUnreachable"; readonly cause: string }
+  | { readonly _tag: "GatewayRejected"; readonly status: number; readonly body: string }
+  | { readonly _tag: "GatewayAuthMissing" };
+
+export type WebhookIntakeError =
+  | { readonly _tag: "SignatureMismatch" }
+  | { readonly _tag: "PayloadShapeInvalid"; readonly reason: string }
+  | { readonly _tag: "SecretMissing"; readonly repo: RepoFullName };
+
+export type DispatchError =
+  | { readonly _tag: "TokenMintFailed"; readonly cause: string }
+  | { readonly _tag: "AoSpawnFailed"; readonly exitCode: number; readonly stderr: string }
+  | { readonly _tag: "MoltzapProvisionFailed"; readonly cause: string }
+  | { readonly _tag: "ProjectNotConfigured"; readonly repo: RepoFullName };
+
+export type GithubStateError =
+  | { readonly _tag: "GitHubAuthMissing" }
+  | { readonly _tag: "GitHubApiFailed"; readonly status: number; readonly message: string }
+  | { readonly _tag: "IssueNotFound"; readonly repo: RepoFullName; readonly issue: IssueNumber };
+
+/**
+ * Typed error channel for gh.* calls the bridge makes
+ * in handleMention. These are local wrappers — not a public v2 module.
+ */
+export type GhCallError = {
+  readonly _tag: "GhCallFailed";
+  readonly label: string;
+  readonly cause: string;
+};
+
+// ── Exhaustiveness helper ───────────────────────────────────────────
+
+export function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
+}
+
+// ── Constructors (centralized branding at boundaries) ───────────────
+
+export function asRepoFullName(s: string): RepoFullName {
+  return s as RepoFullName;
+}
+export function asIssueNumber(n: number): IssueNumber {
+  return n as IssueNumber;
+}
+export function asCommentId(n: number): CommentId {
+  return n as CommentId;
+}
+export function asDeliveryId(s: string): DeliveryId {
+  return s as DeliveryId;
+}
+export function asProjectName(s: string): ProjectName {
+  return s as ProjectName;
+}
+export function asInstallationToken(s: string): InstallationToken {
+  return s as InstallationToken;
+}
+export function asAoSessionName(s: string): AoSessionName {
+  return s as AoSessionName;
+}
+export function asBotUsername(s: string): BotUsername {
+  return s as BotUsername;
+}


### PR DESCRIPTION
Closes #225
Architect plan: https://github.com/chughtapan/zapbot/issues/224#issuecomment-4282773864

## What changed
Implemented the approved bounded runtime migration lane on the live  runtime surface and branch-only contract stubs. The runtime now uses the contract-aligned token broker, GitHub client, signature verification, and MoltZap provisioning helpers from the  lane.

## Plan anchors
| Change | Plan anchor |
|---|---|
| Implement live bridge/runtime surface in  | Modules 1 and Data flow 1, 2, 4 |
| Implement gateway intake/classification in  | Modules 2 and Data flow 3 |
| Implement AO dispatch/env shaping in  and  | Modules 3 and Data flow 5 |
| Implement installation-token broker in  | Modules 4 and Data flow 6 |
| Mirror the live runtime surface in branch-only contract stubs | Branch-only contract stubs |
| Add/support shared lane modules in , , , , and  | Modules 5-9 |

## Scope
- Modules touched: , , , , , , , , , , , , 
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests
- 
> zapbot@0.3.0 test /home/tapanc/zapbot
> vitest run -- --runInBand


 RUN  v3.2.4 /home/tapanc/zapbot

2026-04-20T20:40:32.656Z INFO  [config] No config file; using ZAPBOT_REPO env var for single-repo mode (repo=owner/repo)
2026-04-20T20:40:32.659Z INFO  [config-reload] Config reloaded (1 repos, secret rotated: true)
2026-04-20T20:40:32.661Z INFO  [config] No config file; using ZAPBOT_REPO env var for single-repo mode (repo=owner/repo)
2026-04-20T20:40:32.662Z INFO  [config-reload] Config reloaded (1 repos, secret rotated: false)
2026-04-20T20:40:32.663Z INFO  [config] No config file; using ZAPBOT_REPO env var for single-repo mode (repo=owner/repo)
2026-04-20T20:40:32.663Z INFO  [config] Loaded config from /tmp/zapbot-test-z9pPxg/agent-orchestrator.yaml (repos=1)
2026-04-20T20:40:32.674Z INFO  [config] Loaded config from /tmp/zapbot-test-o5uAeu/agent-orchestrator.yaml (repos=2)
2026-04-20T20:40:32.675Z INFO  [config] No config file; using ZAPBOT_REPO env var for single-repo mode (repo=owner/my-repo)
2026-04-20T20:40:32.677Z WARN  [config] No config file and no ZAPBOT_REPO — bridge will accept webhooks from any repo
 ✓ test/v2-github-state.test.ts (7 tests) 46ms
 ✓ test/v2-ao-dispatcher.test.ts (1 test) 28ms
2026-04-20T20:40:32.683Z INFO  [config] No config file; using ZAPBOT_REPO env var for single-repo mode (repo=owner/repo)
2026-04-20T20:40:32.683Z INFO  [config-reload] Config reloaded (1 repos, secret rotated: true)
2026-04-20T20:40:32.684Z INFO  [config] No config file; using ZAPBOT_REPO env var for single-repo mode (repo=org/my-app)
2026-04-20T20:40:32.684Z INFO  [config-reload] Config reloaded (1 repos, secret rotated: false)
 ✓ test/config-loader.test.ts (10 tests) 46ms
 ✓ test/config-reload.test.ts (18 tests) 45ms
 ✓ test/property/broker-routing.property.test.ts (4 tests) 210ms
 ✓ test/verify-signature.property.test.ts (4 tests) 254ms
2026-04-20T20:40:32.846Z INFO  [v2/bridge] installation_token.request status=401 client_ip=local
2026-04-20T20:40:32.849Z INFO  [v2/bridge] installation_token.request status=401 client_ip=local
2026-04-20T20:40:32.850Z INFO  [v2/bridge] installation_token.request status=409 client_ip=local
2026-04-20T20:40:32.851Z INFO  [v2/bridge] installation_token.request status=409 client_ip=local
 ✓ test/v2-bridge.http.test.ts (14 tests) 59ms
 ✓ test/v2-moltzap-runtime.test.ts (8 tests) 43ms
 ✓ test/v2-gateway.test.ts (9 tests) 26ms
2026-04-20T20:40:33.356Z INFO  [github] Using personal access token for GitHub API calls
2026-04-20T20:40:33.363Z INFO  [github] Using GitHub App for API calls (appId=12345, installationId=67890)
2026-04-20T20:40:33.367Z INFO  [github] Using personal access token for GitHub API calls
2026-04-20T20:40:33.370Z INFO  [github] Using GitHub App for API calls (appId=12345, installationId=67890)
 ✓ test/v2-moltzap-listener.test.ts (16 tests) 20ms
 ✓ test/github-client.test.ts (13 tests) 28ms
 ✓ test/verify-signature.test.ts (5 tests) 27ms
 ✓ test/v2-moltzap-supervisor.test.ts (15 tests) 24ms
 ✓ test/v2-bridge.test.ts (9 tests) 20ms
 ✓ test/error-response.test.ts (6 tests) 19ms
 ✓ test/v2-moltzap-bridge.test.ts (10 tests) 27ms
 ✓ test/v2-moltzap-lifecycle.test.ts (15 tests) 16ms
 ✓ test/installation-token.test.ts (13 tests) 24ms
 ✓ test/v2-moltzap-identity-allowlist.test.ts (3 tests) 9ms
 ✓ test/v2-mention-parser.test.ts (14 tests) 17ms
 ✓ test/systemd-service.test.ts (8 tests) 16ms

 Test Files  21 passed (21)
      Tests  202 passed (202)
   Start at  20:40:31
   Duration  2.43s (transform 1.23s, setup 0ms, collect 3.21s, tests 1.01s, environment 9ms, prepare 3.55s)
- 
> zapbot@0.3.0 lint /home/tapanc/zapbot
> eslint 'v2/**/*.ts' 'gateway/src/**/*.ts' 'bin/**/*.ts'


/home/tapanc/zapbot/bin/webhook-bridge.ts
   89:1   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  103:6   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  120:3   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  120:30  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type

/home/tapanc/zapbot/gateway/src/auth.ts
   72:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
   74:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  135:5  warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch
  189:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  192:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type

/home/tapanc/zapbot/gateway/src/handler.ts
   58:10  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
   58:46  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
   86:1   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
   89:4   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  100:1   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  100:71  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  106:5   warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch
  140:5   warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch
  146:1   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  146:76  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  153:5   warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch
  177:1   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  177:78  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  184:5   warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch

/home/tapanc/zapbot/gateway/src/index.ts
  69:31  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  75:25  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  83:11  warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch

/home/tapanc/zapbot/v2/ao/dispatcher.contract.ts
  23:4  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  24:3  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error

/home/tapanc/zapbot/v2/ao/dispatcher.ts
   86:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
   88:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  114:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type

/home/tapanc/zapbot/v2/bridge.contract.ts
  37:24  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  38:50  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  42:29  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  48:89  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  49:69  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  50:83  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  62:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  68:22  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  69:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  72:37  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  73:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  79:4   warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  80:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  83:52  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  84:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error

/home/tapanc/zapbot/v2/bridge.ts
   56:1    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
   58:13   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
   59:4    warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
   95:24   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
   96:50   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  100:29   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  106:86   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  107:69   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  108:83   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  119:8    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  122:4    warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  132:1    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  135:4    warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  202:1    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  202:72   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  230:3    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  230:92   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  230:105  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  248:27   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  263:22   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  264:10   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  264:32   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  294:9    warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch
  369:8    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  369:43   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  384:8    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  384:58   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  388:3    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  388:50   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  404:3    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  404:52   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  431:5    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  431:19   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  436:5    warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  436:45   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type

/home/tapanc/zapbot/v2/config/loader.ts
   64:7  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  118:7  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error

/home/tapanc/zapbot/v2/gateway.contract.ts
  43:4  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  44:3  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  51:4  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  52:3  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  61:3  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  68:4  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  69:3  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error

/home/tapanc/zapbot/v2/gateway.ts
   42:1   warning  async keyword — prefer Effect.gen / Effect handlers      agent-code-guard/async-keyword
   46:4   warning  Promise<> return type — prefer Effect                    agent-code-guard/promise-type
   78:4   warning  Promise<> return type — prefer Effect                    agent-code-guard/promise-type
   86:4   warning  Promise<> return type — prefer Effect                    agent-code-guard/promise-type
  161:13  warning  Unsafe Record<string, unknown> cast — use typed results  agent-code-guard/record-cast
  174:13  warning  Unsafe Record<string, unknown> cast — use typed results  agent-code-guard/record-cast
  183:13  warning  Unsafe Record<string, unknown> cast — use typed results  agent-code-guard/record-cast
  192:13  warning  Unsafe Record<string, unknown> cast — use typed results  agent-code-guard/record-cast
  216:8   warning  async keyword — prefer Effect.gen / Effect handlers      agent-code-guard/async-keyword
  220:4   warning  Promise<> return type — prefer Effect                    agent-code-guard/promise-type

/home/tapanc/zapbot/v2/github-state.ts
   71:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
   74:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
   98:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  102:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  111:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  114:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  143:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  147:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  197:5  warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch

/home/tapanc/zapbot/v2/github/client.ts
    9:63  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   10:66  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   11:65  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   12:65  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   13:50  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   14:77  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   15:83  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   16:53  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   17:67  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   18:74  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   19:72  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   20:48  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   21:53  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   22:52  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   23:54  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   24:31  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   25:55  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   26:80  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   27:52  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
   50:19  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
   57:5   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
   63:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
   69:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
   80:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
   87:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
   93:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
   99:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  106:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  112:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  121:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  127:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  133:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  139:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  145:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  149:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  153:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  160:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  166:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  177:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  191:5   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  219:8   warning  async keyword — prefer Effect.gen / Effect handlers                                                                                                             agent-code-guard/async-keyword
  219:47  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  241:7   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  262:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error

/home/tapanc/zapbot/v2/http/routes/installation-token.contract.ts
  27:29  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  35:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  41:4   warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  42:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  47:22  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  48:3   warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error

/home/tapanc/zapbot/v2/http/routes/installation-token.ts
   65:29  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  106:8   warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  109:4   warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  118:5   warning  Silently swallowed error — always bind and log it    agent-code-guard/bare-catch
  161:22  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  162:10  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword

/home/tapanc/zapbot/v2/http/verify-signature.ts
  5:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  9:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type

/home/tapanc/zapbot/v2/moltzap/bridge.ts
   57:6  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
   62:6  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
   83:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
   89:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  133:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  139:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type

/home/tapanc/zapbot/v2/moltzap/listener.ts
   56:6   warning  Promise<> return type — prefer Effect                    agent-code-guard/promise-type
   71:8   warning  async keyword — prefer Effect.gen / Effect handlers      agent-code-guard/async-keyword
   77:4   warning  Promise<> return type — prefer Effect                    agent-code-guard/promise-type
  106:13  warning  Unsafe Record<string, unknown> cast — use typed results  agent-code-guard/record-cast

/home/tapanc/zapbot/v2/moltzap/runtime.contract.ts
  47:3  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error
  53:4  warning  Promise<> return type — prefer Effect                                                                                                                           agent-code-guard/promise-type
  54:3  warning  Return a tagged error or Effect.fail; raw `throw new Error` erases the error channel and forces callers to catch-all. See docs/rules/no-raw-throw-new-error.md  agent-code-guard/no-raw-throw-new-error

/home/tapanc/zapbot/v2/moltzap/runtime.ts
  103:8  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  106:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type
  123:1  warning  async keyword — prefer Effect.gen / Effect handlers  agent-code-guard/async-keyword
  126:4  warning  Promise<> return type — prefer Effect                agent-code-guard/promise-type

✖ 184 problems (0 errors, 184 warnings) (warnings only; no errors)

## Confidence
HIGH — full test suite passed after the lane alignment; lint reports only pre-existing Effect-style warnings and no errors.