### PR TITLE
[impl-senior] add gateway PAT proxy routes

### DIFF
--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -56,6 +56,40 @@ function patAuthError(
   return { ok: false, error: { type, message, fix } };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function decodeGitHubUserLogin(body: unknown): { ok: true; login: string } | PatAuthOutcome {
+  if (!isRecord(body) || typeof body.login !== "string" || body.login.length === 0) {
+    return patAuthError(
+      "github_api_error",
+      "GitHub API returned a user response without a login.",
+      "Check GitHub API status and try again.",
+    );
+  }
+
+  return { ok: true, login: body.login };
+}
+
+function decodeGitHubPermission(
+  body: unknown,
+): { ok: true; permission: string } | PatAuthOutcome {
+  if (
+    !isRecord(body) ||
+    typeof body.permission !== "string" ||
+    body.permission.length === 0
+  ) {
+    return patAuthError(
+      "github_api_error",
+      "GitHub API returned a permission response without a permission value.",
+      "Check GitHub API status and try again.",
+    );
+  }
+
+  return { ok: true, permission: body.permission };
+}
+
 function extractBearerToken(authHeader: string | null): { ok: true; token: string } | AuthOutcome {
   if (!authHeader) {
     return authError(
@@ -242,13 +276,9 @@ export async function verifyGitHubPAT(
       );
     }
 
-    const userBody = (await userResp.json()) as { login?: string };
-    if (!userBody.login) {
-      return patAuthError(
-        "github_api_error",
-        "GitHub API returned a user response without a login.",
-        "Check GitHub API status and try again.",
-      );
+    const userBody = decodeGitHubUserLogin(await userResp.json());
+    if (!userBody.ok) {
+      return userBody;
     }
 
     const permissionResp = await globalThis.fetch(
@@ -283,13 +313,9 @@ export async function verifyGitHubPAT(
       );
     }
 
-    const permissionBody = (await permissionResp.json()) as { permission?: string };
-    if (!permissionBody.permission) {
-      return patAuthError(
-        "github_api_error",
-        "GitHub API returned a permission response without a permission value.",
-        "Check GitHub API status and try again.",
-      );
+    const permissionBody = decodeGitHubPermission(await permissionResp.json());
+    if (!permissionBody.ok) {
+      return permissionBody;
     }
 
     if (!WRITE_PERMISSIONS.has(permissionBody.permission)) {

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -30,12 +30,51 @@ export type AuthOutcome =
   | { ok: true; result: AuthResult }
   | { ok: false; error: AuthError };
 
+export interface PatAuthResult {
+  user: string;
+  permission: string;
+  repo: string;
+}
+
+export type PatAuthOutcome =
+  | { ok: true; result: PatAuthResult }
+  | { ok: false; error: AuthError };
+
 // ── Helpers ────────────────────────────────────────────────────────
 
 const encoder = new TextEncoder();
 
 function authError(type: string, message: string, fix: string): AuthOutcome {
   return { ok: false, error: { type, message, fix } };
+}
+
+function patAuthError(
+  type: string,
+  message: string,
+  fix: string,
+): PatAuthOutcome {
+  return { ok: false, error: { type, message, fix } };
+}
+
+function extractBearerToken(authHeader: string | null): { ok: true; token: string } | AuthOutcome {
+  if (!authHeader) {
+    return authError(
+      "missing_token",
+      "No Authorization header provided.",
+      "Include `Authorization: Bearer <token>` header.",
+    );
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer" || !parts[1]) {
+    return authError(
+      "invalid_token_format",
+      "Authorization header must be `Bearer <token>`.",
+      "Check header format.",
+    );
+  }
+
+  return { ok: true, token: parts[1] };
 }
 
 // ── GitHub token cache ─────────────────────────────────────────────
@@ -48,9 +87,18 @@ interface CacheEntry {
 const TOKEN_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const tokenCache = new Map<string, CacheEntry>();
 
+interface PatCacheEntry {
+  result: PatAuthResult;
+  expiresAt: number;
+}
+
+const patCache = new Map<string, PatCacheEntry>();
+const WRITE_PERMISSIONS = new Set(["write", "admin", "maintain"]);
+
 /** Clear the token cache — exposed for tests. */
 export function clearTokenCache(): void {
   tokenCache.clear();
+  patCache.clear();
 }
 
 /** Get current cache size — exposed for tests. */
@@ -141,6 +189,138 @@ export async function verifyGitHubToken(
   }
 }
 
+/**
+ * Verify a teammate GitHub PAT against repo collaborator permissions.
+ *
+ * Flow:
+ * 1. GET /user to identify the PAT holder
+ * 2. GET /repos/{owner}/{repo}/collaborators/{user}/permission
+ * 3. Require write/admin/maintain
+ *
+ * Successful user+permission pairs are cached per token+repo for 5 minutes.
+ */
+export async function verifyGitHubPAT(
+  token: string,
+  repo: string,
+): Promise<PatAuthOutcome> {
+  const cacheKey = `${token}:${repo}`;
+  const cached = patCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return { ok: true, result: cached.result };
+  }
+
+  if (cached) {
+    patCache.delete(cacheKey);
+  }
+
+  try {
+    const headers = {
+      authorization: `Bearer ${token}`,
+      accept: "application/vnd.github+json",
+      "x-github-api-version": "2022-11-28",
+      "user-agent": "zapbot-gateway",
+    };
+
+    const userResp = await globalThis.fetch("https://api.github.com/user", {
+      headers,
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (userResp.status === 401) {
+      return patAuthError(
+        "invalid_token",
+        "GitHub PAT is invalid or expired.",
+        "Ensure you are sending a valid GitHub personal access token.",
+      );
+    }
+
+    if (!userResp.ok) {
+      return patAuthError(
+        "github_api_error",
+        `GitHub API returned ${userResp.status} while identifying the user.`,
+        "Check GitHub API status and try again.",
+      );
+    }
+
+    const userBody = (await userResp.json()) as { login?: string };
+    if (!userBody.login) {
+      return patAuthError(
+        "github_api_error",
+        "GitHub API returned a user response without a login.",
+        "Check GitHub API status and try again.",
+      );
+    }
+
+    const permissionResp = await globalThis.fetch(
+      `https://api.github.com/repos/${repo}/collaborators/${userBody.login}/permission`,
+      {
+        headers,
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+
+    if (permissionResp.status === 401) {
+      return patAuthError(
+        "invalid_token",
+        "GitHub PAT is invalid or expired.",
+        "Ensure you are sending a valid GitHub personal access token.",
+      );
+    }
+
+    if (permissionResp.status === 404) {
+      return patAuthError(
+        "repo_not_authorized",
+        `Not authorized for repo ${repo}.`,
+        "Ensure your GitHub user has write access to this repository.",
+      );
+    }
+
+    if (!permissionResp.ok) {
+      return patAuthError(
+        "github_api_error",
+        `GitHub API returned ${permissionResp.status} while checking repo permissions.`,
+        "Check GitHub API status and try again.",
+      );
+    }
+
+    const permissionBody = (await permissionResp.json()) as { permission?: string };
+    if (!permissionBody.permission) {
+      return patAuthError(
+        "github_api_error",
+        "GitHub API returned a permission response without a permission value.",
+        "Check GitHub API status and try again.",
+      );
+    }
+
+    if (!WRITE_PERMISSIONS.has(permissionBody.permission)) {
+      return patAuthError(
+        "repo_not_authorized",
+        `Not authorized for repo ${repo}.`,
+        "Ensure your GitHub user has write access to this repository.",
+      );
+    }
+
+    const result: PatAuthResult = {
+      user: userBody.login,
+      permission: permissionBody.permission,
+      repo,
+    };
+
+    patCache.set(cacheKey, {
+      result,
+      expiresAt: Date.now() + TOKEN_CACHE_TTL_MS,
+    });
+
+    return { ok: true, result };
+  } catch {
+    return patAuthError(
+      "github_api_error",
+      "Failed to reach GitHub API for PAT verification.",
+      "Check network connectivity and try again.",
+    );
+  }
+}
+
 // ── Shared-secret verification ─────────────────────────────────────
 
 /**
@@ -190,25 +370,12 @@ export async function verifyRequest(
   req: Request,
   config: AuthConfig,
 ): Promise<AuthOutcome> {
-  const authHeader = req.headers.get("authorization");
-  if (!authHeader) {
-    return authError(
-      "missing_token",
-      "No Authorization header provided.",
-      "Include `Authorization: Bearer <token>` header.",
-    );
+  const tokenResult = extractBearerToken(req.headers.get("authorization"));
+  if (!tokenResult.ok) {
+    return tokenResult;
   }
 
-  const parts = authHeader.split(" ");
-  if (parts.length !== 2 || parts[0] !== "Bearer" || !parts[1]) {
-    return authError(
-      "invalid_token_format",
-      "Authorization header must be `Bearer <token>`.",
-      "Check header format.",
-    );
-  }
-
-  const token = parts[1];
+  const { token } = tokenResult;
 
   // Try shared-secret first (fast, no network call)
   if (config.gatewaySecret) {

--- a/gateway/src/handler.ts
+++ b/gateway/src/handler.ts
@@ -13,10 +13,12 @@ import {
 } from "./registry.js";
 import {
   verifyRequest,
+  verifyGitHubPAT,
   requireRepoAccess,
   type AuthConfig,
   type AuthResult,
   type AuthError,
+  type PatAuthResult,
 } from "./auth.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -77,6 +79,14 @@ export function createFetchHandler(config: GatewayConfig) {
       return handleBridgeDeregister(req, authConfig);
     }
 
+    if (pathname === "/api/publish" && req.method === "POST") {
+      return handlePublish(req, forwardTimeoutMs);
+    }
+
+    if (pathname.match(/^\/api\/workflows\/[^/]+(?:\/history)?$/) && req.method === "GET") {
+      return handleWorkflowProxy(req, url, forwardTimeoutMs);
+    }
+
     return errorResponse(404, "not_found", "Resource not found.");
   };
 }
@@ -88,6 +98,36 @@ async function authenticateRequest(
   authConfig: AuthConfig,
 ): Promise<AuthResult | Response> {
   const outcome = await verifyRequest(req, authConfig);
+  if (!outcome.ok) {
+    return authErrorResponse(outcome.error);
+  }
+
+  return outcome.result;
+}
+
+async function authenticateTeammateRequest(
+  req: Request,
+  repo: string,
+): Promise<PatAuthResult | Response> {
+  const authHeader = req.headers.get("authorization");
+  if (!authHeader) {
+    return authErrorResponse({
+      type: "missing_token",
+      message: "No Authorization header provided.",
+      fix: "Include `Authorization: Bearer <github-pat>` header.",
+    });
+  }
+
+  const parts = authHeader.split(" ");
+  if (parts.length !== 2 || parts[0] !== "Bearer" || !parts[1]) {
+    return authErrorResponse({
+      type: "invalid_token_format",
+      message: "Authorization header must be `Bearer <token>`.",
+      fix: "Check header format.",
+    });
+  }
+
+  const outcome = await verifyGitHubPAT(parts[1], repo);
   if (!outcome.ok) {
     return authErrorResponse(outcome.error);
   }
@@ -200,4 +240,122 @@ async function handleBridgeDeregister(req: Request, authConfig: AuthConfig): Pro
 
   const removed = deregisterBridge(repo);
   return Response.json({ ok: true, removed });
+}
+
+async function handlePublish(
+  req: Request,
+  timeoutMs: number,
+): Promise<Response> {
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse(400, "invalid_request", "Request body is not valid JSON.");
+  }
+
+  const { repo, issueNumber, issueUrl } = body;
+  if (!repo || typeof repo !== "string") {
+    return errorResponse(400, "invalid_request", "Missing or invalid 'repo' field.");
+  }
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return errorResponse(400, "invalid_request", "Missing or invalid 'issueNumber' field.");
+  }
+  if (issueUrl !== undefined && typeof issueUrl !== "string") {
+    return errorResponse(400, "invalid_request", "Invalid 'issueUrl' field.");
+  }
+
+  const authOrResp = await authenticateTeammateRequest(req, repo);
+  if (authOrResp instanceof Response) return authOrResp;
+
+  const bridge = getBridge(repo);
+  if (!bridge) {
+    return errorResponse(502, "no_bridge", `No active bridge registered for '${repo}'.`);
+  }
+
+  const callbackToken = crypto.randomUUID().replaceAll("-", "");
+
+  try {
+    const tokenRegistration = await globalThis.fetch(`${bridge.bridgeUrl}/api/tokens`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        token: callbackToken,
+        issueNumber,
+        repo,
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    if (!tokenRegistration.ok) {
+      return errorResponse(502, "bridge_error", `Bridge for '${repo}' rejected callback registration.`);
+    }
+
+    const callbackResp = await globalThis.fetch(
+      `${bridge.bridgeUrl}/api/callbacks/plannotator/${issueNumber}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          token: callbackToken,
+          repo,
+          event: "plan_published",
+          author: authOrResp.user,
+        }),
+        signal: AbortSignal.timeout(timeoutMs),
+      },
+    );
+
+    if (!callbackResp.ok) {
+      return errorResponse(502, "bridge_error", `Bridge for '${repo}' rejected publish callback.`);
+    }
+
+    return Response.json({
+      ok: true,
+      issueNumber,
+      issueUrl: issueUrl ?? `https://github.com/${repo}/issues/${issueNumber}`,
+    });
+  } catch {
+    return errorResponse(502, "bridge_error", `Bridge for '${repo}' is unavailable.`);
+  }
+}
+
+async function handleWorkflowProxy(
+  req: Request,
+  url: URL,
+  timeoutMs: number,
+): Promise<Response> {
+  const repo = url.searchParams.get("repo");
+  if (!repo) {
+    return errorResponse(400, "invalid_request", "Missing required 'repo' query parameter.");
+  }
+
+  const authOrResp = await authenticateTeammateRequest(req, repo);
+  if (authOrResp instanceof Response) return authOrResp;
+
+  const bridge = getBridge(repo);
+  if (!bridge) {
+    return errorResponse(502, "no_bridge", `No active bridge registered for '${repo}'.`);
+  }
+
+  const proxyUrl = new URL(`${bridge.bridgeUrl}${url.pathname}`);
+  for (const [key, value] of url.searchParams.entries()) {
+    if (key !== "repo") {
+      proxyUrl.searchParams.append(key, value);
+    }
+  }
+
+  try {
+    const upstream = await globalThis.fetch(proxyUrl, {
+      method: req.method,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    const upstreamBody = await upstream.text();
+    return new Response(upstreamBody, {
+      status: upstream.status,
+      headers: { "content-type": upstream.headers.get("content-type") || "text/plain" },
+    });
+  } catch {
+    return errorResponse(502, "bridge_error", `Bridge for '${repo}' is unavailable.`);
+  }
 }

--- a/gateway/src/handler.ts
+++ b/gateway/src/handler.ts
@@ -35,6 +35,35 @@ function authErrorResponse(error: AuthError): Response {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+interface PublishRequestBody {
+  repo: string;
+  issueNumber: number;
+  issueUrl?: string;
+}
+
+function decodePublishRequest(body: unknown): PublishRequestBody | Response {
+  if (!isRecord(body)) {
+    return errorResponse(400, "invalid_request", "Request body must be a JSON object.");
+  }
+
+  const { repo, issueNumber, issueUrl } = body;
+  if (typeof repo !== "string" || repo.length === 0) {
+    return errorResponse(400, "invalid_request", "Missing or invalid 'repo' field.");
+  }
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return errorResponse(400, "invalid_request", "Missing or invalid 'issueNumber' field.");
+  }
+  if (issueUrl !== undefined && typeof issueUrl !== "string") {
+    return errorResponse(400, "invalid_request", "Invalid 'issueUrl' field.");
+  }
+
+  return { repo, issueNumber, issueUrl };
+}
+
 const FORWARDED_HEADERS = [
   "content-type",
   "x-github-event",
@@ -246,23 +275,18 @@ async function handlePublish(
   req: Request,
   timeoutMs: number,
 ): Promise<Response> {
-  let body: any;
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
     return errorResponse(400, "invalid_request", "Request body is not valid JSON.");
   }
 
-  const { repo, issueNumber, issueUrl } = body;
-  if (!repo || typeof repo !== "string") {
-    return errorResponse(400, "invalid_request", "Missing or invalid 'repo' field.");
+  const decodedBody = decodePublishRequest(body);
+  if (decodedBody instanceof Response) {
+    return decodedBody;
   }
-  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-    return errorResponse(400, "invalid_request", "Missing or invalid 'issueNumber' field.");
-  }
-  if (issueUrl !== undefined && typeof issueUrl !== "string") {
-    return errorResponse(400, "invalid_request", "Invalid 'issueUrl' field.");
-  }
+  const { repo, issueNumber, issueUrl } = decodedBody;
 
   const authOrResp = await authenticateTeammateRequest(req, repo);
   if (authOrResp instanceof Response) return authOrResp;

--- a/gateway/test/auth.test.ts
+++ b/gateway/test/auth.test.ts
@@ -230,6 +230,33 @@ describe("verifyGitHubPAT", () => {
     }
   });
 
+  it("rejects a malformed GitHub user payload", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      Response.json({ login: 91 }, { status: 200 }),
+    );
+
+    const result = await verifyGitHubPAT("ghp_malformed_user", "acme/app");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("github_api_error");
+      expect(result.error.message).toContain("without a login");
+    }
+  });
+
+  it("rejects a malformed GitHub permission payload", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(MOCK_USER_RESPONSE, { status: 200 }))
+      .mockResolvedValueOnce(Response.json({ permission: 123 }, { status: 200 }));
+
+    const result = await verifyGitHubPAT("ghp_malformed_permission", "acme/app");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("github_api_error");
+      expect(result.error.message).toContain("without a permission value");
+    }
+  });
+
   it("caches valid PAT checks per repo", async () => {
     const mockFetch = vi
       .fn()

--- a/gateway/test/auth.test.ts
+++ b/gateway/test/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   verifyGitHubToken,
+  verifyGitHubPAT,
   verifySharedSecret,
   verifyRequest,
   requireRepoAccess,
@@ -19,6 +20,14 @@ const MOCK_REPOS_RESPONSE = {
     { full_name: "acme/app" },
     { full_name: "acme/lib" },
   ],
+};
+
+const MOCK_USER_RESPONSE = {
+  login: "tapanc",
+};
+
+const MOCK_PERMISSION_RESPONSE = {
+  permission: "write",
 };
 
 function defaultConfig(overrides?: Partial<AuthConfig>): AuthConfig {
@@ -175,6 +184,65 @@ describe("verifyGitHubToken", () => {
     if (result.ok) {
       expect(result.result.repos).toEqual([]);
     }
+  });
+});
+
+// ── verifyGitHubPAT ───────────────────────────────────────────────
+
+describe("verifyGitHubPAT", () => {
+  it("accepts a PAT for a teammate with write access", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(MOCK_USER_RESPONSE, { status: 200 }))
+      .mockResolvedValueOnce(Response.json(MOCK_PERMISSION_RESPONSE, { status: 200 }));
+
+    const result = await verifyGitHubPAT("ghp_writer", "acme/app");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.user).toBe("tapanc");
+      expect(result.result.permission).toBe("write");
+      expect(result.result.repo).toBe("acme/app");
+    }
+  });
+
+  it("rejects an invalid PAT", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 }),
+    );
+
+    const result = await verifyGitHubPAT("ghp_invalid", "acme/app");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("invalid_token");
+    }
+  });
+
+  it("rejects a teammate without write access", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(MOCK_USER_RESPONSE, { status: 200 }))
+      .mockResolvedValueOnce(Response.json({ permission: "read" }, { status: 200 }));
+
+    const result = await verifyGitHubPAT("ghp_reader", "acme/app");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe("repo_not_authorized");
+    }
+  });
+
+  it("caches valid PAT checks per repo", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(MOCK_USER_RESPONSE, { status: 200 }))
+      .mockResolvedValueOnce(Response.json(MOCK_PERMISSION_RESPONSE, { status: 200 }));
+    globalThis.fetch = mockFetch;
+
+    const first = await verifyGitHubPAT("ghp_writer", "acme/app");
+    const second = await verifyGitHubPAT("ghp_writer", "acme/app");
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/gateway/test/gateway-endpoints.test.ts
+++ b/gateway/test/gateway-endpoints.test.ts
@@ -417,6 +417,24 @@ describe("gateway endpoints", () => {
     expect(body.error.type).toBe("invalid_token");
   });
 
+  it("POST /api/publish rejects non-object JSON bodies", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const resp = await originalFetch(`${baseUrl}/api/publish`, {
+      method: "POST",
+      body: "null",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${TEST_PAT_WRITE}`,
+      },
+    });
+
+    expect(resp.status).toBe(400);
+    const body = await resp.json();
+    expect(body.error.type).toBe("invalid_request");
+    expect(tokenRegistrations).toHaveLength(0);
+    expect(callbackEvents).toHaveLength(0);
+  });
+
   it("GET /api/workflows/:id proxies to the bridge for a teammate with write access", async () => {
     registerBridge("acme/app", mockBridgeUrl);
     const resp = await originalFetch(`${baseUrl}/api/workflows/91?repo=acme/app`, {

--- a/gateway/test/gateway-endpoints.test.ts
+++ b/gateway/test/gateway-endpoints.test.ts
@@ -13,6 +13,8 @@ import { clearTokenCache, type AuthConfig } from "../src/auth.js";
 
 const TEST_GATEWAY_SECRET = "test-gateway-secret";
 const TEST_GITHUB_TOKEN = "ghs_test_installation_token";
+const TEST_PAT_WRITE = "ghp_writer_pat";
+const TEST_PAT_READ = "ghp_reader_pat";
 
 const MOCK_REPOS_RESPONSE = {
   repositories: [
@@ -29,6 +31,9 @@ let server: ReturnType<typeof Bun.serve>;
 let baseUrl: string;
 let mockBridge: ReturnType<typeof Bun.serve>;
 let mockBridgeUrl: string;
+let tokenRegistrations: Array<{ token: string; issueNumber: number; repo: string }>;
+let callbackEvents: Array<{ token: string; repo: string; event: string; author?: string }>;
+let workflowRequests: string[];
 
 const originalFetch = globalThis.fetch;
 
@@ -41,14 +46,31 @@ function installFetchMock() {
   const mockFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
     if (url.includes("api.github.com")) {
-      // Check the auth header to decide the response
       const headers = init?.headers as Record<string, string> | undefined;
       const authHeader =
         (headers && headers["authorization"]) ||
         (input instanceof Request ? input.headers.get("authorization") : undefined);
 
-      if (authHeader === `Bearer ${TEST_GITHUB_TOKEN}`) {
+      if (url.endsWith("/installation/repositories") && authHeader === `Bearer ${TEST_GITHUB_TOKEN}`) {
         return Response.json(MOCK_REPOS_RESPONSE, { status: 200 });
+      }
+      if (url.endsWith("/user") && authHeader === `Bearer ${TEST_PAT_WRITE}`) {
+        return Response.json({ login: "writer" }, { status: 200 });
+      }
+      if (url.endsWith("/user") && authHeader === `Bearer ${TEST_PAT_READ}`) {
+        return Response.json({ login: "reader" }, { status: 200 });
+      }
+      if (
+        url.endsWith("/repos/acme/app/collaborators/writer/permission") &&
+        authHeader === `Bearer ${TEST_PAT_WRITE}`
+      ) {
+        return Response.json({ permission: "write" }, { status: 200 });
+      }
+      if (
+        url.endsWith("/repos/acme/app/collaborators/reader/permission") &&
+        authHeader === `Bearer ${TEST_PAT_READ}`
+      ) {
+        return Response.json({ permission: "read" }, { status: 200 });
       }
       return new Response(JSON.stringify({ message: "Bad credentials" }), { status: 401 });
     }
@@ -59,6 +81,10 @@ function installFetchMock() {
 }
 
 beforeAll(() => {
+  tokenRegistrations = [];
+  callbackEvents = [];
+  workflowRequests = [];
+
   // Start a mock bridge that echoes back a success response
   mockBridge = Bun.serve({
     port: 0,
@@ -70,6 +96,24 @@ beforeAll(() => {
       if (url.pathname === "/api/webhooks/github" && req.method === "POST") {
         const body = await req.text();
         return Response.json({ forwarded: true, bodyLength: body.length });
+      }
+      if (url.pathname === "/api/tokens" && req.method === "POST") {
+        const body = await req.json();
+        tokenRegistrations.push(body);
+        return Response.json({ ok: true });
+      }
+      if (url.pathname.match(/^\/api\/callbacks\/plannotator\/\d+$/) && req.method === "POST") {
+        const body = await req.json();
+        callbackEvents.push(body);
+        return Response.json({ ok: true });
+      }
+      if (url.pathname.match(/^\/api\/workflows\/\d+$/) && req.method === "GET") {
+        workflowRequests.push(`${url.pathname}${url.search}`);
+        return Response.json({ workflowId: url.pathname.split("/").pop(), status: "running" });
+      }
+      if (url.pathname.match(/^\/api\/workflows\/\d+\/history$/) && req.method === "GET") {
+        workflowRequests.push(`${url.pathname}${url.search}`);
+        return Response.json({ events: ["queued", "running"] });
       }
       return new Response("not found", { status: 404 });
     },
@@ -94,6 +138,9 @@ afterAll(() => {
 beforeEach(() => {
   clearRegistry();
   clearTokenCache();
+  tokenRegistrations = [];
+  callbackEvents = [];
+  workflowRequests = [];
   installFetchMock();
 });
 
@@ -303,6 +350,114 @@ describe("gateway endpoints", () => {
     expect(resp.status).toBe(403);
     const body = await resp.json();
     expect(body.error.type).toBe("repo_not_authorized");
+  });
+
+  // ── Teammate proxy routes ────────────────────────────────────────
+
+  it("POST /api/publish with write-access PAT registers callback token and forwards publish callback", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const resp = await originalFetch(`${baseUrl}/api/publish`, {
+      method: "POST",
+      body: JSON.stringify({
+        repo: "acme/app",
+        issueNumber: 91,
+        issueUrl: "https://github.com/acme/app/issues/91",
+      }),
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${TEST_PAT_WRITE}`,
+      },
+    });
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.ok).toBe(true);
+    expect(body.issueUrl).toBe("https://github.com/acme/app/issues/91");
+    expect(tokenRegistrations).toHaveLength(1);
+    expect(tokenRegistrations[0].issueNumber).toBe(91);
+    expect(tokenRegistrations[0].repo).toBe("acme/app");
+    expect(callbackEvents).toHaveLength(1);
+    expect(callbackEvents[0].event).toBe("plan_published");
+    expect(callbackEvents[0].repo).toBe("acme/app");
+    expect(callbackEvents[0].author).toBe("writer");
+    expect(callbackEvents[0].token).toBe(tokenRegistrations[0].token);
+  });
+
+  it("POST /api/publish with read-only PAT returns 403", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const resp = await originalFetch(`${baseUrl}/api/publish`, {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", issueNumber: 91 }),
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${TEST_PAT_READ}`,
+      },
+    });
+
+    expect(resp.status).toBe(403);
+    const body = await resp.json();
+    expect(body.error.type).toBe("repo_not_authorized");
+    expect(tokenRegistrations).toHaveLength(0);
+    expect(callbackEvents).toHaveLength(0);
+  });
+
+  it("POST /api/publish with invalid PAT returns 401", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const resp = await originalFetch(`${baseUrl}/api/publish`, {
+      method: "POST",
+      body: JSON.stringify({ repo: "acme/app", issueNumber: 91 }),
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer ghp_invalid_pat",
+      },
+    });
+
+    expect(resp.status).toBe(401);
+    const body = await resp.json();
+    expect(body.error.type).toBe("invalid_token");
+  });
+
+  it("GET /api/workflows/:id proxies to the bridge for a teammate with write access", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const resp = await originalFetch(`${baseUrl}/api/workflows/91?repo=acme/app`, {
+      headers: { authorization: `Bearer ${TEST_PAT_WRITE}` },
+    });
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.workflowId).toBe("91");
+    expect(body.status).toBe("running");
+    expect(workflowRequests).toEqual(["/api/workflows/91"]);
+  });
+
+  it("GET /api/workflows/:id/history proxies to the bridge", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+    const resp = await originalFetch(`${baseUrl}/api/workflows/91/history?repo=acme/app`, {
+      headers: { authorization: `Bearer ${TEST_PAT_WRITE}` },
+    });
+
+    expect(resp.status).toBe(200);
+    const body = await resp.json();
+    expect(body.events).toEqual(["queued", "running"]);
+    expect(workflowRequests).toEqual(["/api/workflows/91/history"]);
+  });
+
+  it("PAT auth cache avoids a second GitHub API round-trip on repeated workflow checks", async () => {
+    registerBridge("acme/app", mockBridgeUrl);
+
+    await originalFetch(`${baseUrl}/api/workflows/91?repo=acme/app`, {
+      headers: { authorization: `Bearer ${TEST_PAT_WRITE}` },
+    });
+    await originalFetch(`${baseUrl}/api/workflows/91/history?repo=acme/app`, {
+      headers: { authorization: `Bearer ${TEST_PAT_WRITE}` },
+    });
+
+    const githubCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(([input]) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        return url.includes("api.github.com");
+      });
+    expect(githubCalls).toHaveLength(2);
   });
 
   // ── Webhook forwarding ────────────────────────────────────────────


### PR DESCRIPTION
Closes #91
Architect plan: https://github.com/chughtapan/zapbot/issues/91
Parent umbrella: https://github.com/chughtapan/zapbot/issues/72

## What changed
Implemented the missing teammate PAT path in the existing gateway surface. `gateway/src/auth.ts` now verifies teammate PATs with `GET /user` plus collaborator permission checks and caches successful token+repo authorizations for 5 minutes. `gateway/src/handler.ts` now adds `POST /api/publish`, `GET /api/workflows/{n}`, and `GET /api/workflows/{n}/history`, all gated by repo-scoped PAT auth and forwarded through the registered bridge.

## Plan anchors
| Change | Plan anchor |
|---|---|
| Add `verifyGitHubPAT()` with token+repo cache | #91 "gateway/src/auth.ts" |
| Add `POST /api/publish` teammate proxy route | #91 "gateway/src/handler.ts" |
| Add workflow status/history proxy routes | #91 "gateway/src/handler.ts" |
| Expand auth coverage for PAT verification and caching | #91 "gateway/test/auth.test.ts" |
| Add endpoint coverage for publish/status proxy flows | #91 "gateway/test/gateway-endpoints.test.ts" |

## Scope
- Modules touched: `gateway/src/auth.ts`, `gateway/src/handler.ts`, `gateway/test/auth.test.ts`, `gateway/test/gateway-endpoints.test.ts`
- Tier: senior
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Notes
- `repo` is required on teammate proxy requests so the gateway can verify collaborator access and select the registered bridge.
- `/api/publish` accepts `{ repo, issueNumber, issueUrl? }`, registers the callback token with the bridge, emits the `plan_published` callback, and returns the issue URL.
- The bridge-side workflow APIs referenced in #91 are no longer part of the current shipped runtime, so the new workflow routes are implemented as authenticated transparent proxies to any registered bridge exposing those paths.
- Simplify: unavailable in this Codex environment, so no pre-PR `/simplify` pass was run.

## Tests
- `bun test gateway/test/auth.test.ts gateway/test/gateway-endpoints.test.ts`
- `bun test gateway`

## Confidence
HIGH — focused gateway auth/handler coverage passes end-to-end in the isolated issue branch, including PAT success/failure cases, PAT cache hits, publish callback registration, and workflow proxy forwarding.
