### PR TITLE
[impl-senior] route teammate config through gateway

### DIFF
--- a/bin/zapbot-team-init
+++ b/bin/zapbot-team-init
@@ -164,8 +164,7 @@ ZAPBOT_API_KEY=${GENERATED_API_KEY}
 #   ~/.zapbot/config.json
 # with:
 #   { "gateway": "https://zapbot-gateway.up.railway.app" }
-# Legacy `bridges` entries still work during migration, but new teammates should
-# use `gateway` instead of wiring bridge URLs directly.
+# New teammates should use `gateway` instead of wiring bridge URLs directly.
 
 # Bridge port (default: 3000)
 # ZAPBOT_PORT=3000

--- a/bin/zapbot-team-init
+++ b/bin/zapbot-team-init
@@ -160,6 +160,13 @@ if [ ! -f "$ENV_FILE" ]; then
 ZAPBOT_WEBHOOK_SECRET=${GENERATED_WEBHOOK_SECRET}
 ZAPBOT_API_KEY=${GENERATED_API_KEY}
 
+# Teammate config is gateway-first. The installer should point Claude Code at:
+#   ~/.zapbot/config.json
+# with:
+#   { "gateway": "https://zapbot-gateway.up.railway.app" }
+# Legacy `bridges` entries still work during migration, but new teammates should
+# use `gateway` instead of wiring bridge URLs directly.
+
 # Bridge port (default: 3000)
 # ZAPBOT_PORT=3000
 

--- a/skills/zap/SKILL.md
+++ b/skills/zap/SKILL.md
@@ -27,7 +27,7 @@ Parse the user's arguments to determine what they want:
 - If args contain "publish" or "share" or "plan" → invoke the `zapbot-publish` skill.
 - If args contain "help" or nothing → show the help block below.
 - If args contain an issue number → tell the user to comment `@zapbot status` on that issue.
-- Teammate-facing status/publish flows should read `~/.zapbot/config.json`, prefer the top-level `gateway` key, and only fall back to legacy `bridges[repo]` during migration.
+- Teammate-facing status/publish flows should read `~/.zapbot/config.json` and use the top-level `gateway` key.
 
 ## Help
 

--- a/skills/zap/SKILL.md
+++ b/skills/zap/SKILL.md
@@ -27,6 +27,7 @@ Parse the user's arguments to determine what they want:
 - If args contain "publish" or "share" or "plan" → invoke the `zapbot-publish` skill.
 - If args contain "help" or nothing → show the help block below.
 - If args contain an issue number → tell the user to comment `@zapbot status` on that issue.
+- Teammate-facing status/publish flows should read `~/.zapbot/config.json`, prefer the top-level `gateway` key, and only fall back to legacy `bridges[repo]` during migration.
 
 ## Help
 
@@ -39,7 +40,7 @@ Zapbot commands:
 Issue workflow:
   @zapbot plan this         Dispatch a direct ao session
   @zapbot investigate this  Dispatch a direct ao session
-  @zapbot status            Ask the bot to summarize issue state
+  @zapbot status            Ask the bot to summarize issue state via the gateway
 
 Current repo: {REPO}
 ```

--- a/skills/zapbot-publish/SKILL.md
+++ b/skills/zapbot-publish/SKILL.md
@@ -25,7 +25,7 @@ Publish the current plan to a GitHub issue for zapbot dispatch. The issue carrie
 
 ## Gateway-first teammate routing
 
-When teammates use zapbot's issue-status or plan-publish flow, prefer the gateway entrypoint recorded in `~/.zapbot/config.json` under `gateway`. Keep the legacy `bridges[repo]` shape only as a migration fallback. Teammate auth comes from `gh auth token`; do not ask for bridge URLs or shared secrets.
+When teammates use zapbot's issue-status or plan-publish flow, use the gateway entrypoint recorded in `~/.zapbot/config.json` under `gateway`. Teammate auth comes from `gh auth token`; do not ask for bridge URLs or shared secrets.
 
 ## Steps
 

--- a/skills/zapbot-publish/SKILL.md
+++ b/skills/zapbot-publish/SKILL.md
@@ -23,6 +23,10 @@ gh auth status >/dev/null 2>&1 && echo "GH: ok" || echo "GH: missing"
 
 Publish the current plan to a GitHub issue for zapbot dispatch. The issue carries the `zapbot-plan` label so teammates can mention `@zapbot plan this` or `@zapbot investigate this` to spawn a direct `ao` session on it.
 
+## Gateway-first teammate routing
+
+When teammates use zapbot's issue-status or plan-publish flow, prefer the gateway entrypoint recorded in `~/.zapbot/config.json` under `gateway`. Keep the legacy `bridges[repo]` shape only as a migration fallback. Teammate auth comes from `gh auth token`; do not ask for bridge URLs or shared secrets.
+
 ## Steps
 
 ### 1. Verify auth


### PR DESCRIPTION
Closes #93

Issue: https://github.com/chughtapan/zapbot/issues/93

## What changed
Updated the teammate-facing skill/help/init docs to prefer gateway-based routing and to describe the new `~/.zapbot/config.json` shape with a top-level `gateway` key. The init script now advertises the gateway-first config instead of bridge-oriented teammate wiring.

## Plan anchors
| Change | Issue anchor |
|---|---|
| Add gateway-first guidance to `skills/zapbot-publish/SKILL.md` | Issue #93 "Route teammate skill/config/init flow through the gateway" |
| Update `skills/zap/SKILL.md` help text for gateway-backed status routing | Issue #93 "Same config change (gateway URL only)" |
| Add gateway-first teammate config snippet to `bin/zapbot-team-init` | Issue #93 "Update config template to use gateway key instead of bridges" |

## Scope
- Modules touched: 3
- Tier (from safer-diff-scope): senior
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Validation
- `bash -n bin/zapbot-team-init`
- `git diff --check`
- `safer-diff-scope --head HEAD` => `senior`

## Confidence
MED — this is a docs/init routing change; no runtime code paths were altered, so verification is limited to syntax and diff-scope checks.
