### PR TITLE
[impl-senior] align bridge AO config with MoltZap worker bootstrap

### DIFF
--- a/bin/ao-spawn-with-moltzap.ts
+++ b/bin/ao-spawn-with-moltzap.ts
@@ -27,7 +27,9 @@ const configPath = trimEnv(process.env.AO_CONFIG_PATH) ?? "";
 const orchestratorSenderId = resolveMetadataValue(
   currentSession,
   "moltzap_sender_id",
-) ?? fatal("moltzap_sender_id not found in orchestrator metadata");
+) ?? fatal(
+  "moltzap_sender_id not found in orchestrator metadata; plain `ao spawn` fallback is forbidden for MoltZap-linked worker bootstrap",
+);
 const serverUrl = requireEnv("MOLTZAP_SERVER_URL");
 const registrationSecret = requireEnv("MOLTZAP_REGISTRATION_SECRET");
 const beforeSessions = new Set(listSessionNames(sessionDataDir));

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -499,6 +499,7 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
     configPath: current.aoConfigPath,
     env: {
       ...process.env,
+      AO_CALLER_TYPE: "orchestrator",
       ...buildMoltzapProcessEnv(current.moltzap),
     },
   });
@@ -534,6 +535,7 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
         configPath: current.aoConfigPath,
         env: {
           ...process.env,
+          AO_CALLER_TYPE: "orchestrator",
           ...buildMoltzapProcessEnv(current.moltzap),
         },
       });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -79,7 +79,9 @@ export function resolveRuntimeEnv(
     normalizeEnvValue(mergedEnv.ZAPBOT_BOT_USERNAME) ?? "zapbot[bot]",
   );
 
-  const aoConfigPathValue = normalizeEnvValue(mergedEnv.ZAPBOT_CONFIG);
+  const aoConfigPathValue =
+    normalizeEnvValue(mergedEnv.AO_CONFIG_PATH) ??
+    normalizeEnvValue(mergedEnv.ZAPBOT_CONFIG);
   const singleRepoValue = normalizeEnvValue(mergedEnv.ZAPBOT_REPO);
 
   return ok({

--- a/src/orchestrator/control-event.ts
+++ b/src/orchestrator/control-event.ts
@@ -60,6 +60,7 @@ export function toOrchestratorControlPrompt(
       "",
       "Interpret the GitHub message directly. Do not rely on the webhook bridge having pre-classified it into a specific command.",
       "When you need a new worker session, use `bun run bin/ao-spawn-with-moltzap.ts <issue-number>` instead of plain `ao spawn` so the worker keeps its MoltZap control link back to you.",
+      "If MoltZap-linked worker bootstrap fails, treat that as blocking and publish the failure. Do not fall back to plain `ao spawn`.",
       "",
       "github_comment_body:",
       event.commentBody,

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -242,13 +242,17 @@ function isNotReadyStatus(status: string | undefined): boolean {
   return STARTING_STATUSES.has(status.trim().toLowerCase());
 }
 
-function resolveSenderId(projectName: ProjectName, session: AoStatusSession): MoltzapSenderId {
+function requiresMoltzapIdentity(options: AoCliOptions): boolean {
+  const env = options.env ?? process.env;
+  return normalizeEnvValue(env.MOLTZAP_SERVER_URL) !== undefined;
+}
+
+function resolveSenderId(session: AoStatusSession): MoltzapSenderId | null {
   const raw =
+    normalizeEnvValue(session.metadata?.moltzap_sender_id as string | undefined) ??
     normalizeEnvValue(session.metadata?.senderId as string | undefined) ??
-    normalizeEnvValue(session.metadata?.localSenderId as string | undefined) ??
-    normalizeEnvValue(process.env.MOLTZAP_ORCHESTRATOR_SENDER_ID) ??
-    sessionNameFor(projectName);
-  return asMoltzapSenderId(raw);
+    normalizeEnvValue(session.metadata?.localSenderId as string | undefined);
+  return raw === undefined ? null : asMoltzapSenderId(raw);
 }
 
 function formatPrompt(prompt: OrchestratorControlPrompt): string {
@@ -300,9 +304,17 @@ export function createAoCliControlHost(options: AoCliOptions): AoControlHost {
         reason: `orchestrator session ${name} is ${found.status ?? "not ready"}`,
       });
     }
+    const senderId = resolveSenderId(found);
+    if (requiresMoltzapIdentity(options) && senderId === null) {
+      return err({
+        _tag: "OrchestratorNotReady",
+        projectName,
+        reason: `orchestrator session ${name} is missing moltzap_sender_id metadata`,
+      });
+    }
     return ok({
       session: name as AoSessionName,
-      senderId: resolveSenderId(projectName, found),
+      senderId: senderId ?? asMoltzapSenderId(sessionNameFor(projectName)),
       mode: found.status ? "reused" : "started",
     });
   }

--- a/start.sh
+++ b/start.sh
@@ -69,7 +69,7 @@ fi
 
 start_ao_once() {
   : > "$AO_LOG_FILE"
-  (cd "$PROJECT_DIR" && AO_CONFIG_PATH="$AO_CONFIG_FILE" ao start > "$AO_LOG_FILE" 2>&1) &
+  (cd "$PROJECT_DIR" && AO_CONFIG_PATH="$AO_CONFIG_FILE" AO_CALLER_TYPE="orchestrator" ao start > "$AO_LOG_FILE" 2>&1) &
   AO_PID=$!
 }
 
@@ -212,6 +212,7 @@ export ZAPBOT_API_KEY
 export ZAPBOT_WEBHOOK_SECRET
 export ZAPBOT_CONFIG="$PROJECT_DIR/agent-orchestrator.yaml"
 export ZAPBOT_PORT=$BRIDGE_PORT
+export AO_CONFIG_PATH="$AO_CONFIG_FILE"
 [ -n "${ZAPBOT_GATEWAY_URL:-}" ] && export ZAPBOT_GATEWAY_URL
 [ -n "${ZAPBOT_GATEWAY_SECRET:-}" ] && export ZAPBOT_GATEWAY_SECRET
 [ -n "${ZAPBOT_BRIDGE_URL:-}" ] && export ZAPBOT_BRIDGE_URL

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -92,6 +92,21 @@ projects:
     expect(runtime.aoConfigPath).toBe(configPath);
   });
 
+  it("prefers AO_CONFIG_PATH over ZAPBOT_CONFIG for the live AO control surface", () => {
+    const projectConfigPath = join(tmpDir, "agent-orchestrator.yaml");
+    const liveAoConfigPath = join(tmpDir, "zapbot-ao-config.runtime.yaml");
+    writeFileSync(projectConfigPath, "projects:\n");
+
+    const env = expectOk(resolveRuntimeEnv({
+      ZAPBOT_API_KEY: "api-key-123",
+      ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
+      ZAPBOT_CONFIG: projectConfigPath,
+      AO_CONFIG_PATH: liveAoConfigPath,
+    }, null));
+
+    expect(env.aoConfigPath).toBe(liveAoConfigPath);
+  });
+
   it("builds runtime routes for multiple projects", () => {
     const yaml = `
 projects:

--- a/test/orchestrator-control-event.test.ts
+++ b/test/orchestrator-control-event.test.ts
@@ -26,6 +26,7 @@ describe("toOrchestratorControlPrompt", () => {
     expect(result.value.body).toContain("github_comment_body:");
     expect(result.value.body).toContain("please review the open work");
     expect(result.value.body).toContain("bun run bin/ao-spawn-with-moltzap.ts");
+    expect(result.value.body).toContain("Do not fall back to plain `ao spawn`");
   });
 
   it("rejects blank GitHub comments", () => {

--- a/test/orchestrator-runtime.test.ts
+++ b/test/orchestrator-runtime.test.ts
@@ -112,6 +112,7 @@ shift || true
 case "$cmd" in
   start)
     printf 'start %s\\n' "$*" >> "$log"
+    printf 'env AO_CONFIG_PATH=%s AO_CALLER_TYPE=%s\\n' "\${AO_CONFIG_PATH:-}" "\${AO_CALLER_TYPE:-}" >> "$log"
     ;;
   status)
     printf 'status %s\\n' "$*" >> "$log"
@@ -150,6 +151,8 @@ esac
       env: {
         FAKE_AO_LOG: logFile,
         FAKE_AO_STATUS_JSON: statusJson,
+        AO_CALLER_TYPE: "orchestrator",
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
       },
       timeoutMs: 5_000,
     });
@@ -179,10 +182,55 @@ esac
 
     const log = readFileSync(logFile, "utf8");
     expect(log).toContain("start app --no-dashboard");
+    expect(log).toContain("env AO_CONFIG_PATH=/tmp/agent-orchestrator.yaml AO_CALLER_TYPE=orchestrator");
     expect(log).toContain("status --project app --json");
     expect(log).toContain("send app-orchestrator --file");
     expect(log).toContain("# GitHub control");
     expect(log).toContain("github_comment_body:");
     expect(log).toContain("@zapbot plan this");
+  });
+
+  it("holds the orchestrator as not ready when MoltZap is enabled but sender metadata is missing", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "zapbot-ao-host-"));
+    const logFile = join(workdir, "ao.log");
+    const fakeAo = join(workdir, "ao");
+    const statusJson = JSON.stringify([
+      {
+        name: "app-orchestrator",
+        role: "orchestrator",
+        status: "running",
+        metadata: {},
+      },
+    ]);
+    writeFileSync(
+      fakeAo,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "\${FAKE_AO_STATUS_JSON:-[]}"
+`,
+      "utf8",
+    );
+    chmodSync(fakeAo, 0o755);
+
+    const host = createAoCliControlHost({
+      aoBinary: fakeAo,
+      configPath: "/tmp/agent-orchestrator.yaml",
+      env: {
+        FAKE_AO_LOG: logFile,
+        FAKE_AO_STATUS_JSON: statusJson,
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
+      },
+      timeoutMs: 5_000,
+    });
+
+    const ready = await host.resolveReady(asProjectName("app"));
+    expect(ready).toEqual({
+      _tag: "Err",
+      error: {
+        _tag: "OrchestratorNotReady",
+        projectName: "app",
+        reason: "orchestrator session app-orchestrator is missing moltzap_sender_id metadata",
+      },
+    });
   });
 });


### PR DESCRIPTION
Closes #243
Spike verdict: https://github.com/chughtapan/zapbot/issues/242#issuecomment-4285775722
Live evidence: https://github.com/chughtapan/zapbot/issues/239

## What changed
This keeps the bridge, orchestrator startup, and MoltZap worker bootstrap on the same live AO session surface. The bridge now prefers the launcher's real `AO_CONFIG_PATH` instead of querying the project yaml, the persistent orchestrator startup path is explicitly marked as `AO_CALLER_TYPE=orchestrator` so MoltZap channel registration can write `moltzap_sender_id` metadata, and the control prompt / spawn helper now treat plain `ao spawn` fallback as a blocking failure instead of an acceptable substitute.

## Plan anchors
| Change | Plan anchor |
|---|---|
| Prefer the live launcher `AO_CONFIG_PATH` over `ZAPBOT_CONFIG` for AO control lookups | #243 frozen target: fix the bridge / AO config-path mismatch so the running bridge queries the AO session surface that actually sees the live orchestrator session |
| Export the live AO config path into the bridge process and start AO with `AO_CALLER_TYPE=orchestrator` | #243 frozen target: fix the bridge / AO config-path mismatch so the running bridge queries the AO session surface that actually sees the live orchestrator session |
| Require MoltZap sender metadata before treating an orchestrator session as ready when MoltZap is enabled | #243 frozen target: ensure the persistent orchestrator startup path writes `moltzap_sender_id` / MoltZap identity into orchestrator session metadata before worker spawns are attempted |
| Make the orchestrator prompt and bootstrap fatal message explicitly forbid plain `ao spawn` fallback | #243 frozen target: remove or hard-fail the plain `ao spawn` fallback when this lane requires MoltZap-linked worker bootstrap |
| Add regression coverage for config-path precedence, orchestrator metadata gating, and no-fallback prompt wording | #243 acceptance: draft PR fixes the exact load-bearing defects named by the spike |

## Scope
- Modules touched: `src/config`, `src/orchestrator`, `src/bridge`, `bin`, launcher `start.sh`, targeted tests
- Tier (from `safer-diff-scope`): `senior`
- New modules: 0
- New public signatures outside the frozen target: 0
- New deps: 0

## Tests
- `bun test test/config-loader.test.ts test/config-reload.test.ts test/orchestrator-runtime.test.ts test/orchestrator-control-event.test.ts`
- `bash -n start.sh`
- `git diff --check`
- `safer-diff-scope --head HEAD`
- `bun run build`
- `bun run lint` (warnings only, 0 errors)

## Validation notes
- Full `bun test` still reports unrelated failures outside this diff, including `test/bridge.http.test.ts`, `test/v2-bridge.http.test.ts`, and `test/github-thread-links.test.ts`.
- The scoped modules for this lane are green.

## Confidence
HIGH — the exact seams named in the spike now have targeted regression coverage, the AO control host is pinned to the launcher config path, and MoltZap-enabled orchestrators no longer look ready without `moltzap_sender_id` metadata.
