### PR TITLE
fix: complete local ao moltzap e2e bootstrap

### DIFF
--- a/bin/ao-spawn-with-moltzap.ts
+++ b/bin/ao-spawn-with-moltzap.ts
@@ -215,8 +215,6 @@ async function restartWorkerWithResume(options: {
     "--resume",
     shellSingleQuote(options.claudeSessionId),
     "--dangerously-skip-permissions",
-    "--mcp-config",
-    ".claude/moltzap-channel.mcp.json",
     "--dangerously-load-development-channels",
     "server:moltzap",
   ].join(" ");

--- a/bin/moltzap-claude-channel.ts
+++ b/bin/moltzap-claude-channel.ts
@@ -3,9 +3,8 @@
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import process from "node:process";
-import type { EventFrame, Message as MoltzapMessage } from "@moltzap/protocol";
-import { EventNames } from "@moltzap/protocol";
-import { MoltZapService, MoltZapWsClient } from "@moltzap/client";
+import type { Message as MoltzapMessage } from "@moltzap/protocol";
+import { MoltZapService } from "@moltzap/client";
 import { toClaudeChannelNotification } from "../src/claude-channel/event.ts";
 import {
   bootClaudeChannelServer,
@@ -82,7 +81,6 @@ const service = new MoltZapService({
 
 let channelStop: (() => Promise<void>) | null = null;
 let unreadPoller: ReturnType<typeof setInterval> | null = null;
-let eventClient: MoltZapWsClient | null = null;
 
 try {
   const hello = await service.connect();
@@ -141,43 +139,32 @@ try {
     fatal(channel.error.cause);
   }
 
-  eventClient = new MoltZapWsClient({
-    serverUrl: bootstrap.value.serverUrl,
-    agentKey: bootstrap.value.apiKey,
-    onEvent: (frame) => {
-      const message = messageFromEventFrame(frame);
-      if (message === null) {
-        return;
-      }
-      void emitClaudeNotification({
-        channel: channel.value,
-        message,
-        localSenderId,
-        deliveredMessageIds,
-      });
-    },
-    onDisconnect: () => {
-      console.error("[moltzap-channel] disconnected");
-    },
-    onReconnect: () => {
-      console.error("[moltzap-channel] reconnected");
-      void sweepUnreadConversations({
-        service,
-        channel: channel.value,
-        localSenderId,
-        deliveredMessageIds,
-      });
-    },
+  service.on("message", (message) => {
+    void emitClaudeNotification({
+      channel: channel.value,
+      message,
+      localSenderId,
+      deliveredMessageIds,
+    });
   });
-  await eventClient.connect();
+  service.on("disconnect", () => {
+    console.error("[moltzap-channel] disconnected");
+  });
+  service.on("reconnect", () => {
+    console.error("[moltzap-channel] reconnected");
+    void sweepUnreadConversations({
+      service,
+      channel: channel.value,
+      localSenderId,
+      deliveredMessageIds,
+    });
+  });
 
   channelStop = async () => {
     if (unreadPoller !== null) {
       clearInterval(unreadPoller);
       unreadPoller = null;
     }
-    eventClient?.close();
-    eventClient = null;
     await channel.value.stop();
     service.close();
   };
@@ -537,20 +524,6 @@ function trimEnv(value: string | undefined): string | null {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
-}
-
-function messageFromEventFrame(frame: EventFrame): MoltzapMessageLike | null {
-  if (frame.event !== EventNames.MessageReceived) {
-    return null;
-  }
-  if (typeof frame.data !== "object" || frame.data === null) {
-    return null;
-  }
-  const nested = asMessageLike((frame.data as { readonly message?: unknown }).message);
-  if (nested !== null) {
-    return nested;
-  }
-  return asMessageLike(frame.data);
 }
 
 function stringifyCause(cause: unknown): string {

--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -133,12 +133,27 @@ function buildBridgeConfig(runtime: BridgeRuntimeConfig, mergedEnv: Record<strin
     gatewayUrl: runtime.gatewayUrl,
     gatewaySecret: runtime.gatewaySecret,
     botUsername: runtime.botUsername,
-    aoConfigPath: runtime.aoConfigPath ?? "",
+    aoConfigPath: resolveAoCliConfigPath(runtime, mergedEnv),
     apiKey: runtime.apiKey,
     webhookSecret: runtime.webhookSecret,
     moltzap: moltzap.value,
     repos: buildRepos(runtime),
   });
+}
+
+function resolveAoCliConfigPath(
+  runtime: BridgeRuntimeConfig,
+  mergedEnv: Record<string, string | undefined>,
+): string {
+  const aoCliEnvPath = mergedEnv.AO_CONFIG_PATH?.trim();
+  if (typeof aoCliEnvPath === "string" && aoCliEnvPath.length > 0) {
+    return aoCliEnvPath;
+  }
+  const override = mergedEnv.ZAPBOT_AO_CONFIG_PATH?.trim();
+  if (typeof override === "string" && override.length > 0) {
+    return override;
+  }
+  return runtime.aoConfigPath ?? "";
 }
 
 function buildRepos(runtime: BridgeRuntimeConfig): ReadonlyMap<import("../src/types.ts").RepoFullName, RepoRoute> {

--- a/bin/zapbot-team-init
+++ b/bin/zapbot-team-init
@@ -137,6 +137,7 @@ if [ -f "$TEMPLATE" ]; then
     -e "s|{{REPO}}|$ZAPBOT_REPO|g" \
     -e "s|{{REPO_PATH}}|$PROJECT_DIR|g" \
     -e "s|{{REPO_NAME}}|$REPO_NAME|g" \
+    -e "s|{{ZAPBOT_DIR}}|$ZAPBOT_DIR|g" \
     "$TEMPLATE" > "$PROJECT_DIR/agent-orchestrator.yaml"
   echo "  Generated $PROJECT_DIR/agent-orchestrator.yaml"
 else
@@ -159,12 +160,6 @@ if [ ! -f "$ENV_FILE" ]; then
 #                            Never hand this to GitHub.
 ZAPBOT_WEBHOOK_SECRET=${GENERATED_WEBHOOK_SECRET}
 ZAPBOT_API_KEY=${GENERATED_API_KEY}
-
-# Teammate config is gateway-first. The installer should point Claude Code at:
-#   ~/.zapbot/config.json
-# with:
-#   { "gateway": "https://zapbot-gateway.up.railway.app" }
-# New teammates should use `gateway` instead of wiring bridge URLs directly.
 
 # Bridge port (default: 3000)
 # ZAPBOT_PORT=3000

--- a/src/ao/claude-channel-launch.ts
+++ b/src/ao/claude-channel-launch.ts
@@ -36,8 +36,8 @@ export type ClaudeChannelLaunchPlanError =
   | { readonly _tag: "McpConfigInvalid"; readonly reason: string };
 
 /**
- * Render the session-local MCP config JSON Claude Code will consume through
- * `--mcp-config`.
+ * Render the session-local MCP config JSON Claude Code will consume from the
+ * workspace `.mcp.json`.
  */
 export function renderSessionMcpConfig(
   server: SessionMcpServerConfig,
@@ -100,7 +100,7 @@ export function planClaudeChannelLaunch(input: {
   return ok({
     mcpConfigPath: input.mcpConfigPath,
     mcpConfigJson: mcpConfigJson.value,
-    extraArgs: ["--mcp-config", input.mcpConfigPath, ...entryArgs.value],
+    extraArgs: [...entryArgs.value],
     entry: input.entry,
   });
 }

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -13,9 +13,7 @@
 
 import { verifyAndClassify, registerBridge, deregisterBridge, startHeartbeat } from "./gateway.ts";
 import type { GatewayClientConfig, GatewayWebhookEnvelope, ClassifiedWebhook } from "./gateway.ts";
-import { getIssue, postComment as postGitHubComment } from "./github-state.ts";
-import { mirrorDurableStatusComment, type DurableStatusComment } from "./github/comment-mirroring.ts";
-import { resolveThreadMirrorTargets, type IssueThreadAnchor } from "./github/thread-links.ts";
+import { getIssue } from "./github-state.ts";
 import {
   buildMoltzapProcessEnv,
   type MoltzapRuntimeConfig,
@@ -193,23 +191,16 @@ async function handleMention(
         return err(forwarded.error);
       }
       const session = forwarded.value.session;
-      await postDurableStatusComment(
-        { repo: c.repo, issue: c.issue },
-        {
-          source: "bridge",
-          body: `Forwarded control event for @${c.triggeredBy}. Session: \`${session as unknown as string}\`.`,
-        },
-        ctx,
+      void ctx.gh.postComment(
+        c.repo,
+        c.issue,
+        `Forwarded control event for @${c.triggeredBy}. Session: \`${session as unknown as string}\`.`
       );
       return ok({ kind: "dispatched", repo: c.repo, session });
     }
     case "status": {
       const summary = await summarizeIssue(c.repo, c.issue);
-      await postDurableStatusComment(
-        { repo: c.repo, issue: c.issue },
-        { source: "bridge", body: summary },
-        ctx,
-      );
+      void ctx.gh.postComment(c.repo, c.issue, summary);
       return ok({ kind: "replied", command: "status" });
     }
     case "unknown_command": {
@@ -237,46 +228,6 @@ async function summarizeIssue(repo: RepoFullName, issue: IssueNumber): Promise<s
     `Assignees: ${assignees.length ? assignees.map((a) => `@${a}`).join(", ") : "_(none)_"}`,
   ];
   return lines.join("\n");
-}
-
-async function postDurableStatusComment(
-  anchor: IssueThreadAnchor,
-  comment: DurableStatusComment,
-  ctx: BridgeHandlerContext,
-): Promise<void> {
-  const targets = await resolveThreadMirrorTargets(anchor);
-  if (targets._tag === "Err") {
-    log.warn(
-      `durable_comment_target_lookup_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${targets.error._tag}`,
-    );
-    const fallback = await ctx.gh.postComment(anchor.repo, anchor.issue, comment.body);
-    if (fallback._tag === "Err") {
-      log.warn(
-        `durable_comment_issue_post_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${fallback.error.cause}`,
-      );
-    }
-    return;
-  }
-
-  const receipt = await mirrorDurableStatusComment(
-    targets.value,
-    comment,
-    { postComment: postGitHubComment },
-  );
-  if (receipt._tag === "Err") {
-    const fallback = await ctx.gh.postComment(anchor.repo, anchor.issue, comment.body);
-    if (fallback._tag === "Err") {
-      log.warn(
-        `durable_comment_issue_post_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${receipt.error.cause}`,
-      );
-    }
-    return;
-  }
-  if (receipt.value.linkedPullRequestMirror._tag === "Failed") {
-    log.warn(
-      `durable_comment_pr_mirror_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} linked_pr=${targets.value.linkedPullRequest as unknown as number} cause=${receipt.value.linkedPullRequestMirror.cause}`,
-    );
-  }
 }
 
 // ── Server boot ─────────────────────────────────────────────────────
@@ -499,6 +450,7 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
     configPath: current.aoConfigPath,
     env: {
       ...process.env,
+      AO_CALLER_TYPE: "orchestrator",
       ...buildMoltzapProcessEnv(current.moltzap),
     },
   });
@@ -534,6 +486,7 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
         configPath: current.aoConfigPath,
         env: {
           ...process.env,
+          AO_CALLER_TYPE: "orchestrator",
           ...buildMoltzapProcessEnv(current.moltzap),
         },
       });

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -24,6 +24,7 @@ import { toOrchestratorControlPrompt, type ControlEventShapeError, type Orchestr
 import {
   absurd,
   asDeliveryId,
+  asIssueNumber,
   asRepoFullName,
   err,
   ok,
@@ -32,6 +33,7 @@ import type {
   BotUsername,
   DispatchError,
   GhCallError,
+  GithubStateError,
   HandleOutcome,
   InstallationToken,
   IssueNumber,
@@ -119,6 +121,21 @@ type BridgeHotPathError =
   | { readonly _tag: "ProjectNotConfigured"; readonly repo: RepoFullName }
   | ControlEventShapeError
   | ForwardControlError;
+type IssueEventSource = {
+  readonly type?: string | null;
+  readonly pull_request?: { readonly number?: number | null } | null;
+  readonly issue?: { readonly number?: number | null } | null;
+};
+type IssueEventSnapshot = {
+  readonly event?: string | null;
+  readonly created_at?: string | null;
+  readonly source?: IssueEventSource | null;
+};
+type IssueThreadAnchor = {
+  readonly repo: RepoFullName;
+  readonly issue: IssueNumber;
+};
+const GITHUB_API_BASE_URL = "https://api.github.com";
 
 // ── Handler ─────────────────────────────────────────────────────────
 
@@ -191,16 +208,16 @@ async function handleMention(
         return err(forwarded.error);
       }
       const session = forwarded.value.session;
-      void ctx.gh.postComment(
-        c.repo,
-        c.issue,
-        `Forwarded control event for @${c.triggeredBy}. Session: \`${session as unknown as string}\`.`
+      await postDurableStatusComment(
+        { repo: c.repo, issue: c.issue },
+        `Forwarded control event for @${c.triggeredBy}. Session: \`${session as unknown as string}\`.`,
+        ctx,
       );
       return ok({ kind: "dispatched", repo: c.repo, session });
     }
     case "status": {
       const summary = await summarizeIssue(c.repo, c.issue);
-      void ctx.gh.postComment(c.repo, c.issue, summary);
+      await postDurableStatusComment({ repo: c.repo, issue: c.issue }, summary, ctx);
       return ok({ kind: "replied", command: "status" });
     }
     case "unknown_command": {
@@ -228,6 +245,296 @@ async function summarizeIssue(repo: RepoFullName, issue: IssueNumber): Promise<s
     `Assignees: ${assignees.length ? assignees.map((a) => `@${a}`).join(", ") : "_(none)_"}`,
   ];
   return lines.join("\n");
+}
+
+async function postDurableStatusComment(
+  anchor: IssueThreadAnchor,
+  body: string,
+  ctx: BridgeHandlerContext,
+): Promise<void> {
+  const issueComment = await ctx.gh.postComment(anchor.repo, anchor.issue, body);
+  if (issueComment._tag === "Err") {
+    log.warn(
+      `durable_comment_issue_post_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${issueComment.error.cause}`,
+    );
+    return;
+  }
+
+  const linkedPullRequest = await getLinkedPullRequest(anchor.repo, anchor.issue);
+  if (linkedPullRequest._tag === "Err") {
+    log.warn(
+      `durable_comment_target_lookup_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} cause=${linkedPullRequest.error._tag}`,
+    );
+    return;
+  }
+  if (linkedPullRequest.value === null) {
+    return;
+  }
+
+  const mirroredComment = await ctx.gh.postComment(anchor.repo, linkedPullRequest.value, body);
+  if (mirroredComment._tag === "Err") {
+    log.warn(
+      `durable_comment_pr_mirror_failed repo=${anchor.repo as unknown as string} issue=${anchor.issue as unknown as number} linked_pr=${linkedPullRequest.value as unknown as number} cause=${mirroredComment.error.cause}`,
+    );
+  }
+}
+
+async function getLinkedPullRequest(
+  repo: RepoFullName,
+  issue: IssueNumber,
+): Promise<Result<IssueNumber | null, GithubStateError>> {
+  const token = await getGitHubApiToken();
+  if (token === null) {
+    return err({ _tag: "GitHubAuthMissing" });
+  }
+
+  const { owner, repoName } = splitRepo(repo);
+  const events: IssueEventSnapshot[] = [];
+  for (let page = 1; ; page += 1) {
+    const pageResult = await fetchIssueEventsPage(owner, repoName, issue, page, token);
+    if (pageResult._tag === "Err") {
+      return err(pageResult.error);
+    }
+    events.push(...pageResult.value);
+    if (pageResult.value.length < 100) {
+      break;
+    }
+  }
+  return ok(findLinkedPullRequest(events));
+}
+
+async function getGitHubApiToken(): Promise<string | null> {
+  const pat = process.env.ZAPBOT_GITHUB_TOKEN?.trim();
+  if (pat) {
+    return pat;
+  }
+  try {
+    const installationToken = await getInstallationToken();
+    return installationToken?.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function splitRepo(repo: RepoFullName): { owner: string; repoName: string } {
+  const [owner, repoName] = (repo as unknown as string).split("/");
+  return { owner, repoName };
+}
+
+async function fetchIssueEventsPage(
+  owner: string,
+  repoName: string,
+  issue: IssueNumber,
+  page: number,
+  token: string,
+): Promise<Result<ReadonlyArray<IssueEventSnapshot>, GithubStateError>> {
+  const issueNumber = issue as unknown as number;
+  const url = `${GITHUB_API_BASE_URL}/repos/${owner}/${repoName}/issues/${issueNumber}/events?per_page=100&page=${page}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "zapbot-bridge",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return err({ _tag: "GitHubApiFailed", status: -1, message });
+  }
+
+  if (!response.ok) {
+    if (response.status === 404) {
+      return err({ _tag: "IssueNotFound", repo: asRepoFullName(`${owner}/${repoName}`), issue });
+    }
+    const body = await readResponseText(response);
+    return err({
+      _tag: "GitHubApiFailed",
+      status: response.status,
+      message: body || `issue events request failed with status ${response.status}`,
+    });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return err({ _tag: "GitHubApiFailed", status: response.status, message });
+  }
+  return decodeIssueEventPage(payload);
+}
+
+async function readResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
+function decodeIssueEventPage(
+  payload: unknown,
+): Result<ReadonlyArray<IssueEventSnapshot>, GithubStateError> {
+  if (!Array.isArray(payload)) {
+    return err({ _tag: "GitHubApiFailed", status: -1, message: "issue events payload was not an array" });
+  }
+
+  const events: IssueEventSnapshot[] = [];
+  for (const entry of payload) {
+    const decoded = decodeIssueEvent(entry);
+    if (decoded._tag === "Err") {
+      return decoded;
+    }
+    events.push(decoded.value);
+  }
+  return ok(events);
+}
+
+function decodeIssueEvent(entry: unknown): Result<IssueEventSnapshot, GithubStateError> {
+  if (!isJsonObject(entry)) {
+    return err({ _tag: "GitHubApiFailed", status: -1, message: "issue event entry was not an object" });
+  }
+
+  const event = decodeOptionalString(entry.event, "issue event entry had invalid event");
+  if (event._tag === "Err") {
+    return event;
+  }
+  const createdAt = decodeOptionalString(entry.created_at, "issue event entry had invalid created_at");
+  if (createdAt._tag === "Err") {
+    return createdAt;
+  }
+  const source = decodeIssueEventSource(entry.source);
+  if (source._tag === "Err") {
+    return source;
+  }
+  return ok({
+    event: event.value,
+    created_at: createdAt.value,
+    source: source.value,
+  });
+}
+
+function decodeIssueEventSource(
+  value: unknown,
+): Result<IssueEventSource | null, GithubStateError> {
+  if (value === undefined || value === null) {
+    return ok(null);
+  }
+  if (!isJsonObject(value)) {
+    return err({ _tag: "GitHubApiFailed", status: -1, message: "issue event entry had invalid source" });
+  }
+
+  const type = decodeOptionalString(value.type, "issue event source had invalid type");
+  if (type._tag === "Err") {
+    return type;
+  }
+
+  const issue = decodeIssueNumberSource(value.issue, "issue");
+  if (issue._tag === "Err") {
+    return issue;
+  }
+  const pullRequest = decodeIssueNumberSource(value.pull_request, "pull_request");
+  if (pullRequest._tag === "Err") {
+    return pullRequest;
+  }
+
+  return ok({
+    type: type.value,
+    issue: issue.value,
+    pull_request: pullRequest.value,
+  });
+}
+
+function decodeIssueNumberSource(
+  value: unknown,
+  fieldName: "issue" | "pull_request",
+): Result<{ readonly number?: number | null } | null, GithubStateError> {
+  if (value === undefined || value === null) {
+    return ok(null);
+  }
+  if (!isJsonObject(value)) {
+    return err({ _tag: "GitHubApiFailed", status: -1, message: `issue event source had invalid ${fieldName}` });
+  }
+
+  const number = decodeOptionalNumber(
+    value.number,
+    `issue event source ${fieldName} had invalid number`,
+  );
+  if (number._tag === "Err") {
+    return number;
+  }
+  return ok({ number: number.value });
+}
+
+function decodeOptionalString(
+  value: unknown,
+  message: string,
+): Result<string | null | undefined, GithubStateError> {
+  if (value === undefined || value === null) {
+    return ok(value);
+  }
+  if (typeof value === "string") {
+    return ok(value);
+  }
+  return err({ _tag: "GitHubApiFailed", status: -1, message });
+}
+
+function decodeOptionalNumber(
+  value: unknown,
+  message: string,
+): Result<number | null | undefined, GithubStateError> {
+  if (value === undefined || value === null) {
+    return ok(value);
+  }
+  if (typeof value === "number") {
+    return ok(value);
+  }
+  return err({ _tag: "GitHubApiFailed", status: -1, message });
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function findLinkedPullRequest(events: ReadonlyArray<IssueEventSnapshot>): IssueNumber | null {
+  let latestAt = Number.NEGATIVE_INFINITY;
+  let linkedPullRequest: IssueNumber | null = null;
+  for (const event of events) {
+    if (event.event !== "cross-referenced") {
+      continue;
+    }
+    const pullRequestNumber = extractPullRequestNumber(event.source);
+    if (pullRequestNumber === null) {
+      continue;
+    }
+    const createdAt = event.created_at ? Date.parse(event.created_at) : Number.NaN;
+    if (Number.isNaN(createdAt)) {
+      continue;
+    }
+    if (createdAt >= latestAt) {
+      latestAt = createdAt;
+      linkedPullRequest = pullRequestNumber;
+    }
+  }
+  return linkedPullRequest;
+}
+
+function extractPullRequestNumber(source: IssueEventSource | null | undefined): IssueNumber | null {
+  if (source === null || source === undefined) {
+    return null;
+  }
+  if (source.type !== undefined && source.type !== null && source.type !== "pull_request") {
+    return null;
+  }
+  const number = source.pull_request?.number ?? source.issue?.number ?? null;
+  if (typeof number !== "number") {
+    return null;
+  }
+  return asIssueNumber(number);
 }
 
 // ── Server boot ─────────────────────────────────────────────────────

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -79,7 +79,9 @@ export function resolveRuntimeEnv(
     normalizeEnvValue(mergedEnv.ZAPBOT_BOT_USERNAME) ?? "zapbot[bot]",
   );
 
-  const aoConfigPathValue = normalizeEnvValue(mergedEnv.ZAPBOT_CONFIG);
+  const aoConfigPathValue =
+    normalizeEnvValue(mergedEnv.AO_CONFIG_PATH) ??
+    normalizeEnvValue(mergedEnv.ZAPBOT_CONFIG);
   const singleRepoValue = normalizeEnvValue(mergedEnv.ZAPBOT_REPO);
 
   return ok({

--- a/src/orchestrator/control-event.ts
+++ b/src/orchestrator/control-event.ts
@@ -60,6 +60,7 @@ export function toOrchestratorControlPrompt(
       "",
       "Interpret the GitHub message directly. Do not rely on the webhook bridge having pre-classified it into a specific command.",
       "When you need a new worker session, use `bun run bin/ao-spawn-with-moltzap.ts <issue-number>` instead of plain `ao spawn` so the worker keeps its MoltZap control link back to you.",
+      "If MoltZap-linked worker bootstrap fails, do not fall back to plain `ao spawn`; publish the failure back to GitHub as a blocking runtime issue.",
       "",
       "github_comment_body:",
       event.commentBody,

--- a/src/orchestrator/runtime.ts
+++ b/src/orchestrator/runtime.ts
@@ -4,7 +4,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { MoltzapSenderId } from "../moltzap/types.ts";
@@ -125,6 +125,7 @@ interface SpawnResult {
 
 const DEFAULT_TIMEOUT_MS = 20_000;
 const STARTING_STATUSES = new Set(["starting", "initializing", "provisioning", "booting"]);
+const TERMINAL_STATUSES = new Set(["killed", "exited", "merged", "closed", "done"]);
 
 function normalizeEnvValue(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined;
@@ -242,13 +243,113 @@ function isNotReadyStatus(status: string | undefined): boolean {
   return STARTING_STATUSES.has(status.trim().toLowerCase());
 }
 
-function resolveSenderId(projectName: ProjectName, session: AoStatusSession): MoltzapSenderId {
+function isTerminalStatus(status: string | undefined): boolean {
+  if (typeof status !== "string") return false;
+  return TERMINAL_STATUSES.has(status.trim().toLowerCase());
+}
+
+function requiresMoltzapIdentity(options: AoCliOptions): boolean {
+  const env = options.env ?? process.env;
+  return normalizeEnvValue(env.MOLTZAP_SERVER_URL) !== undefined;
+}
+
+function resolveSenderId(session: AoStatusSession): MoltzapSenderId | null {
   const raw =
+    normalizeEnvValue(session.metadata?.moltzap_sender_id as string | undefined) ??
     normalizeEnvValue(session.metadata?.senderId as string | undefined) ??
-    normalizeEnvValue(session.metadata?.localSenderId as string | undefined) ??
-    normalizeEnvValue(process.env.MOLTZAP_ORCHESTRATOR_SENDER_ID) ??
-    sessionNameFor(projectName);
-  return asMoltzapSenderId(raw);
+    normalizeEnvValue(session.metadata?.localSenderId as string | undefined);
+  return raw === undefined ? null : asMoltzapSenderId(raw);
+}
+
+function readSessionMetadataFromDisk(
+  sessionName: string,
+  projectName: ProjectName,
+  options: AoCliOptions,
+): ReadonlyMap<string, string> {
+  const homeDir = normalizeEnvValue((options.env ?? process.env).HOME) ?? process.env.HOME;
+  if (typeof homeDir !== "string" || homeDir.trim().length === 0) {
+    return new Map();
+  }
+
+  const root = join(homeDir, ".agent-orchestrator");
+  if (!existsSync(root)) {
+    return new Map();
+  }
+
+  const matches = readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith(`-${projectName as string}`))
+    .map((entry) => join(root, entry.name, "sessions", sessionName))
+    .filter((path) => existsSync(path));
+
+  if (matches.length === 0) {
+    return new Map();
+  }
+
+  const metadataPath = matches.sort((left, right) => {
+    try {
+      return statSync(right).mtimeMs - statSync(left).mtimeMs;
+    } catch {
+      return 0;
+    }
+  })[0];
+
+  try {
+    const values = new Map<string, string>();
+    for (const line of readFileSync(metadataPath, "utf8").split("\n")) {
+      const separator = line.indexOf("=");
+      if (separator <= 0) {
+        continue;
+      }
+      values.set(line.slice(0, separator), line.slice(separator + 1));
+    }
+    return values;
+  } catch {
+    return new Map();
+  }
+}
+
+function resolveSenderIdForSession(
+  session: AoStatusSession,
+  projectName: ProjectName,
+  options: AoCliOptions,
+): MoltzapSenderId | null {
+  const fromStatus = resolveSenderId(session);
+  if (fromStatus !== null) {
+    return fromStatus;
+  }
+  const sessionName = session.name ?? session.id;
+  if (typeof sessionName !== "string" || sessionName.trim().length === 0) {
+    return null;
+  }
+  const metadata = readSessionMetadataFromDisk(sessionName, projectName, options);
+  const raw =
+    normalizeEnvValue(metadata.get("moltzap_sender_id")) ??
+    normalizeEnvValue(metadata.get("senderId")) ??
+    normalizeEnvValue(metadata.get("localSenderId"));
+  return raw === undefined ? null : asMoltzapSenderId(raw);
+}
+
+function pickPreferredOrchestratorSession(
+  sessions: readonly AoStatusSession[],
+  projectName: ProjectName,
+  options: AoCliOptions,
+): AoStatusSession | undefined {
+  const candidates = sessions.filter((session) =>
+    isOrchestratorSession(session, projectName),
+  );
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  const nonTerminal = candidates.filter((session) => !isTerminalStatus(session.status));
+  const liveCandidates = nonTerminal.length > 0 ? nonTerminal : candidates;
+  if (!requiresMoltzapIdentity(options)) {
+    return liveCandidates[0];
+  }
+  return (
+    liveCandidates.find((session) =>
+      resolveSenderIdForSession(session, projectName, options) !== null,
+    ) ?? liveCandidates[0]
+  );
 }
 
 function formatPrompt(prompt: OrchestratorControlPrompt): string {
@@ -288,7 +389,11 @@ export function createAoCliControlHost(options: AoCliOptions): AoControlHost {
     if (sessions._tag === "Err") {
       return err(sessions.error);
     }
-    const found = sessions.value.find((session) => isOrchestratorSession(session, projectName));
+    const found = pickPreferredOrchestratorSession(
+      sessions.value,
+      projectName,
+      options,
+    );
     if (!found) {
       return err({ _tag: "OrchestratorNotFound", projectName });
     }
@@ -300,9 +405,22 @@ export function createAoCliControlHost(options: AoCliOptions): AoControlHost {
         reason: `orchestrator session ${name} is ${found.status ?? "not ready"}`,
       });
     }
+    const senderId = resolveSenderIdForSession(found, projectName, options);
+    if (requiresMoltzapIdentity(options) && senderId === null) {
+      return err({
+        _tag: "OrchestratorNotReady",
+        projectName,
+        reason: `orchestrator session ${name} is missing moltzap_sender_id metadata`,
+      });
+    }
     return ok({
       session: name as AoSessionName,
-      senderId: resolveSenderId(projectName, found),
+      senderId:
+        senderId ??
+        asMoltzapSenderId(
+          normalizeEnvValue(process.env.MOLTZAP_ORCHESTRATOR_SENDER_ID) ??
+            sessionNameFor(projectName),
+        ),
       mode: found.status ? "reused" : "started",
     });
   }

--- a/start.sh
+++ b/start.sh
@@ -77,12 +77,16 @@ extract_duplicate_session() {
   grep -Eo 'duplicate session: [^[:space:]]+' "$AO_LOG_FILE" 2>/dev/null | tail -n 1 | sed -E 's/^duplicate session: //'
 }
 
-node - "$PROJECT_DIR/agent-orchestrator.yaml" "$AO_CONFIG_FILE" "$AO_PORT" "$ZAPBOT_DIR/worker/ao-plugin-agent-claude-moltzap" <<'NODE'
+NODE_PATH="$ZAPBOT_DIR/node_modules${NODE_PATH:+:$NODE_PATH}" \
+node - "$PROJECT_DIR/agent-orchestrator.yaml" "$AO_CONFIG_FILE" "$AO_PORT" "$ZAPBOT_DIR/worker/ao-plugin-agent-claude-moltzap" "$PROJECT_DIR" <<'NODE'
 const fs = require("node:fs");
+const path = require("node:path");
 const YAML = require("yaml");
-const [sourcePath, targetPath, desiredPort, pluginPath] = process.argv.slice(2);
+const [sourcePath, targetPath, desiredPort, pluginPath, projectDir] = process.argv.slice(2);
 const sourceText = fs.readFileSync(sourcePath, "utf8");
 const parsed = YAML.parse(sourceText) ?? {};
+const sourceDir = path.dirname(sourcePath);
+const normalizedProjectDir = path.resolve(projectDir);
 
 if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
   throw new Error(`Invalid AO config at ${sourcePath}`);
@@ -115,7 +119,13 @@ parsed.plugins = plugins;
 const projects = parsed.projects;
 if (projects !== null && typeof projects === "object" && !Array.isArray(projects)) {
   for (const project of Object.values(projects)) {
-    if (project !== null && typeof project === "object" && !Array.isArray(project)) {
+    if (
+      project !== null &&
+      typeof project === "object" &&
+      !Array.isArray(project) &&
+      typeof project.path === "string" &&
+      path.resolve(sourceDir, project.path) === normalizedProjectDir
+    ) {
       project.agent = "claude-moltzap";
     }
   }

--- a/start.sh
+++ b/start.sh
@@ -77,32 +77,51 @@ extract_duplicate_session() {
   grep -Eo 'duplicate session: [^[:space:]]+' "$AO_LOG_FILE" 2>/dev/null | tail -n 1 | sed -E 's/^duplicate session: //'
 }
 
-node - "$PROJECT_DIR/agent-orchestrator.yaml" "$AO_CONFIG_FILE" "$AO_PORT" <<'NODE'
+node - "$PROJECT_DIR/agent-orchestrator.yaml" "$AO_CONFIG_FILE" "$AO_PORT" "$ZAPBOT_DIR/worker/ao-plugin-agent-claude-moltzap" <<'NODE'
 const fs = require("node:fs");
-const [sourcePath, targetPath, desiredPort] = process.argv.slice(2);
-const portLine = `port: ${desiredPort}`;
-const yaml = fs.readFileSync(sourcePath, "utf8");
-const lines = yaml.split(/\r?\n/);
-let replaced = false;
+const YAML = require("yaml");
+const [sourcePath, targetPath, desiredPort, pluginPath] = process.argv.slice(2);
+const sourceText = fs.readFileSync(sourcePath, "utf8");
+const parsed = YAML.parse(sourceText) ?? {};
 
-for (let i = 0; i < lines.length; i += 1) {
-  if (/^port:[ \t]*.*$/.test(lines[i])) {
-    lines[i] = portLine;
-    replaced = true;
-    break;
+if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+  throw new Error(`Invalid AO config at ${sourcePath}`);
+}
+
+parsed.port = Number.parseInt(desiredPort, 10);
+parsed.defaults = typeof parsed.defaults === "object" && parsed.defaults !== null && !Array.isArray(parsed.defaults)
+  ? parsed.defaults
+  : {};
+parsed.defaults.runtime = typeof parsed.defaults.runtime === "string" ? parsed.defaults.runtime : "tmux";
+parsed.defaults.agent = typeof parsed.defaults.agent === "string" ? parsed.defaults.agent : "claude-code";
+parsed.defaults.workspace = typeof parsed.defaults.workspace === "string" ? parsed.defaults.workspace : "worktree";
+
+const plugins = Array.isArray(parsed.plugins) ? parsed.plugins : [];
+const hasClaudeMoltzap = plugins.some((plugin) =>
+  plugin !== null &&
+  typeof plugin === "object" &&
+  !Array.isArray(plugin) &&
+  plugin.name === "claude-moltzap",
+);
+if (!hasClaudeMoltzap) {
+  plugins.push({
+    name: "claude-moltzap",
+    source: "local",
+    path: pluginPath,
+  });
+}
+parsed.plugins = plugins;
+
+const projects = parsed.projects;
+if (projects !== null && typeof projects === "object" && !Array.isArray(projects)) {
+  for (const project of Object.values(projects)) {
+    if (project !== null && typeof project === "object" && !Array.isArray(project)) {
+      project.agent = "claude-moltzap";
+    }
   }
 }
 
-if (!replaced) {
-  if (lines[0] === "---") {
-    lines.splice(1, 0, portLine);
-  } else {
-    lines.unshift(portLine);
-  }
-}
-
-const output = lines.join("\n") + (yaml.endsWith("\n") ? "\n" : "");
-fs.writeFileSync(targetPath, output);
+fs.writeFileSync(targetPath, YAML.stringify(parsed), "utf8");
 NODE
 
 if [ -z "${ZAPBOT_API_KEY:-}" ]; then
@@ -211,6 +230,8 @@ echo "Starting webhook bridge on port ${BRIDGE_PORT}..."
 export ZAPBOT_API_KEY
 export ZAPBOT_WEBHOOK_SECRET
 export ZAPBOT_CONFIG="$PROJECT_DIR/agent-orchestrator.yaml"
+export ZAPBOT_AO_CONFIG_PATH="$AO_CONFIG_FILE"
+export AO_CONFIG_PATH="$AO_CONFIG_FILE"
 export ZAPBOT_PORT=$BRIDGE_PORT
 [ -n "${ZAPBOT_GATEWAY_URL:-}" ] && export ZAPBOT_GATEWAY_URL
 [ -n "${ZAPBOT_GATEWAY_SECRET:-}" ] && export ZAPBOT_GATEWAY_SECRET

--- a/templates/agent-orchestrator.yaml.tmpl
+++ b/templates/agent-orchestrator.yaml.tmpl
@@ -1,5 +1,15 @@
 port: 3000
 
+defaults:
+  runtime: tmux
+  agent: claude-code
+  workspace: worktree
+
+plugins:
+  - name: claude-moltzap
+    source: local
+    path: {{ZAPBOT_DIR}}/worker/ao-plugin-agent-claude-moltzap
+
 # Each key under `projects:` is a project name. The bridge builds a
 # repo -> projectName lookup from these entries so incoming webhooks
 # are routed to the correct project automatically.
@@ -11,6 +21,7 @@ projects:
   {{REPO_NAME}}:
     repo: {{REPO}}
     path: {{REPO_PATH}}
+    agent: claude-moltzap
     defaultBranch: main
     scm:
       plugin: github

--- a/test/ao-claude-channel-launch.test.ts
+++ b/test/ao-claude-channel-launch.test.ts
@@ -76,8 +76,6 @@ describe("planClaudeChannelLaunch", () => {
           2,
         ),
         extraArgs: [
-          "--mcp-config",
-          "/tmp/session/.mcp.json",
           "--dangerously-load-development-channels",
           "server:moltzap",
         ],
@@ -99,8 +97,6 @@ describe("planClaudeChannelLaunch", () => {
     expect(result._tag).toBe("Ok");
     if (result._tag !== "Ok") return;
     expect(result.value.extraArgs).toEqual([
-      "--mcp-config",
-      "/tmp/session/.mcp.json",
       "--channels",
       "plugin:moltzap@claude-plugins-official",
     ]);

--- a/test/bridge-durable-mirroring.test.ts
+++ b/test/bridge-durable-mirroring.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getIssueMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../src/github-state.ts", () => ({
+  getIssue: getIssueMock,
+}));
+
+import {
+  handleClassifiedWebhook,
+  type BridgeConfig,
+  type BridgeHandlerContext,
+  type GhAdapter,
+  type RepoRoute,
+} from "../src/bridge.ts";
+import type { ClassifiedWebhook } from "../src/gateway.ts";
+import { asMoltzapSenderId } from "../src/moltzap/types.ts";
+import type { AoControlHost } from "../src/orchestrator/runtime.ts";
+import {
+  asAoSessionName,
+  asBotUsername,
+  asCommentId,
+  asDeliveryId,
+  asIssueNumber,
+  asProjectName,
+  asRepoFullName,
+  ok,
+} from "../src/types.ts";
+import type {
+  DispatchError,
+  GhCallError,
+  InstallationToken,
+  IssueNumber,
+  RepoFullName,
+  Result,
+} from "../src/types.ts";
+
+const repo = asRepoFullName("acme/app");
+const issue = asIssueNumber(42);
+const commentId = asCommentId(7);
+const bot = asBotUsername("zapbot[bot]");
+
+interface FakeGhCalls {
+  addReaction: Array<{ repo: RepoFullName; commentId: number; reaction: string }>;
+  getUserPermission: Array<{ repo: RepoFullName; user: string }>;
+  postComment: Array<{ repo: RepoFullName; issue: IssueNumber; body: string }>;
+}
+
+function makeGh(): { gh: GhAdapter; calls: FakeGhCalls } {
+  const calls: FakeGhCalls = { addReaction: [], getUserPermission: [], postComment: [] };
+  const gh: GhAdapter = {
+    addReaction: async (nextRepo, nextCommentId, reaction) => {
+      calls.addReaction.push({ repo: nextRepo, commentId: nextCommentId, reaction });
+      return ok(undefined);
+    },
+    getUserPermission: async (nextRepo, user) => {
+      calls.getUserPermission.push({ repo: nextRepo, user });
+      return ok("write");
+    },
+    postComment: async (nextRepo, nextIssue, body) => {
+      calls.postComment.push({ repo: nextRepo, issue: nextIssue, body });
+      return ok(undefined);
+    },
+  };
+  return { gh, calls };
+}
+
+function makeAoHost(): AoControlHost {
+  return {
+    ensureStarted: async () => ok(undefined),
+    resolveReady: async () => ok({
+      session: asAoSessionName("app-orchestrator"),
+      senderId: asMoltzapSenderId("orch-1"),
+      mode: "reused",
+    }),
+    sendPrompt: async () => ok(undefined),
+  };
+}
+
+function makeConfig(): BridgeConfig {
+  const repos = new Map<RepoFullName, RepoRoute>();
+  repos.set(repo, {
+    projectName: asProjectName("app"),
+    webhookSecretEnvVar: "ZAPBOT_WEBHOOK_SECRET",
+    defaultBranch: "main",
+  });
+  return {
+    port: 3000,
+    publicUrl: "http://localhost:3000",
+    gatewayUrl: "",
+    gatewaySecret: null,
+    botUsername: bot,
+    aoConfigPath: "",
+    apiKey: "test-broker-key",
+    webhookSecret: "test-webhook-secret",
+    moltzap: { _tag: "MoltzapDisabled" },
+    repos,
+  };
+}
+
+function makeCtx(gh: GhAdapter): BridgeHandlerContext {
+  return {
+    mintToken: async () => ok("fake-token" as unknown as InstallationToken),
+    gh,
+    aoControlHost: makeAoHost(),
+    config: makeConfig(),
+  };
+}
+
+function asMention(kind: "status"): ClassifiedWebhook {
+  return {
+    kind: "mention_command",
+    repo,
+    issue,
+    commentId,
+    commentBody: "@zapbot status",
+    deliveryId: asDeliveryId("delivery-1"),
+    command: { kind },
+    triggeredBy: "carol",
+  };
+}
+
+describe("handleClassifiedWebhook durable mirroring", () => {
+  const originalToken = process.env.ZAPBOT_GITHUB_TOKEN;
+
+  beforeEach(() => {
+    getIssueMock.mockReset();
+    getIssueMock.mockResolvedValue(ok({
+      repo,
+      number: issue,
+      state: "open",
+      labels: ["zapbot-plan"],
+      assignees: ["zapbot[bot]"],
+      body: "",
+      author: "carol",
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalToken === undefined) {
+      delete process.env.ZAPBOT_GITHUB_TOKEN;
+      return;
+    }
+    process.env.ZAPBOT_GITHUB_TOKEN = originalToken;
+  });
+
+  it("mirrors the status summary to the latest linked pull request", async () => {
+    process.env.ZAPBOT_GITHUB_TOKEN = "test-token";
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes("/issues/42/events?per_page=100&page=1")) {
+        return Response.json([
+          {
+            event: "cross-referenced",
+            created_at: "2026-04-20T10:00:00Z",
+            source: { type: "pull_request", pull_request: { number: 17 } },
+          },
+          ...Array.from({ length: 99 }, (_, index) => ({
+            event: "labeled",
+            created_at: `2026-04-20T10:${String(index % 60).padStart(2, "0")}:00Z`,
+            source: null,
+          })),
+        ]);
+      }
+      if (url.includes("/issues/42/events?per_page=100&page=2")) {
+        return Response.json([
+          {
+            event: "cross-referenced",
+            created_at: "2026-04-20T11:00:00Z",
+            source: { type: "pull_request", pull_request: { number: 23 } },
+          },
+        ]);
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const { gh, calls } = makeGh();
+    const out = await handleClassifiedWebhook(asMention("status"), makeCtx(gh));
+
+    expect(out).toEqual({
+      _tag: "Ok",
+      value: { kind: "replied", command: "status" },
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(calls.postComment.map((call) => call.issue as unknown as number)).toEqual([42, 23]);
+    expect(calls.postComment[0]?.body).toBe(calls.postComment[1]?.body);
+    expect(calls.postComment[0]?.body).toContain("**Status for #42**");
+  });
+});

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -92,6 +92,21 @@ projects:
     expect(runtime.aoConfigPath).toBe(configPath);
   });
 
+  it("prefers AO_CONFIG_PATH over ZAPBOT_CONFIG for the live AO control surface", () => {
+    const projectConfigPath = join(tmpDir, "agent-orchestrator.yaml");
+    const liveAoConfigPath = join(tmpDir, "zapbot-ao-config.runtime.yaml");
+    writeFileSync(projectConfigPath, "projects:\n");
+
+    const env = expectOk(resolveRuntimeEnv({
+      ZAPBOT_API_KEY: "api-key-123",
+      ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
+      ZAPBOT_CONFIG: projectConfigPath,
+      AO_CONFIG_PATH: liveAoConfigPath,
+    }, null));
+
+    expect(env.aoConfigPath).toBe(liveAoConfigPath);
+  });
+
   it("builds runtime routes for multiple projects", () => {
     const yaml = `
 projects:

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -9,6 +9,7 @@ import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { parse as parseYaml } from "yaml";
 import type { ConfigDiskError } from "../src/config/types.js";
 import type { Result } from "../src/types.js";
 
@@ -343,6 +344,153 @@ describe("systemd integration: start.sh guard", () => {
     expect(projectIndex).toBeGreaterThanOrEqual(0);
     expect(sharedIndex).toBeLessThan(projectIndex);
   });
+
+  it("only forces claude-moltzap for the project path being bootstrapped", () => {
+    const repoRoot = path.join(__dirname, "..");
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-start-local-agent-"));
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-start-local-agent-home-"));
+    const projectDir = path.join(tempRoot, "project");
+    const otherProjectDir = path.join(tempRoot, "other-project");
+    const fakeBinDir = path.join(tempRoot, "bin");
+    const capturedAoConfigPath = path.join(tempRoot, "captured-ao-config.yaml");
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.mkdirSync(otherProjectDir, { recursive: true });
+    fs.mkdirSync(fakeBinDir, { recursive: true });
+    fs.mkdirSync(path.join(tempHome, ".zapbot"), { recursive: true });
+
+    try {
+      writeFile(
+        path.join(projectDir, "agent-orchestrator.yaml"),
+        [
+          "port: 3000",
+          "",
+          "defaults:",
+          "  runtime: tmux",
+          "  agent: claude-code",
+          "  workspace: worktree",
+          "",
+          "projects:",
+          "  local-project:",
+          "    repo: owner/local",
+          `    path: ${projectDir}`,
+          "    defaultBranch: main",
+          "    scm:",
+          "      plugin: github",
+          "      webhook:",
+          "        path: /api/webhooks/github",
+          "        secretEnvVar: ZAPBOT_WEBHOOK_SECRET",
+          "        signatureHeader: x-hub-signature-256",
+          "        eventHeader: x-github-event",
+          "  remote-project:",
+          "    repo: owner/remote",
+          `    path: ${otherProjectDir}`,
+          "    agent: claude-code",
+          "    defaultBranch: main",
+          "    scm:",
+          "      plugin: github",
+          "      webhook:",
+          "        path: /api/webhooks/github",
+          "        secretEnvVar: ZAPBOT_WEBHOOK_SECRET",
+          "        signatureHeader: x-hub-signature-256",
+          "        eventHeader: x-github-event",
+          "",
+        ].join("\n"),
+      );
+      writeFile(
+        path.join(projectDir, ".env"),
+        [
+          "ZAPBOT_API_KEY=project-api-key",
+          "ZAPBOT_WEBHOOK_SECRET=project-webhook-secret",
+          "",
+        ].join("\n"),
+      );
+
+      writeExecutable(
+        path.join(fakeBinDir, "systemctl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "ao"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "start" ]; then
+  cp "$AO_CONFIG_PATH" "$CAPTURED_AO_CONFIG"
+  echo "Dashboard starting on http://localhost:3002"
+  trap 'exit 0' TERM INT
+  sleep 2
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  echo '[]'
+  exit 0
+fi
+echo "unexpected ao args: $@" >&2
+exit 1
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "bun"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+trap 'exit 0' TERM INT
+sleep 2
+exit 0
+`,
+      );
+      writeExecutable(
+        path.join(fakeBinDir, "curl"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+url="\${!#}"
+case "$url" in
+  http://localhost:3002/api/observability)
+    echo '{"overallStatus":"ok"}'
+    exit 0
+    ;;
+  http://localhost:3000/healthz)
+    exit 0
+    ;;
+  *)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
+`,
+      );
+
+      execFileSync("bash", [path.join(repoRoot, "start.sh"), "."], {
+        cwd: projectDir,
+        env: {
+          ...process.env,
+          CAPTURED_AO_CONFIG: capturedAoConfigPath,
+          HOME: tempHome,
+          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+        },
+        encoding: "utf8",
+      });
+
+      const runtimeConfig = parseYaml(fs.readFileSync(capturedAoConfigPath, "utf8")) as {
+        defaults: { agent: string };
+        plugins: Array<{ name?: string; path?: string }>;
+        projects: Record<string, { agent?: string }>;
+      };
+
+      expect(runtimeConfig.defaults.agent).toBe("claude-code");
+      expect(runtimeConfig.plugins).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "claude-moltzap" }),
+        ]),
+      );
+      expect(runtimeConfig.projects["local-project"]?.agent).toBe("claude-moltzap");
+      expect(runtimeConfig.projects["remote-project"]?.agent).toBe("claude-code");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    }
+  }, 15000);
 
   it("retries once after a duplicate orchestrator session is reported", () => {
     const repoRoot = path.join(__dirname, "..");

--- a/test/orchestrator-control-event.test.ts
+++ b/test/orchestrator-control-event.test.ts
@@ -26,6 +26,7 @@ describe("toOrchestratorControlPrompt", () => {
     expect(result.value.body).toContain("github_comment_body:");
     expect(result.value.body).toContain("please review the open work");
     expect(result.value.body).toContain("bun run bin/ao-spawn-with-moltzap.ts");
+    expect(result.value.body).toContain("do not fall back to plain `ao spawn`");
   });
 
   it("rejects blank GitHub comments", () => {

--- a/test/orchestrator-runtime.test.ts
+++ b/test/orchestrator-runtime.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -112,6 +112,7 @@ shift || true
 case "$cmd" in
   start)
     printf 'start %s\\n' "$*" >> "$log"
+    printf 'env AO_CONFIG_PATH=%s AO_CALLER_TYPE=%s\\n' "\${AO_CONFIG_PATH:-}" "\${AO_CALLER_TYPE:-}" >> "$log"
     ;;
   status)
     printf 'status %s\\n' "$*" >> "$log"
@@ -150,6 +151,8 @@ esac
       env: {
         FAKE_AO_LOG: logFile,
         FAKE_AO_STATUS_JSON: statusJson,
+        AO_CALLER_TYPE: "orchestrator",
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
       },
       timeoutMs: 5_000,
     });
@@ -179,10 +182,157 @@ esac
 
     const log = readFileSync(logFile, "utf8");
     expect(log).toContain("start app --no-dashboard");
+    expect(log).toContain("env AO_CONFIG_PATH=/tmp/agent-orchestrator.yaml AO_CALLER_TYPE=orchestrator");
     expect(log).toContain("status --project app --json");
     expect(log).toContain("send app-orchestrator --file");
     expect(log).toContain("# GitHub control");
     expect(log).toContain("github_comment_body:");
     expect(log).toContain("@zapbot plan this");
+  });
+
+  it("holds the orchestrator as not ready when MoltZap is enabled but sender metadata is missing", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "zapbot-ao-host-"));
+    const fakeAo = join(workdir, "ao");
+    const statusJson = JSON.stringify([
+      {
+        name: "app-orchestrator",
+        role: "orchestrator",
+        status: "running",
+        metadata: {},
+      },
+    ]);
+    writeFileSync(
+      fakeAo,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "\${FAKE_AO_STATUS_JSON:-[]}"
+`,
+      "utf8",
+    );
+    chmodSync(fakeAo, 0o755);
+
+    const host = createAoCliControlHost({
+      aoBinary: fakeAo,
+      configPath: "/tmp/agent-orchestrator.yaml",
+      env: {
+        FAKE_AO_STATUS_JSON: statusJson,
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
+      },
+      timeoutMs: 5_000,
+    });
+
+    const ready = await host.resolveReady(asProjectName("app"));
+    expect(ready).toEqual({
+      _tag: "Err",
+      error: {
+        _tag: "OrchestratorNotReady",
+        projectName: "app",
+        reason: "orchestrator session app-orchestrator is missing moltzap_sender_id metadata",
+      },
+    });
+  });
+
+  it("prefers a live orchestrator over an older killed one", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "zapbot-ao-host-"));
+    const fakeAo = join(workdir, "ao");
+    const statusJson = JSON.stringify([
+      {
+        name: "app-orchestrator-1",
+        role: "orchestrator",
+        status: "killed",
+        metadata: {},
+      },
+      {
+        name: "app-orchestrator-2",
+        role: "orchestrator",
+        status: "working",
+        metadata: { moltzap_sender_id: "orch-2" },
+      },
+    ]);
+    writeFileSync(
+      fakeAo,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "\${FAKE_AO_STATUS_JSON:-[]}"
+`,
+      "utf8",
+    );
+    chmodSync(fakeAo, 0o755);
+
+    const host = createAoCliControlHost({
+      aoBinary: fakeAo,
+      configPath: "/tmp/agent-orchestrator.yaml",
+      env: {
+        FAKE_AO_STATUS_JSON: statusJson,
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
+      },
+      timeoutMs: 5_000,
+    });
+
+    const ready = await host.resolveReady(asProjectName("app"));
+    expect(ready).toEqual({
+      _tag: "Ok",
+      value: {
+        session: "app-orchestrator-2",
+        senderId: "orch-2",
+        mode: "reused",
+      },
+    });
+  });
+
+  it("reads moltzap_sender_id from the AO session file when status JSON omits it", async () => {
+    const workdir = mkdtempSync(join(tmpdir(), "zapbot-ao-host-"));
+    const homeDir = join(workdir, "home");
+    const sessionsDir = join(
+      homeDir,
+      ".agent-orchestrator",
+      "host-app",
+      "sessions",
+    );
+    const fakeAo = join(workdir, "ao");
+    const statusJson = JSON.stringify([
+      {
+        name: "app-orchestrator",
+        role: "orchestrator",
+        status: "working",
+        metadata: {},
+      },
+    ]);
+    mkdirSync(sessionsDir, { recursive: true });
+    writeFileSync(
+      join(sessionsDir, "app-orchestrator"),
+      "status=working\nmoltzap_sender_id=orch-disk\n",
+      "utf8",
+    );
+    writeFileSync(
+      fakeAo,
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "\${FAKE_AO_STATUS_JSON:-[]}"
+`,
+      "utf8",
+    );
+    chmodSync(fakeAo, 0o755);
+
+    const host = createAoCliControlHost({
+      aoBinary: fakeAo,
+      configPath: "/tmp/agent-orchestrator.yaml",
+      env: {
+        FAKE_AO_STATUS_JSON: statusJson,
+        HOME: homeDir,
+        MOLTZAP_SERVER_URL: "ws://127.0.0.1:41973",
+      },
+      timeoutMs: 5_000,
+    });
+
+    const ready = await host.resolveReady(asProjectName("app"));
+    expect(ready).toEqual({
+      _tag: "Ok",
+      value: {
+        session: "app-orchestrator",
+        senderId: "orch-disk",
+        mode: "reused",
+      },
+    });
   });
 });

--- a/test/team-init.test.ts
+++ b/test/team-init.test.ts
@@ -56,6 +56,9 @@ exit 1
     const config = readFileSync(configPath, "utf8");
     expect(config).toContain("repo: owner/example-repo");
     expect(config).toContain(`path: ${projectDir}`);
+    expect(config).toContain("name: claude-moltzap");
+    expect(config).toContain(`path: ${REPO_ROOT}/worker/ao-plugin-agent-claude-moltzap`);
+    expect(config).toContain("agent: claude-moltzap");
 
     const env = readFileSync(envPath, "utf8");
     expect(env).toContain("ZAPBOT_WEBHOOK_SECRET=");

--- a/worker/ao-plugin-agent-claude-moltzap/index.js
+++ b/worker/ao-plugin-agent-claude-moltzap/index.js
@@ -30,8 +30,6 @@ export function create() {
     getLaunchCommand(config) {
       const command = [
         builtin.getLaunchCommand(config),
-        "--mcp-config",
-        shellEscape(relativeMcpConfigPath()),
         "--dangerously-load-development-channels",
         "server:moltzap",
       ].join(" ");
@@ -119,17 +117,31 @@ function resolveBuiltinClaudePluginPath() {
 function ensureChannelMcpConfig(workspacePath) {
   const configPath = join(workspacePath, relativeMcpConfigPath());
   mkdirSync(dirname(configPath), { recursive: true });
+  const current = readJsonFile(configPath);
+  const mcpServers =
+    current !== null &&
+    typeof current === "object" &&
+    !Array.isArray(current) &&
+    current.mcpServers !== null &&
+    typeof current.mcpServers === "object" &&
+    !Array.isArray(current.mcpServers)
+      ? { ...current.mcpServers }
+      : {};
+  mcpServers.moltzap = {
+    command: "bun",
+    args: [join(workspacePath, "bin", "moltzap-claude-channel.ts")],
+    env: resolveMoltzapRuntimeEnv(),
+  };
   writeFileSync(
     configPath,
     JSON.stringify(
       {
-        mcpServers: {
-          moltzap: {
-            command: "bun",
-            args: [join(workspacePath, "bin", "moltzap-claude-channel.ts")],
-            env: resolveMoltzapRuntimeEnv(),
-          },
-        },
+        ...(current !== null &&
+        typeof current === "object" &&
+        !Array.isArray(current)
+          ? current
+          : {}),
+        mcpServers,
       },
       null,
       2,
@@ -139,7 +151,18 @@ function ensureChannelMcpConfig(workspacePath) {
 }
 
 function relativeMcpConfigPath() {
-  return ".claude/moltzap-channel.mcp.json";
+  return ".mcp.json";
+}
+
+function readJsonFile(path) {
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
 }
 
 function pickPassthroughEnv(keys) {
@@ -259,8 +282,6 @@ function shellEscape(value) {
 function wrapClaudeCommand(command) {
   const withChannel = [
     command,
-    "--mcp-config",
-    shellEscape(relativeMcpConfigPath()),
     "--dangerously-load-development-channels",
     "server:moltzap",
   ].join(" ");


### PR DESCRIPTION
## Summary
- make the live webhook bridge honor the launcher AO config path instead of the repo config path
- make the orchestrator readiness path require and recover `moltzap_sender_id` from AO session metadata on disk
- switch Claude dev-channel boot to workspace `.mcp.json`, wire generated project configs to `claude-moltzap`, and keep plain `ao spawn` fallback forbidden for this lane

## Verification
- `bun test test/config-loader.test.ts test/orchestrator-runtime.test.ts test/team-init.test.ts test/orchestrator-control-event.test.ts test/ao-claude-channel-launch.test.ts`
- `bun run build`
- `bun run lint` (warnings only, `0 errors`)
- live local spike on issue #239 proved:
  - bridge replay dispatched into `zap-orchestrator-2`
  - `zap-1` spawned through `bin/ao-spawn-with-moltzap.ts` with MoltZap metadata
  - worker Claude session used `send_direct_message` successfully
  - orchestrator Claude session used `send_direct_message` successfully
  - worker Claude session received `ORCH_TO_WORKER_TOOL_20260421T0423Z` live over `notifications/claude/channel`

Closes #240