### PR TITLE
fix: use service-backed moltzap channel delivery

### DIFF
--- a/bin/moltzap-claude-channel.ts
+++ b/bin/moltzap-claude-channel.ts
@@ -3,9 +3,8 @@
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import process from "node:process";
-import type { EventFrame, Message as MoltzapMessage } from "@moltzap/protocol";
-import { EventNames } from "@moltzap/protocol";
-import { MoltZapService, MoltZapWsClient } from "@moltzap/client";
+import type { Message as MoltzapMessage } from "@moltzap/protocol";
+import { MoltZapService } from "@moltzap/client";
 import { toClaudeChannelNotification } from "../src/claude-channel/event.ts";
 import {
   bootClaudeChannelServer,
@@ -82,7 +81,6 @@ const service = new MoltZapService({
 
 let channelStop: (() => Promise<void>) | null = null;
 let unreadPoller: ReturnType<typeof setInterval> | null = null;
-let eventClient: MoltZapWsClient | null = null;
 
 try {
   const hello = await service.connect();
@@ -141,43 +139,32 @@ try {
     fatal(channel.error.cause);
   }
 
-  eventClient = new MoltZapWsClient({
-    serverUrl: bootstrap.value.serverUrl,
-    agentKey: bootstrap.value.apiKey,
-    onEvent: (frame) => {
-      const message = messageFromEventFrame(frame);
-      if (message === null) {
-        return;
-      }
-      void emitClaudeNotification({
-        channel: channel.value,
-        message,
-        localSenderId,
-        deliveredMessageIds,
-      });
-    },
-    onDisconnect: () => {
-      console.error("[moltzap-channel] disconnected");
-    },
-    onReconnect: () => {
-      console.error("[moltzap-channel] reconnected");
-      void sweepUnreadConversations({
-        service,
-        channel: channel.value,
-        localSenderId,
-        deliveredMessageIds,
-      });
-    },
+  service.on("message", (message) => {
+    void emitClaudeNotification({
+      channel: channel.value,
+      message,
+      localSenderId,
+      deliveredMessageIds,
+    });
   });
-  await eventClient.connect();
+  service.on("disconnect", () => {
+    console.error("[moltzap-channel] disconnected");
+  });
+  service.on("reconnect", () => {
+    console.error("[moltzap-channel] reconnected");
+    void sweepUnreadConversations({
+      service,
+      channel: channel.value,
+      localSenderId,
+      deliveredMessageIds,
+    });
+  });
 
   channelStop = async () => {
     if (unreadPoller !== null) {
       clearInterval(unreadPoller);
       unreadPoller = null;
     }
-    eventClient?.close();
-    eventClient = null;
     await channel.value.stop();
     service.close();
   };
@@ -537,20 +524,6 @@ function trimEnv(value: string | undefined): string | null {
   }
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
-}
-
-function messageFromEventFrame(frame: EventFrame): MoltzapMessageLike | null {
-  if (frame.event !== EventNames.MessageReceived) {
-    return null;
-  }
-  if (typeof frame.data !== "object" || frame.data === null) {
-    return null;
-  }
-  const nested = asMessageLike((frame.data as { readonly message?: unknown }).message);
-  if (nested !== null) {
-    return nested;
-  }
-  return asMessageLike(frame.data);
 }
 
 function stringifyCause(cause: unknown): string {


### PR DESCRIPTION
## Summary
- replace the extra raw `MoltZapWsClient` event connection in `bin/moltzap-claude-channel.ts`
- consume inbound delivery from the already-connected `MoltZapService` event stream instead
- keep the existing unread sweep recovery path for missed realtime delivery

## Why
The live worker->orchestrator failure reproduced only on the `MoltZapService` + separate raw `MoltZapWsClient` topology used by the Claude channel shim. A pure `MoltZapService` topology delivered both directions. This change puts the runtime on the working path.

## Live proof
- worker -> orchestrator token: `WORKER_TO_ORCH_PATCHED_20260421T1751Z`
- orchestrator received it as a real Claude channel event
- orchestrator replied `ORCH_ACK_WORKER_PATCHED_20260421T1751Z`
- worker received that reply as a real Claude channel event

Receipts:
- orchestrator log: `/home/tapanc/.cache/claude-cli-nodejs/-home-tapanc--worktrees-zapbot-zap-orchestrator-3/mcp-logs-moltzap/2026-04-21T17-51-02-433Z.jsonl`
- worker log: `/home/tapanc/.cache/claude-cli-nodejs/-home-tapanc--worktrees-zapbot-zap-3/mcp-logs-moltzap/2026-04-21T17-47-50-631Z.jsonl`

## Verification
- `bun run build`
- `bun test test/config-loader.test.ts test/orchestrator-runtime.test.ts test/team-init.test.ts test/orchestrator-control-event.test.ts test/ao-claude-channel-launch.test.ts`
- `bun run lint` with warnings only, `0 errors`
