### PR TITLE
[impl-junior] fix bridge handler env isolation

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -32,10 +32,8 @@ import {
 } from "./types.ts";
 import type {
   BotUsername,
-  DispatchError,
   GhCallError,
   HandleOutcome,
-  InstallationToken,
   IssueNumber,
   ProjectName,
   RepoFullName,
@@ -105,7 +103,7 @@ export interface RunningBridge {
 }
 
 export interface BridgeHandlerContext {
-  readonly mintToken: () => Promise<Result<InstallationToken, DispatchError>>;
+  readonly mintToken: () => Promise<MintedInstallationToken | null>;
   readonly gh: GhAdapter;
   readonly aoControlHost: AoControlHost;
   readonly config: BridgeConfig;
@@ -340,22 +338,7 @@ export function buildFetchHandler(
     // Installation token broker (paired with safer-by-default#50).
     if (pathname === "/api/tokens/installation" && req.method === "GET") {
       const result: InstallationTokenStatus = await handleInstallationTokenRequest(req, {
-        mintToken: async () => {
-          const minted = await ctx.mintToken();
-          if (minted._tag === "Ok") {
-            return {
-              token: minted.value as unknown as MintedInstallationToken["token"],
-              expiresAt: new Date().toISOString(),
-            };
-          }
-          if (
-            minted.error._tag === "TokenMintFailed" &&
-            minted.error.cause === "no installation token available"
-          ) {
-            return null;
-          }
-          throw new Error(minted.error.cause);
-        },
+        mintToken: ctx.mintToken,
         apiKey: current.apiKey,
       });
       const clientIp = req.headers.get("x-forwarded-for") ?? "local";
@@ -449,17 +432,10 @@ export function buildFetchHandler(
 
 /**
  * Default `mintToken` implementation — delegates to the v1 singleton
- * `getInstallationToken` and maps `null`/throw into `DispatchError`.
+ * `getInstallationToken` and preserves the broker's minted token contract.
  */
-export async function defaultMintToken(): Promise<Result<InstallationToken, DispatchError>> {
-  try {
-    const t = await getInstallationToken();
-    if (!t) return err({ _tag: "TokenMintFailed", cause: "no installation token available" });
-    return ok(t.token as unknown as InstallationToken);
-  } catch (e) {
-    const cause = e instanceof Error ? e.message : String(e);
-    return err({ _tag: "TokenMintFailed", cause });
-  }
+export async function defaultMintToken(): Promise<MintedInstallationToken | null> {
+  return await getInstallationToken();
 }
 
 /**

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -46,6 +46,7 @@ import { createLogger } from "./logger.ts";
 import { errorResponse } from "./http/error-response.ts";
 import {
   handleInstallationTokenRequest,
+  type MintedInstallationToken,
   type InstallationTokenStatus,
 } from "./http/routes/installation-token.ts";
 
@@ -337,10 +338,24 @@ export function buildFetchHandler(
     }
 
     // Installation token broker (paired with safer-by-default#50).
-    // Thin wrapper around getInstallationToken() — no new mint path.
     if (pathname === "/api/tokens/installation" && req.method === "GET") {
       const result: InstallationTokenStatus = await handleInstallationTokenRequest(req, {
-        mintToken: getInstallationToken,
+        mintToken: async () => {
+          const minted = await ctx.mintToken();
+          if (minted._tag === "Ok") {
+            return {
+              token: minted.value as unknown as MintedInstallationToken["token"],
+              expiresAt: new Date().toISOString(),
+            };
+          }
+          if (
+            minted.error._tag === "TokenMintFailed" &&
+            minted.error.cause === "no installation token available"
+          ) {
+            return null;
+          }
+          throw new Error(minted.error.cause);
+        },
         apiKey: current.apiKey,
       });
       const clientIp = req.headers.get("x-forwarded-for") ?? "local";
@@ -543,12 +558,6 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
   return running;
 }
 
-function resolveSecret(repo: RepoFullName, cfg: BridgeConfig): string | null {
-  const route = cfg.repos.get(repo);
-  if (!route) {
-    return cfg.webhookSecret;
-  }
-  const perRepo = process.env[route.webhookSecretEnvVar];
-  if (perRepo) return perRepo;
+function resolveSecret(_repo: RepoFullName, cfg: BridgeConfig): string | null {
   return cfg.webhookSecret;
 }

--- a/test/bridge.http.test.ts
+++ b/test/bridge.http.test.ts
@@ -11,7 +11,6 @@ import {
   asBotUsername,
   asProjectName,
   asRepoFullName,
-  err,
   ok,
 } from "../src/types.ts";
 import { asMoltzapSenderId } from "../src/moltzap/types.ts";
@@ -86,7 +85,7 @@ function fakeAo(): AoControlHost {
 
 function makeHandler(cfg: BridgeConfig = makeConfig()): (req: Request) => Promise<Response> {
   const ctx: BridgeHandlerContext = {
-    mintToken: async () => err({ _tag: "TokenMintFailed", cause: "no installation token available" }),
+    mintToken: async () => null,
     gh: fakeGh(),
     aoControlHost: fakeAo(),
     config: cfg,
@@ -320,12 +319,27 @@ describe("bridge fetch handler — installation token broker", () => {
     const saved = process.env.ZAPBOT_API_KEY;
     delete process.env.ZAPBOT_API_KEY;
     try {
-      const h = makeHandler();
+      const minted = {
+        token: "ghs_mockinstallationtoken",
+        expiresAt: "2026-04-18T03:59:59Z",
+      };
+      const h = buildFetchHandler(
+        () => makeConfig(),
+        {
+          mintToken: async () => minted,
+          gh: fakeGh(),
+          aoControlHost: fakeAo(),
+          config: makeConfig(),
+        }
+      );
       const r = await get(h, "/api/tokens/installation", {
         authorization: `Bearer ${API_KEY}`,
       });
-      // 409 proves Bearer passed and the handler stayed on the injected seam.
-      expect(r.status).toBe(409);
+      expect(r.status).toBe(200);
+      expect(await r.json()).toEqual({
+        token: minted.token,
+        expires_at: minted.expiresAt,
+      });
     } finally {
       if (savedAppId !== undefined) process.env.GITHUB_APP_ID = savedAppId;
       else delete process.env.GITHUB_APP_ID;

--- a/test/bridge.http.test.ts
+++ b/test/bridge.http.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
   buildFetchHandler,
-  defaultMintToken,
   type BridgeConfig,
   type BridgeHandlerContext,
   type GhAdapter,
@@ -12,6 +11,7 @@ import {
   asBotUsername,
   asProjectName,
   asRepoFullName,
+  err,
   ok,
 } from "../src/types.ts";
 import { asMoltzapSenderId } from "../src/moltzap/types.ts";
@@ -86,7 +86,7 @@ function fakeAo(): AoControlHost {
 
 function makeHandler(cfg: BridgeConfig = makeConfig()): (req: Request) => Promise<Response> {
   const ctx: BridgeHandlerContext = {
-    mintToken: defaultMintToken,
+    mintToken: async () => err({ _tag: "TokenMintFailed", cause: "no installation token available" }),
     gh: fakeGh(),
     aoControlHost: fakeAo(),
     config: cfg,
@@ -259,6 +259,30 @@ describe("bridge fetch handler — webhook route", () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.outcome.kind).toBe("ignored");
   });
+
+  it("ignores ambient webhook secret env and uses BridgeConfig", async () => {
+    const saved = process.env.ZAPBOT_WEBHOOK_SECRET;
+    process.env.ZAPBOT_WEBHOOK_SECRET = "wrong-wrong-wrong-wrong-wrong-wrong-wrong-wrong";
+    try {
+      const h = makeHandler();
+      const body = JSON.stringify({
+        action: "opened",
+        repository: { full_name: "acme/app" },
+        sender: { login: "alice" },
+        pull_request: { number: 1 },
+      });
+      const sig = await signPayload(body, WEBHOOK_SECRET);
+      const r = await post(h, "/api/webhooks/github", body, {
+        "x-hub-signature-256": sig,
+        "x-github-event": "pull_request",
+        "x-github-delivery": "d-1",
+      });
+      expect(r.status).toBe(200);
+    } finally {
+      if (saved !== undefined) process.env.ZAPBOT_WEBHOOK_SECRET = saved;
+      else delete process.env.ZAPBOT_WEBHOOK_SECRET;
+    }
+  });
 });
 
 describe("bridge fetch handler — installation token broker", () => {
@@ -286,7 +310,13 @@ describe("bridge fetch handler — installation token broker", () => {
     expect((await r.json()).error).toBe("app_not_configured");
   });
 
-  it("reads apiKey from BridgeConfig, not process.env (no env-leak)", async () => {
+  it("uses the injected mintToken seam even when GitHub App env is present", async () => {
+    const savedAppId = process.env.GITHUB_APP_ID;
+    const savedInstallationId = process.env.GITHUB_APP_INSTALLATION_ID;
+    const savedPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+    process.env.GITHUB_APP_ID = "123456";
+    process.env.GITHUB_APP_INSTALLATION_ID = "654321";
+    process.env.GITHUB_APP_PRIVATE_KEY = "-----BEGIN PRIVATE KEY----- fake";
     const saved = process.env.ZAPBOT_API_KEY;
     delete process.env.ZAPBOT_API_KEY;
     try {
@@ -294,10 +324,17 @@ describe("bridge fetch handler — installation token broker", () => {
       const r = await get(h, "/api/tokens/installation", {
         authorization: `Bearer ${API_KEY}`,
       });
-      // 409 proves Bearer passed. If the bridge read from process.env we'd see 401.
+      // 409 proves Bearer passed and the handler stayed on the injected seam.
       expect(r.status).toBe(409);
     } finally {
+      if (savedAppId !== undefined) process.env.GITHUB_APP_ID = savedAppId;
+      else delete process.env.GITHUB_APP_ID;
+      if (savedInstallationId !== undefined) process.env.GITHUB_APP_INSTALLATION_ID = savedInstallationId;
+      else delete process.env.GITHUB_APP_INSTALLATION_ID;
+      if (savedPrivateKey !== undefined) process.env.GITHUB_APP_PRIVATE_KEY = savedPrivateKey;
+      else delete process.env.GITHUB_APP_PRIVATE_KEY;
       if (saved !== undefined) process.env.ZAPBOT_API_KEY = saved;
+      else delete process.env.ZAPBOT_API_KEY;
     }
   });
 });

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -24,6 +24,7 @@ import type {
   GhCallError,
   IssueNumber,
   RepoFullName,
+  Result,
 } from "../src/types.ts";
 import type { MintedInstallationToken } from "../src/http/routes/installation-token.ts";
 

--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -21,13 +21,11 @@ import {
   ok,
 } from "../src/types.ts";
 import type {
-  DispatchError,
   GhCallError,
-  InstallationToken,
   IssueNumber,
   RepoFullName,
-  Result,
 } from "../src/types.ts";
+import type { MintedInstallationToken } from "../src/http/routes/installation-token.ts";
 
 const repo = asRepoFullName("acme/app");
 const issue = asIssueNumber(42);
@@ -121,13 +119,13 @@ function makeConfig(withRoute = true): BridgeConfig {
 function makeCtx(
   gh: GhAdapter,
   opts: {
-    mintToken?: () => Promise<Result<InstallationToken, DispatchError>>;
+    mintToken?: () => Promise<MintedInstallationToken | null>;
     withRoute?: boolean;
     aoControlHost?: AoControlHost;
   } = {}
 ): BridgeHandlerContext {
   return {
-    mintToken: opts.mintToken ?? (async () => ok("fake-token" as unknown as InstallationToken)),
+    mintToken: opts.mintToken ?? (async () => null),
     gh,
     aoControlHost: opts.aoControlHost ?? makeAoHost().host,
     config: makeConfig(opts.withRoute ?? true),


### PR DESCRIPTION
Scope:\n- Route /api/tokens/installation through the injected mintToken seam instead of calling the GitHub client singleton directly.\n- Make webhook secret resolution pure by using BridgeConfig only.\n- Update bridge HTTP tests to cover ambient ZAPBOT_WEBHOOK_SECRET and GITHUB_APP_* env leakage.\n\nValidation:\n- npm test -- --run test/bridge.http.test.ts