### PR TITLE
[arch] managed session lifecycle path

### DIFF
--- a/src/lifecycle/commands.ts
+++ b/src/lifecycle/commands.ts
@@ -1,0 +1,35 @@
+import type {
+  LifecycleCommandError,
+  LifecycleCommandSpec,
+  LifecycleDocsTouchpoint,
+} from "./contracts.ts";
+import type { Result } from "../types.ts";
+
+export interface LifecycleCommandInput {
+  readonly argv: ReadonlyArray<string>;
+}
+
+export interface LifecycleCommand {
+  readonly name: LifecycleCommandSpec["name"];
+  readonly args: ReadonlyArray<string>;
+}
+
+export function parseLifecycleCommand(
+  input: LifecycleCommandInput,
+): Result<LifecycleCommand, LifecycleCommandError> {
+  throw new Error("not implemented");
+}
+
+export function renderLifecycleHelp(
+  commands: ReadonlyArray<LifecycleCommandSpec>,
+): string {
+  throw new Error("not implemented");
+}
+
+export function listLifecycleCommands(): ReadonlyArray<LifecycleCommandSpec> {
+  throw new Error("not implemented");
+}
+
+export function lifecycleDocsTouchpoints(): ReadonlyArray<LifecycleDocsTouchpoint> {
+  throw new Error("not implemented");
+}

--- a/src/lifecycle/contracts.ts
+++ b/src/lifecycle/contracts.ts
@@ -1,0 +1,133 @@
+import type { AoSessionName, ProjectName, Result } from "../types.ts";
+
+export type ManagedSessionId = string & { readonly __brand: "ManagedSessionId" };
+export type ManagedSessionScope = "orchestrator" | "worker" | "bridge";
+export type ManagedSessionPhase = "claimed" | "active" | "draining" | "stopped" | "orphaned";
+
+export interface ManagedSessionTag {
+  readonly managed: true;
+  readonly owner: "zapbot";
+  readonly projectName: ProjectName;
+  readonly sessionName: AoSessionName;
+  readonly scope: ManagedSessionScope;
+  readonly origin: "start.sh" | "ao-spawn-with-moltzap.ts" | "webhook-bridge.ts";
+  readonly claimedAtMs: number;
+}
+
+export interface ManagedSessionRecord {
+  readonly id: ManagedSessionId;
+  readonly tag: ManagedSessionTag;
+  readonly tmuxName: string | null;
+  readonly worktree: string | null;
+  readonly processId: number | null;
+  readonly phase: ManagedSessionPhase;
+  readonly lastHeartbeatAtMs: number | null;
+}
+
+export interface ManagedSessionClaimRequest {
+  readonly record: ManagedSessionRecord;
+}
+
+export interface ManagedSessionReleaseRequest {
+  readonly sessionId: ManagedSessionId;
+  readonly projectName: ProjectName;
+}
+
+export interface ManagedSessionRegistry {
+  readonly put: (
+    record: ManagedSessionRecord,
+  ) => Promise<Result<ManagedSessionRecord, ManagedSessionRegistryError>>;
+  readonly get: (
+    sessionId: ManagedSessionId,
+  ) => Promise<Result<ManagedSessionRecord | null, ManagedSessionRegistryError>>;
+  readonly listByProject: (
+    projectName: ProjectName,
+  ) => Promise<Result<ReadonlyArray<ManagedSessionRecord>, ManagedSessionRegistryError>>;
+  readonly delete: (
+    sessionId: ManagedSessionId,
+  ) => Promise<Result<void, ManagedSessionRegistryError>>;
+}
+
+export interface ManagedSessionRuntime {
+  readonly start: (
+    request: ManagedSessionClaimRequest,
+  ) => Promise<Result<ManagedSessionRecord, ManagedSessionRuntimeError>>;
+  readonly stop: (
+    record: ManagedSessionRecord,
+  ) => Promise<Result<void, ManagedSessionRuntimeError>>;
+  readonly inspect: (
+    sessionId: ManagedSessionId,
+  ) => Promise<Result<ManagedSessionRecord | null, ManagedSessionRuntimeError>>;
+  readonly list: (
+    projectName: ProjectName,
+  ) => Promise<Result<ReadonlyArray<ManagedSessionRecord>, ManagedSessionRuntimeError>>;
+}
+
+export interface ManagedSessionGcPolicy {
+  readonly projectName: ProjectName;
+  readonly pruneStopped: boolean;
+  readonly pruneOrphaned: boolean;
+  readonly maxIdleMs: number;
+}
+
+export interface ManagedSessionGcPlan {
+  readonly projectName: ProjectName;
+  readonly candidates: ReadonlyArray<ManagedSessionRecord>;
+  readonly stale: ReadonlyArray<ManagedSessionRecord>;
+}
+
+export interface ManagedSessionGcReport {
+  readonly projectName: ProjectName;
+  readonly stopped: ReadonlyArray<ManagedSessionId>;
+  readonly retained: ReadonlyArray<ManagedSessionId>;
+}
+
+export interface ManagedSessionLifecycleReport {
+  readonly projectName: ProjectName;
+  readonly sessionIds: ReadonlyArray<ManagedSessionId>;
+}
+
+export type ManagedSessionRegistryError =
+  | { readonly _tag: "ManagedSessionRegistryUnavailable"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionRecordCorrupt"; readonly sessionId: ManagedSessionId; readonly reason: string }
+  | { readonly _tag: "ManagedSessionAlreadyOwned"; readonly sessionId: ManagedSessionId }
+  | { readonly _tag: "ManagedSessionNotFound"; readonly sessionId: ManagedSessionId };
+
+export type ManagedSessionRuntimeError =
+  | { readonly _tag: "ManagedSessionStartFailed"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionStopFailed"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionInspectFailed"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionListFailed"; readonly cause: string };
+
+export type ManagedSessionLifecycleError =
+  | { readonly _tag: "ManagedSessionRegistryFailed"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionRuntimeFailed"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionNotOwned"; readonly sessionId: ManagedSessionId }
+  | { readonly _tag: "ManagedSessionNotFound"; readonly sessionId: ManagedSessionId }
+  | { readonly _tag: "ManagedSessionStopRejected"; readonly sessionId: ManagedSessionId; readonly reason: string };
+
+export type ManagedSessionGcError =
+  | { readonly _tag: "ManagedSessionGcRegistryFailed"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionGcRuntimeFailed"; readonly cause: string }
+  | { readonly _tag: "ManagedSessionGcPolicyRejected"; readonly reason: string };
+
+export type LifecycleCommandName = "status" | "stop" | "gc" | "reconcile" | "help";
+
+export interface LifecycleCommandSpec {
+  readonly name: LifecycleCommandName;
+  readonly summary: string;
+  readonly managedOnly: boolean;
+  readonly docAnchor: "README.md" | "ARCHITECTURE.md";
+}
+
+export interface LifecycleDocsTouchpoint {
+  readonly file: "README.md" | "ARCHITECTURE.md";
+  readonly section: string;
+  readonly command: LifecycleCommandName;
+  readonly note: string;
+}
+
+export type LifecycleCommandError =
+  | { readonly _tag: "LifecycleCommandUnknown"; readonly input: string }
+  | { readonly _tag: "LifecycleCommandMissingSession"; readonly command: LifecycleCommandName }
+  | { readonly _tag: "LifecycleCommandInvalidTarget"; readonly input: string; readonly reason: string };

--- a/src/lifecycle/controller.ts
+++ b/src/lifecycle/controller.ts
@@ -1,0 +1,63 @@
+import type { Result } from "../types.ts";
+import type {
+  ManagedSessionClaimRequest,
+  ManagedSessionLifecycleError,
+  ManagedSessionLifecycleReport,
+  ManagedSessionRecord,
+  ManagedSessionRegistry,
+  ManagedSessionRuntime,
+} from "./contracts.ts";
+
+export interface ManagedSessionStartRequest extends ManagedSessionClaimRequest {
+  readonly registry: ManagedSessionRegistry;
+  readonly runtime: ManagedSessionRuntime;
+}
+
+export interface ManagedSessionStopRequest {
+  readonly sessionId: ManagedSessionRecord["id"];
+  readonly registry: ManagedSessionRegistry;
+  readonly runtime: ManagedSessionRuntime;
+}
+
+export interface ManagedSessionReconcileRequest {
+  readonly projectName: ManagedSessionRecord["tag"]["projectName"];
+  readonly registry: ManagedSessionRegistry;
+  readonly runtime: ManagedSessionRuntime;
+}
+
+export interface ManagedSessionController {
+  readonly start: (
+    request: ManagedSessionStartRequest,
+  ) => Promise<Result<ManagedSessionRecord, ManagedSessionLifecycleError>>;
+  readonly stop: (
+    request: ManagedSessionStopRequest,
+  ) => Promise<Result<void, ManagedSessionLifecycleError>>;
+  readonly reconcile: (
+    request: ManagedSessionReconcileRequest,
+  ) => Promise<Result<ManagedSessionLifecycleReport, ManagedSessionLifecycleError>>;
+  readonly shutdown: (
+    request: ManagedSessionReconcileRequest,
+  ) => Promise<Result<ManagedSessionLifecycleReport, ManagedSessionLifecycleError>>;
+}
+
+export function createManagedSessionController(): ManagedSessionController {
+  throw new Error("not implemented");
+}
+
+export function startManagedSession(
+  request: ManagedSessionStartRequest,
+): Promise<Result<ManagedSessionRecord, ManagedSessionLifecycleError>> {
+  throw new Error("not implemented");
+}
+
+export function stopManagedSession(
+  request: ManagedSessionStopRequest,
+): Promise<Result<void, ManagedSessionLifecycleError>> {
+  throw new Error("not implemented");
+}
+
+export function reconcileManagedSessions(
+  request: ManagedSessionReconcileRequest,
+): Promise<Result<ManagedSessionLifecycleReport, ManagedSessionLifecycleError>> {
+  throw new Error("not implemented");
+}

--- a/src/lifecycle/gc.ts
+++ b/src/lifecycle/gc.ts
@@ -1,0 +1,27 @@
+import type { Result } from "../types.ts";
+import type {
+  ManagedSessionGcError,
+  ManagedSessionGcPlan,
+  ManagedSessionGcPolicy,
+  ManagedSessionGcReport,
+  ManagedSessionRegistry,
+  ManagedSessionRuntime,
+} from "./contracts.ts";
+
+export interface ManagedSessionGcRequest {
+  readonly policy: ManagedSessionGcPolicy;
+  readonly registry: ManagedSessionRegistry;
+  readonly runtime: ManagedSessionRuntime;
+}
+
+export function planManagedSessionGc(
+  request: ManagedSessionGcRequest,
+): Promise<Result<ManagedSessionGcPlan, ManagedSessionGcError>> {
+  throw new Error("not implemented");
+}
+
+export function runManagedSessionGc(
+  request: ManagedSessionGcRequest,
+): Promise<Result<ManagedSessionGcReport, ManagedSessionGcError>> {
+  throw new Error("not implemented");
+}

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -1,0 +1,4 @@
+export * from "./contracts.ts";
+export * from "./controller.ts";
+export * from "./gc.ts";
+export * from "./commands.ts";


### PR DESCRIPTION
Architecture only. Not for merge. Design doc: https://github.com/chughtapan/zapbot/issues/256#issuecomment-4293452421.

Stubs: 5 lifecycle files.
Every body is `throw new Error("not implemented")`.