### PR TITLE
[impl-senior] remove static MoltZap provisioning path

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,12 @@ Zapbot does not splice raw comment text into a shell command.
 
 ## MoltZap
 
-Zapbot can provision MoltZap credentials for orchestrator and worker sessions.
-
-Supported modes:
+Zapbot provisions MoltZap credentials for orchestrator and worker sessions by
+registering fresh runtime identities.
 
 | Env | Meaning |
 |---|---|
-| `ZAPBOT_MOLTZAP_SERVER_URL` + `ZAPBOT_MOLTZAP_REGISTRATION_SECRET` | register a fresh MoltZap agent for each spawned worker; this takes precedence over a static API key if both are set |
-| `ZAPBOT_MOLTZAP_SERVER_URL` + `ZAPBOT_MOLTZAP_API_KEY` | pass through a pre-provisioned MoltZap agent key to the runtime |
+| `ZAPBOT_MOLTZAP_SERVER_URL` + `ZAPBOT_MOLTZAP_REGISTRATION_SECRET` | register a fresh MoltZap agent for each spawned worker and orchestrator session |
 | `ZAPBOT_MOLTZAP_ALLOWED_SENDERS` | optional comma-separated sender allowlist forwarded to the session runtime |
 
 If `ZAPBOT_MOLTZAP_SERVER_URL` is unset, zapbot runs without MoltZap.
@@ -182,7 +180,6 @@ GITHUB_APP_PRIVATE_KEY=/path/to/app.pem
 
 # Optional: MoltZap
 # ZAPBOT_MOLTZAP_SERVER_URL=wss://moltzap.example/ws
-# ZAPBOT_MOLTZAP_API_KEY=...
 # ZAPBOT_MOLTZAP_REGISTRATION_SECRET=...
 # ZAPBOT_MOLTZAP_ALLOWED_SENDERS=agent-a,agent-b
 ```
@@ -361,7 +358,7 @@ Demo env checklist:
 | `ZAPBOT_GATEWAY_URL` | yes for `github-demo` | `https://gateway.example.com` | your public gateway/proxy URL | startup stays `local-only` or demo cannot ingress |
 | `ZAPBOT_BRIDGE_URL` | yes for `github-demo` | `https://bridge.example.com` | the public URL that reaches this bridge host | startup exits `missing` or `unreachable` |
 | `ZAPBOT_MOLTZAP_SERVER_URL` | yes for this demo | `wss://moltzap.example/ws` | your MoltZap server | workers come up without live MoltZap coordination |
-| `ZAPBOT_MOLTZAP_API_KEY` or `ZAPBOT_MOLTZAP_REGISTRATION_SECRET` | yes for this demo | `mz_...` or shared registration secret | your MoltZap deployment | worker provisioning fails |
+| `ZAPBOT_MOLTZAP_REGISTRATION_SECRET` | yes for this demo | shared registration secret | your MoltZap deployment | worker provisioning fails |
 
 ```bash
 "$ZAPBOT_DIR/start.sh" .

--- a/bin/ao-spawn-with-moltzap.ts
+++ b/bin/ao-spawn-with-moltzap.ts
@@ -15,13 +15,6 @@ import {
 } from "../src/lifecycle/contracts.ts";
 import { asAoSessionName, asProjectName } from "../src/types.ts";
 
-const MOLTZAP_ENV_FALLBACKS = {
-  MOLTZAP_SERVER_URL: "ZAPBOT_MOLTZAP_SERVER_URL",
-  MOLTZAP_API_KEY: "ZAPBOT_MOLTZAP_API_KEY",
-  MOLTZAP_ALLOWED_SENDERS: "ZAPBOT_MOLTZAP_ALLOWED_SENDERS",
-  MOLTZAP_REGISTRATION_SECRET: "ZAPBOT_MOLTZAP_REGISTRATION_SECRET",
-} as const;
-
 interface WorkerSessionMetadata {
   readonly worktree: string;
   readonly tmuxName: string;
@@ -519,24 +512,9 @@ function resolveRuntimeEnv(
     return direct;
   }
 
-  const fallbackKey = MOLTZAP_ENV_FALLBACKS[name as keyof typeof MOLTZAP_ENV_FALLBACKS];
-  if (fallbackKey !== undefined) {
-    const mappedProcessValue = trimEnv(process.env[fallbackKey]);
-    if (mappedProcessValue !== null) {
-      return mappedProcessValue;
-    }
-  }
-
   const fileValue = trimEnv(moltzapEnvFile[name]);
   if (fileValue !== null) {
     return fileValue;
-  }
-
-  if (fallbackKey !== undefined) {
-    const mappedFileValue = trimEnv(moltzapEnvFile[fallbackKey]);
-    if (mappedFileValue !== null) {
-      return mappedFileValue;
-    }
   }
 
   return null;

--- a/src/moltzap/runtime.ts
+++ b/src/moltzap/runtime.ts
@@ -30,13 +30,6 @@ export interface MoltzapSpawnContext {
 export type MoltzapRuntimeConfig =
   | { readonly _tag: "MoltzapDisabled" }
   | {
-      readonly _tag: "MoltzapStatic";
-      readonly serverUrl: string;
-      readonly apiKey: string;
-      readonly allowlistCsv: string | null;
-      readonly allowlist: SenderAllowlist;
-    }
-  | {
       readonly _tag: "MoltzapRegistration";
       readonly serverUrl: string;
       readonly registrationSecret: string;
@@ -58,13 +51,12 @@ export function loadMoltzapRuntimeConfig(
   env: Record<string, string | undefined>,
 ): Result<MoltzapRuntimeConfig, MoltzapConfigError> {
   const serverUrl = normalizeEnvVar(env.ZAPBOT_MOLTZAP_SERVER_URL);
-  const apiKey = normalizeEnvVar(env.ZAPBOT_MOLTZAP_API_KEY);
   const registrationSecret = normalizeEnvVar(env.ZAPBOT_MOLTZAP_REGISTRATION_SECRET);
   const allowlistCsv = normalizeCsv(env.ZAPBOT_MOLTZAP_ALLOWED_SENDERS);
   const allowlist = fromSenderIds(parseAllowlist(allowlistCsv));
 
   if (serverUrl === null) {
-    if (apiKey !== null || registrationSecret !== null) {
+    if (registrationSecret !== null) {
       return err({
         _tag: "MoltzapConfigInvalid",
         reason: "ZAPBOT_MOLTZAP_SERVER_URL is required when MoltZap auth is configured.",
@@ -83,20 +75,10 @@ export function loadMoltzapRuntimeConfig(
     });
   }
 
-  if (apiKey !== null) {
-    return ok({
-      _tag: "MoltzapStatic",
-      serverUrl,
-      apiKey,
-      allowlistCsv,
-      allowlist,
-    });
-  }
-
   return err({
     _tag: "MoltzapConfigInvalid",
     reason:
-      "Set either ZAPBOT_MOLTZAP_API_KEY or ZAPBOT_MOLTZAP_REGISTRATION_SECRET when ZAPBOT_MOLTZAP_SERVER_URL is configured.",
+      "Set ZAPBOT_MOLTZAP_REGISTRATION_SECRET when ZAPBOT_MOLTZAP_SERVER_URL is configured.",
   });
 }
 
@@ -107,8 +89,6 @@ export async function buildMoltzapSpawnEnv(
   switch (config._tag) {
     case "MoltzapDisabled":
       return ok({});
-    case "MoltzapStatic":
-      return ok(toSpawnEnv(config.serverUrl, config.apiKey, config.allowlistCsv));
     case "MoltzapRegistration":
       return registerSessionAgent(config, ctx);
     default:
@@ -127,14 +107,6 @@ export function buildMoltzapProcessEnv(
   switch (config._tag) {
     case "MoltzapDisabled":
       return {};
-    case "MoltzapStatic":
-      return {
-        MOLTZAP_SERVER_URL: config.serverUrl,
-        MOLTZAP_API_KEY: config.apiKey,
-        ...(config.allowlistCsv !== null
-          ? { MOLTZAP_ALLOWED_SENDERS: config.allowlistCsv }
-          : {}),
-      };
     case "MoltzapRegistration":
       return {
         MOLTZAP_SERVER_URL: config.serverUrl,

--- a/test/moltzap-runtime.test.ts
+++ b/test/moltzap-runtime.test.ts
@@ -3,7 +3,6 @@ import {
   buildMoltzapProcessEnv,
   buildMoltzapSpawnEnv,
   loadMoltzapRuntimeConfig,
-  type MoltzapRuntimeConfig,
 } from "../src/moltzap/runtime.ts";
 import {
   asAoSessionName,
@@ -35,28 +34,13 @@ describe("moltzap runtime / loadMoltzapRuntimeConfig", () => {
     expect(result).toEqual({ _tag: "Ok", value: { _tag: "MoltzapDisabled" } });
   });
 
-  it("rejects auth config without a server URL", () => {
+  it("rejects registration config without a server URL", () => {
     const result = loadMoltzapRuntimeConfig({
-      ZAPBOT_MOLTZAP_API_KEY: "mz-key",
+      ZAPBOT_MOLTZAP_REGISTRATION_SECRET: "reg-secret",
     });
     expect(result._tag).toBe("Err");
     if (result._tag !== "Err") return;
     expect(result.error.reason).toContain("ZAPBOT_MOLTZAP_SERVER_URL");
-  });
-
-  it("loads static API-key mode", () => {
-    const result = loadMoltzapRuntimeConfig({
-      ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-      ZAPBOT_MOLTZAP_API_KEY: "mz-key",
-    });
-    expect(result._tag).toBe("Ok");
-    if (result._tag !== "Ok") return;
-    expect(result.value).toMatchObject({
-      _tag: "MoltzapStatic",
-      serverUrl: "wss://moltzap.example/ws",
-      apiKey: "mz-key",
-      allowlistCsv: null,
-    });
   });
 
   it("loads registration mode and builds a sender allowlist from CSV", () => {
@@ -79,46 +63,21 @@ describe("moltzap runtime / loadMoltzapRuntimeConfig", () => {
     });
     expect(gate._tag).toBe("Ok");
   });
+
+  it("requires a registration secret when a MoltZap server URL is configured", () => {
+    const result = loadMoltzapRuntimeConfig({
+      ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
+    });
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error.reason).toContain("ZAPBOT_MOLTZAP_REGISTRATION_SECRET");
+  });
 });
 
 describe("moltzap runtime / buildMoltzapSpawnEnv", () => {
   it("returns an empty env map when MoltZap is disabled", async () => {
     const result = await buildMoltzapSpawnEnv({ _tag: "MoltzapDisabled" }, spawnContext);
     expect(result).toEqual({ _tag: "Ok", value: {} });
-  });
-
-  it("returns static MOLTZAP_* env when using a pre-provisioned API key", async () => {
-    const config: MoltzapRuntimeConfig = {
-      _tag: "MoltzapStatic",
-      serverUrl: "wss://moltzap.example/ws",
-      apiKey: "mz-key",
-      allowlistCsv: "agent-a,agent-b",
-      allowlist: loadMoltzapRuntimeConfig({
-        ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-        ZAPBOT_MOLTZAP_API_KEY: "mz-key",
-        ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "agent-a,agent-b",
-      })._tag === "Ok"
-        ? (loadMoltzapRuntimeConfig({
-            ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-            ZAPBOT_MOLTZAP_API_KEY: "mz-key",
-            ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "agent-a,agent-b",
-          }) as Extract<
-            ReturnType<typeof loadMoltzapRuntimeConfig>,
-            { readonly _tag: "Ok" }
-          >).value.allowlist
-        : (() => {
-            throw new Error("unreachable");
-          })(),
-    };
-    const result = await buildMoltzapSpawnEnv(config, spawnContext);
-    expect(result).toEqual({
-      _tag: "Ok",
-      value: {
-        MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-        MOLTZAP_API_KEY: "mz-key",
-        MOLTZAP_ALLOWED_SENDERS: "agent-a,agent-b",
-      },
-    });
   });
 
   it("registers a fresh agent when a registration secret is configured", async () => {
@@ -180,37 +139,6 @@ describe("moltzap runtime / buildMoltzapSpawnEnv", () => {
 describe("moltzap runtime / buildMoltzapProcessEnv", () => {
   it("returns an empty env map when MoltZap is disabled", () => {
     expect(buildMoltzapProcessEnv({ _tag: "MoltzapDisabled" })).toEqual({});
-  });
-
-  it("maps static config into parent-process env for ao sessions", () => {
-    expect(
-      buildMoltzapProcessEnv({
-        _tag: "MoltzapStatic",
-        serverUrl: "wss://moltzap.example/ws",
-        apiKey: "mz-key",
-        allowlistCsv: "orch-1,worker-1",
-        allowlist: loadMoltzapRuntimeConfig({
-          ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-          ZAPBOT_MOLTZAP_API_KEY: "mz-key",
-          ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "orch-1,worker-1",
-        })._tag === "Ok"
-          ? (loadMoltzapRuntimeConfig({
-              ZAPBOT_MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-              ZAPBOT_MOLTZAP_API_KEY: "mz-key",
-              ZAPBOT_MOLTZAP_ALLOWED_SENDERS: "orch-1,worker-1",
-            }) as Extract<
-              ReturnType<typeof loadMoltzapRuntimeConfig>,
-              { readonly _tag: "Ok" }
-            >).value.allowlist
-          : (() => {
-              throw new Error("unreachable");
-            })(),
-      }),
-    ).toEqual({
-      MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-      MOLTZAP_API_KEY: "mz-key",
-      MOLTZAP_ALLOWED_SENDERS: "orch-1,worker-1",
-    });
   });
 
   it("maps registration config into parent-process env for ao sessions", () => {

--- a/worker/ao-plugin-agent-claude-moltzap/index.js
+++ b/worker/ao-plugin-agent-claude-moltzap/index.js
@@ -9,12 +9,6 @@ const builtinModule = await import(pathToFileURL(resolveBuiltinClaudePluginPath(
 const builtin = builtinModule.create();
 const launchWrapperPath = fileURLToPath(new URL("./launch-claude-moltzap.py", import.meta.url));
 const execFileAsync = promisify(execFile);
-const MOLTZAP_ENV_FALLBACKS = Object.freeze({
-  MOLTZAP_SERVER_URL: "ZAPBOT_MOLTZAP_SERVER_URL",
-  MOLTZAP_API_KEY: "ZAPBOT_MOLTZAP_API_KEY",
-  MOLTZAP_ALLOWED_SENDERS: "ZAPBOT_MOLTZAP_ALLOWED_SENDERS",
-  MOLTZAP_REGISTRATION_SECRET: "ZAPBOT_MOLTZAP_REGISTRATION_SECRET",
-});
 
 export const manifest = {
   ...builtinModule.manifest,
@@ -178,24 +172,9 @@ function resolveEnvValue(key, fileEnv) {
     return direct;
   }
 
-  const fallbackKey = MOLTZAP_ENV_FALLBACKS[key];
-  if (typeof fallbackKey === "string") {
-    const mappedProcessValue = normalizeEnvValue(process.env[fallbackKey]);
-    if (mappedProcessValue !== null) {
-      return mappedProcessValue;
-    }
-  }
-
   const fileValue = normalizeEnvValue(fileEnv[key]);
   if (fileValue !== null) {
     return fileValue;
-  }
-
-  if (typeof fallbackKey === "string") {
-    const mappedFileValue = normalizeEnvValue(fileEnv[fallbackKey]);
-    if (mappedFileValue !== null) {
-      return mappedFileValue;
-    }
   }
 
   return null;


### PR DESCRIPTION
Closes #276
Spec: https://github.com/chughtapan/zapbot/issues/275
Scope addendum: https://github.com/chughtapan/zapbot/issues/275#issuecomment-4298015961

## What changed
Removed the operator-facing static MoltZap provisioning path so zapbot now treats registration as the only supported provisioning contract. The runtime no longer models `MoltzapStatic`, the launch helpers no longer read `ZAPBOT_*` MoltZap fallbacks, and the README plus runtime tests only describe the registration flow.

## Plan anchors
| Change | Plan anchor |
|---|---|
| Remove `MoltzapStatic` from `src/moltzap/runtime.ts` and keep only registration/disabled config states | #275 Invariants 1, 2, 6 |
| Stop helper-level `ZAPBOT_*` MoltZap fallback reads in `bin/ao-spawn-with-moltzap.ts` and `worker/ao-plugin-agent-claude-moltzap/index.js` | #275 Invariants 4, 5 |
| Update `README.md` to document only registration-based MoltZap provisioning | #275 Acceptance criterion 5 |
| Remove static-path runtime tests and keep registration-only assertions in `test/moltzap-runtime.test.ts` | #275 Acceptance criteria 1, 6 |

## Scope
- Modules touched: `src/moltzap/runtime.ts`, `bin/ao-spawn-with-moltzap.ts`, `worker/ao-plugin-agent-claude-moltzap/index.js`, `README.md`, `test/moltzap-runtime.test.ts`
- Tier: senior
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests
- `bun run test --run test/moltzap-runtime.test.ts test/ao-spawn-with-moltzap.test.ts`
- `bun run build`
- `bun run lint` (warnings only, 0 errors)

## Confidence
HIGH — the edited branch no longer contains `ZAPBOT_MOLTZAP_API_KEY` or `MoltzapStatic`, targeted runtime tests pass, and build/lint remain green enough for the existing repo baseline.
