### PR TITLE
[arch] raw GitHub message intake for AO

### DIFF
--- a/src/github-control-request.ts
+++ b/src/github-control-request.ts
@@ -1,0 +1,42 @@
+import type {
+  CommentId,
+  DeliveryId,
+  IssueNumber,
+  ProjectName,
+  RepoFullName,
+  Result,
+} from "./types.ts";
+
+export type IssueThreadKind = "issue" | "pull_request";
+
+export interface GitHubPlacementContext {
+  readonly repo: RepoFullName;
+  readonly projectName: ProjectName;
+  readonly issue: IssueNumber;
+  readonly issueThreadKind: IssueThreadKind;
+  readonly issueTitle: string | null;
+  readonly issueUrl: string | null;
+  readonly commentId: CommentId;
+  readonly commentUrl: string | null;
+  readonly deliveryId: DeliveryId;
+}
+
+export interface EligibleMentionRequest {
+  readonly _tag: "EligibleMentionRequest";
+  readonly placement: GitHubPlacementContext;
+  readonly rawCommentBody: string;
+  readonly triggeredBy: string;
+}
+
+export type EligibleMentionRequestError =
+  | { readonly _tag: "PlacementInvalid"; readonly reason: string }
+  | { readonly _tag: "RawCommentBodyInvalid"; readonly reason: string }
+  | { readonly _tag: "TriggeredByInvalid"; readonly reason: string };
+
+export function buildEligibleMentionRequest(args: {
+  readonly placement: GitHubPlacementContext;
+  readonly rawCommentBody: string;
+  readonly triggeredBy: string;
+}): Result<EligibleMentionRequest, EligibleMentionRequestError> {
+  throw new Error("not implemented");
+}

--- a/src/mention-detection.ts
+++ b/src/mention-detection.ts
@@ -1,0 +1,22 @@
+import type { BotUsername, Result } from "./types.ts";
+
+export interface EligibleBotMention {
+  readonly _tag: "EligibleBotMention";
+  readonly mentionText: string;
+  readonly sanitizedBody: string;
+}
+
+export type MentionDetectionError =
+  | { readonly _tag: "MentionBodyInvalid"; readonly reason: string }
+  | { readonly _tag: "BotUsernameInvalid"; readonly reason: string };
+
+export function stripQuotedContent(body: string): string {
+  throw new Error("not implemented");
+}
+
+export function detectEligibleBotMention(
+  body: string,
+  botUsername: BotUsername,
+): Result<EligibleBotMention | null, MentionDetectionError> {
+  throw new Error("not implemented");
+}

--- a/src/orchestrator/github-control-prompt.ts
+++ b/src/orchestrator/github-control-prompt.ts
@@ -1,0 +1,17 @@
+import type { EligibleMentionRequest } from "../github-control-request.ts";
+import type { Result } from "../types.ts";
+
+export interface OrchestratorControlPrompt {
+  readonly title: string;
+  readonly body: string;
+}
+
+export type ControlPromptShapeError =
+  | { readonly _tag: "PlacementMissing"; readonly reason: string }
+  | { readonly _tag: "PromptShapeInvalid"; readonly reason: string };
+
+export function toOrchestratorControlPrompt(
+  request: EligibleMentionRequest,
+): Result<OrchestratorControlPrompt, ControlPromptShapeError> {
+  throw new Error("not implemented");
+}


### PR DESCRIPTION
Architecture only. Not for merge.

Design doc: https://github.com/chughtapan/zapbot/issues/280#issuecomment-4298459391

This branch contains interface stubs only for the raw GitHub message intake lane:
- `src/mention-detection.ts`
- `src/github-control-request.ts`
- `src/orchestrator/github-control-prompt.ts`

Every exported function body is `throw new Error("not implemented")` by design.
