### PR TITLE
[test] (zap#310) bridge.test.ts: mock rosterBudgetCoordinator

### DIFF
--- a/test/bridge.test.ts
+++ b/test/bridge.test.ts
@@ -131,6 +131,18 @@ function makeCtx(
     gh,
     aoControlHost: opts.aoControlHost ?? makeAoHost().host,
     config: makeConfig(opts.withRoute ?? true),
+    roster: {
+      createWorkerSession: async () => ({ _tag: "Ok" as const, value: "fake-session" as any }),
+      lookupWorkerSession: async () => ({ _tag: "Ok" as const, value: undefined }),
+      recordWorkerTokenConsumption: async () => ({ _tag: "Ok" as const, value: undefined }),
+      getActiveRostersSnapshot: () => [],
+    } as any,
+    rosterBudgetCoordinator: {
+      observeInboundPeerMessage: () => {},
+      observeTokensConsumed: () => {},
+      tickAllBudgets: async () => [],
+      startPeriodicTick: () => () => {},
+    },
   };
 }
 


### PR DESCRIPTION
Closes #310

## What changed

Updated `makeCtx()` helper in `test/bridge.test.ts` to include minimal stubs for `rosterBudgetCoordinator` and `roster` fields required by `BridgeHandlerContext` interface. Stubs are no-op implementations satisfying call sites in `src/bridge.ts` (observeInboundPeerMessage at line 236 and startPeriodicTick in runBridge).

## Scope

- Module: test/bridge.test.ts
- Tier: junior
- New exported signatures: none
- New deps: none

## Tests

- All 8 tests in bridge.test.ts now pass (previously 7 pass, 1 fail due to missing rosterBudgetCoordinator)
- Full test suite: 467 pass (pre-existing failures in unrelated test files)

## Confidence

HIGH — call sites identified via grep; stubs verified against RosterBudgetCoordinator interface definition; tests passing locally.