### PR TITLE
[impl-senior] restore ingress + receipt + config trajectory on main (sbd#168)

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -52,7 +52,21 @@ interface LoadedBridgeInputs {
   readonly mergedEnv: Record<string, string | undefined>;
 }
 
-async function loadBridgeInputs(configPath: string | undefined): Promise<Result<LoadedBridgeInputs, { readonly reason: string }>> {
+async function probeHealthz(publicUrl: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${publicUrl.replace(/\/+$/u, "")}/healthz`, {
+      signal: AbortSignal.timeout(2_000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function loadBridgeInputs(
+  configPath: string | undefined,
+  isPublicUrlReachable: (publicUrl: string) => Promise<boolean> = probeHealthz,
+): Promise<Result<LoadedBridgeInputs, { readonly reason: string }>> {
   const sourcePaths = deriveConfigSourcePaths(configPath);
   const rawFiles = readConfigFiles(sourcePaths, nodeDiskReader);
   if (rawFiles._tag === "Err") {
@@ -80,16 +94,7 @@ async function loadBridgeInputs(configPath: string | undefined): Promise<Result<
     mode: ingressMode,
     gatewayUrl: runtimeEnv.value.gatewayUrl ?? "",
     publicUrl: runtimeEnv.value.publicUrl,
-    isPublicUrlReachable: async (publicUrl) => {
-      try {
-        const response = await fetch(`${publicUrl.replace(/\/+$/u, "")}/healthz`, {
-          signal: AbortSignal.timeout(2_000),
-        });
-        return response.ok;
-      } catch {
-        return false;
-      }
-    },
+    isPublicUrlReachable,
   });
   if (ingress._tag === "Err") {
     return err({ reason: formatIngressError(ingress.error) });
@@ -192,7 +197,9 @@ function formatIngressError(error: { readonly _tag?: string; readonly mode?: str
 }
 
 async function main() {
-  const initialInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG);
+  // Skip the reachability probe on initial load — the bridge isn't running yet
+  // so /healthz isn't open. We boot first, then probe the live endpoint below.
+  const initialInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG, async () => true);
   if (initialInputs._tag === "Err") {
     console.error(`[bridge] ${initialInputs.error.reason}`);
     process.exit(1);
@@ -212,6 +219,18 @@ async function main() {
   log.info(`Ingress mode: ${cfg.ingress.mode}`);
 
   const running = await startBridge(cfg);
+
+  // Post-boot reachability probe — fires against the now-live /healthz endpoint.
+  // If the probe fails, tear down the bridge cleanly before exiting.
+  if (cfg.ingress.mode === "github-demo" && cfg.publicUrl !== null) {
+    const reachable = await probeHealthz(cfg.publicUrl);
+    if (!reachable) {
+      await running.stop();
+      console.error(`[bridge] ZAPBOT_BRIDGE_URL is unreachable: ${cfg.publicUrl}`);
+      process.exit(1);
+    }
+  }
+
   log.info(`Webhook bridge listening on ${cfg.ingress.mode === "github-demo" ? cfg.publicUrl : "local-only ingress"}`);
 
   let reloadInFlight = false;
@@ -223,7 +242,7 @@ async function main() {
     reloadInFlight = true;
     (async () => {
       try {
-        const nextInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG);
+        const nextInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG, probeHealthz);
         if (nextInputs._tag === "Err") {
           log.error(`Reload failed: ${nextInputs.error.reason}`);
           return;

--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -13,6 +13,7 @@ import {
   loadBridgeRuntimeConfig,
 } from "../src/config/load.ts";
 import { parseEnvFile, resolveRuntimeEnv } from "../src/config/env.ts";
+import { resolveIngressPolicy } from "../src/config/ingress.ts";
 import { parseProjectConfig, readConfigFiles } from "../src/config/disk.ts";
 import { reloadBridgeRuntimeConfig } from "../src/config/reload.ts";
 import type { BridgeRuntimeConfig } from "../src/config/types.ts";
@@ -51,7 +52,7 @@ interface LoadedBridgeInputs {
   readonly mergedEnv: Record<string, string | undefined>;
 }
 
-function loadBridgeInputs(configPath: string | undefined): Result<LoadedBridgeInputs, { readonly reason: string }> {
+async function loadBridgeInputs(configPath: string | undefined): Promise<Result<LoadedBridgeInputs, { readonly reason: string }>> {
   const sourcePaths = deriveConfigSourcePaths(configPath);
   const rawFiles = readConfigFiles(sourcePaths, nodeDiskReader);
   if (rawFiles._tag === "Err") {
@@ -74,6 +75,26 @@ function loadBridgeInputs(configPath: string | undefined): Result<LoadedBridgeIn
     return err({ reason: formatConfigError(runtimeEnv.error) });
   }
 
+  const ingressMode = runtimeEnv.value.gatewayUrl === null ? "local-only" : "github-demo";
+  const ingress = await resolveIngressPolicy({
+    mode: ingressMode,
+    gatewayUrl: runtimeEnv.value.gatewayUrl ?? "",
+    publicUrl: runtimeEnv.value.publicUrl,
+    isPublicUrlReachable: async (publicUrl) => {
+      try {
+        const response = await fetch(`${publicUrl.replace(/\/+$/u, "")}/healthz`, {
+          signal: AbortSignal.timeout(2_000),
+        });
+        return response.ok;
+      } catch {
+        return false;
+      }
+    },
+  });
+  if (ingress._tag === "Err") {
+    return err({ reason: formatIngressError(ingress.error) });
+  }
+
   const projectDocument = rawFiles.value.projectConfigText === null || sourcePaths.projectConfigPath === null
     ? ok(null)
     : parseProjectConfig(sourcePaths.projectConfigPath, rawFiles.value.projectConfigText);
@@ -81,7 +102,7 @@ function loadBridgeInputs(configPath: string | undefined): Result<LoadedBridgeIn
     return err({ reason: formatConfigError(projectDocument.error) });
   }
 
-  const runtime = loadBridgeRuntimeConfig(runtimeEnv.value, parsedEnv.value, projectDocument.value);
+  const runtime = loadBridgeRuntimeConfig(runtimeEnv.value, parsedEnv.value, projectDocument.value, ingress.value);
   if (runtime._tag === "Err") {
     return err({ reason: formatConfigError(runtime.error) });
   }
@@ -107,6 +128,7 @@ function buildBridgeConfig(runtime: BridgeRuntimeConfig, mergedEnv: Record<strin
 
   return ok({
     port: runtime.port,
+    ingress: runtime.ingress,
     publicUrl: runtime.publicUrl,
     gatewayUrl: runtime.gatewayUrl,
     gatewaySecret: runtime.gatewaySecret,
@@ -154,8 +176,23 @@ function formatConfigError(error: { readonly _tag?: string; readonly reason?: st
   }
 }
 
+function formatIngressError(error: { readonly _tag?: string; readonly mode?: string; readonly gatewayUrl?: string; readonly publicUrl?: string }): string {
+  switch (error._tag) {
+    case "InvalidIngressMode":
+      return `Unsupported ingress mode: ${error.mode}`;
+    case "MissingPublicBridgeUrl":
+      return "ZAPBOT_BRIDGE_URL is required in GitHub demo mode.";
+    case "UnreachablePublicBridgeUrl":
+      return `ZAPBOT_BRIDGE_URL is unreachable: ${error.publicUrl}`;
+    case "DemoModeRequiresGateway":
+      return "ZAPBOT_GATEWAY_URL is required in GitHub demo mode.";
+    default:
+      return "Unknown ingress error.";
+  }
+}
+
 async function main() {
-  const initialInputs = loadBridgeInputs(process.env.ZAPBOT_CONFIG);
+  const initialInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG);
   if (initialInputs._tag === "Err") {
     console.error(`[bridge] ${initialInputs.error.reason}`);
     process.exit(1);
@@ -172,9 +209,10 @@ async function main() {
   let liveRuntime = initialInputs.value.runtime;
   const cfg = initialConfig.value;
   log.info(`Webhook bridge starting on port ${cfg.port}`);
+  log.info(`Ingress mode: ${cfg.ingress.mode}`);
 
   const running = await startBridge(cfg);
-  log.info(`Webhook bridge listening on ${cfg.publicUrl}`);
+  log.info(`Webhook bridge listening on ${cfg.ingress.mode === "github-demo" ? cfg.publicUrl : "local-only ingress"}`);
 
   let reloadInFlight = false;
   process.on("SIGHUP", () => {
@@ -185,7 +223,7 @@ async function main() {
     reloadInFlight = true;
     (async () => {
       try {
-        const nextInputs = loadBridgeInputs(process.env.ZAPBOT_CONFIG);
+        const nextInputs = await loadBridgeInputs(process.env.ZAPBOT_CONFIG);
         if (nextInputs._tag === "Err") {
           log.error(`Reload failed: ${nextInputs.error.reason}`);
           return;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -18,6 +18,7 @@ import {
   buildMoltzapProcessEnv,
   type MoltzapRuntimeConfig,
 } from "./moltzap/runtime.ts";
+import type { IngressPolicy } from "./config/ingress.ts";
 import { createAoCliControlHost, forwardControlPrompt, type AoControlHost, type ForwardControlError } from "./orchestrator/runtime.ts";
 import { toOrchestratorControlPrompt, type ControlEventShapeError, type OrchestratorControlEvent } from "./orchestrator/control-event.ts";
 import {
@@ -73,8 +74,9 @@ async function safeGh<T>(
 
 export interface BridgeConfig {
   readonly port: number;
-  readonly publicUrl: string;
-  readonly gatewayUrl: string;
+  readonly ingress: IngressPolicy;
+  readonly publicUrl: string | null;
+  readonly gatewayUrl: string | null;
   readonly gatewaySecret: string | null;
   readonly botUsername: BotUsername;
   readonly aoConfigPath: string;
@@ -407,28 +409,36 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
   async function registerAll(cfg: BridgeConfig): Promise<void> {
     const repos = Array.from(cfg.repos.keys());
     if (repos.length === 0) return;
+    if (cfg.ingress.mode === "local-only") return;
+    if (cfg.gatewayUrl === null || cfg.publicUrl === null) return;
+    const gatewayUrl = cfg.gatewayUrl;
+    const publicUrl = cfg.publicUrl;
     const client: GatewayClientConfig = {
-      gatewayUrl: cfg.gatewayUrl,
+      gatewayUrl,
       secret: cfg.gatewaySecret,
       token: null,
     };
     await Promise.allSettled(
-      repos.map((repo) => registerBridge(client, repo, cfg.publicUrl))
+      repos.map((repo) => registerBridge(client, repo, publicUrl))
     );
     if (stopHeartbeat) stopHeartbeat();
     const intervalMs = parseInt(process.env.ZAPBOT_GATEWAY_HEARTBEAT_MS ?? "300000", 10);
-    stopHeartbeat = startHeartbeat(client, repos, cfg.publicUrl, intervalMs);
+    stopHeartbeat = startHeartbeat(client, repos, publicUrl, intervalMs);
   }
 
   async function deregisterAll(cfg: BridgeConfig): Promise<void> {
+    if (cfg.ingress.mode === "local-only") return;
+    if (cfg.gatewayUrl === null || cfg.publicUrl === null) return;
+    const gatewayUrl = cfg.gatewayUrl;
+    const publicUrl = cfg.publicUrl;
     const repos = Array.from(cfg.repos.keys());
     const client: GatewayClientConfig = {
-      gatewayUrl: cfg.gatewayUrl,
+      gatewayUrl,
       secret: cfg.gatewaySecret,
       token: null,
     };
     await Promise.allSettled(
-      repos.map((repo) => deregisterBridge(client, repo, cfg.publicUrl))
+      repos.map((repo) => deregisterBridge(client, repo, publicUrl))
     );
   }
 

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -473,6 +473,13 @@ export async function startBridge(config: BridgeConfig): Promise<RunningBridge> 
       server.stop();
     },
     async reload(nextConfig: BridgeConfig): Promise<void> {
+      // Stop stale heartbeat when ingress mode flips github-demo → local-only.
+      // registerAll returns early for local-only and never reaches the stopHeartbeat
+      // call inside it, so the old heartbeat would keep running indefinitely.
+      if (current.ingress.mode === "github-demo" && nextConfig.ingress.mode === "local-only") {
+        stopHeartbeat?.();
+        stopHeartbeat = null;
+      }
       current = nextConfig;
       aoControlHost = createAoCliControlHost({
         configPath: current.aoConfigPath,

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -72,9 +72,8 @@ export function resolveRuntimeEnv(
     });
   }
 
-  const publicUrl =
-    normalizeEnvValue(mergedEnv.ZAPBOT_BRIDGE_URL) ?? `http://localhost:${port}`;
-  const gatewayUrl = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_URL) ?? "";
+  const publicUrl = normalizeEnvValue(mergedEnv.ZAPBOT_BRIDGE_URL);
+  const gatewayUrl = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_URL);
   const gatewaySecret = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_SECRET);
   const botUsername = asBotUsername(
     normalizeEnvValue(mergedEnv.ZAPBOT_BOT_USERNAME) ?? "zapbot[bot]",

--- a/src/config/ingress.ts
+++ b/src/config/ingress.ts
@@ -1,0 +1,72 @@
+import type { Result } from "../types.ts";
+import { err, ok } from "../types.ts";
+
+export type IngressMode = "local-only" | "github-demo";
+
+export type IngressResolutionError =
+  | { readonly _tag: "InvalidIngressMode"; readonly mode: string }
+  | { readonly _tag: "MissingPublicBridgeUrl" }
+  | { readonly _tag: "UnreachablePublicBridgeUrl"; readonly publicUrl: string }
+  | { readonly _tag: "DemoModeRequiresGateway"; readonly gatewayUrl: string };
+
+export type IngressPolicy =
+  | {
+      readonly _tag: "LocalOnly";
+      readonly mode: "local-only";
+      readonly gatewayUrl: null;
+      readonly publicUrl: null;
+      readonly requiresReachablePublicUrl: false;
+    }
+  | {
+      readonly _tag: "GitHubDemo";
+      readonly mode: "github-demo";
+      readonly gatewayUrl: string;
+      readonly publicUrl: string;
+      readonly requiresReachablePublicUrl: true;
+    };
+
+export interface IngressPolicyInputs {
+  readonly mode: IngressMode;
+  readonly gatewayUrl: string;
+  readonly publicUrl: string | null;
+  readonly isPublicUrlReachable: (publicUrl: string) => Promise<boolean>;
+}
+
+export async function resolveIngressPolicy(
+  inputs: IngressPolicyInputs,
+): Promise<Result<IngressPolicy, IngressResolutionError>> {
+  if (inputs.mode === "local-only") {
+    return Promise.resolve(
+      ok({
+        _tag: "LocalOnly",
+        mode: "local-only",
+        gatewayUrl: null,
+        publicUrl: null,
+        requiresReachablePublicUrl: false,
+      }),
+    );
+  }
+
+  const gatewayUrl = inputs.gatewayUrl.trim();
+  if (gatewayUrl.length === 0) {
+    return Promise.resolve(err({ _tag: "DemoModeRequiresGateway", gatewayUrl: inputs.gatewayUrl }));
+  }
+
+  const publicUrl = inputs.publicUrl?.trim() ?? null;
+  if (publicUrl === null || publicUrl.length === 0) {
+    return Promise.resolve(err({ _tag: "MissingPublicBridgeUrl" }));
+  }
+
+  const reachable = await inputs.isPublicUrlReachable(publicUrl);
+  if (!reachable) {
+    return err({ _tag: "UnreachablePublicBridgeUrl", publicUrl });
+  }
+
+  return ok({
+    _tag: "GitHubDemo",
+    mode: "github-demo",
+    gatewayUrl,
+    publicUrl,
+    requiresReachablePublicUrl: true,
+  });
+}

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -15,6 +15,7 @@ import type {
   ProjectConfigDocument,
   ProjectRouteConfig,
 } from "./types.ts";
+import type { IngressPolicy } from "./ingress.ts";
 import type { RepoFullName } from "../types.ts";
 
 export function deriveConfigSourcePaths(
@@ -61,6 +62,7 @@ export function loadBridgeRuntimeConfig(
   env: NormalizedRuntimeEnv,
   _parsedEnvFile: ParsedEnvFile | null,
   document: ProjectConfigDocument | null,
+  ingress: IngressPolicy,
 ): Result<BridgeRuntimeConfig, ConfigLoadError> {
   const routeResult = buildRepoRoutes(document);
   if (routeResult._tag === "Err") return routeResult;
@@ -71,8 +73,9 @@ export function loadBridgeRuntimeConfig(
 
   return ok({
     port: env.port,
-    publicUrl: env.publicUrl,
-    gatewayUrl: env.gatewayUrl,
+    ingress,
+    publicUrl: ingress.publicUrl,
+    gatewayUrl: ingress.gatewayUrl,
     gatewaySecret: env.gatewaySecret,
     botUsername: env.botUsername,
     aoConfigPath: env.aoConfigPath,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -3,6 +3,7 @@ import type {
   ProjectName,
   RepoFullName,
 } from "../types.ts";
+import type { IngressPolicy } from "./ingress.ts";
 
 export type EnvFilePath = string & { readonly __brand: "EnvFilePath" };
 export type ProjectConfigPath = string & { readonly __brand: "ProjectConfigPath" };
@@ -34,8 +35,8 @@ export interface ProjectConfigDocument {
 
 export interface NormalizedRuntimeEnv {
   readonly port: number;
-  readonly publicUrl: string;
-  readonly gatewayUrl: string;
+  readonly publicUrl: string | null;
+  readonly gatewayUrl: string | null;
   readonly gatewaySecret: string | null;
   readonly botUsername: BotUsername;
   readonly aoConfigPath: ProjectConfigPath | null;
@@ -53,8 +54,9 @@ export interface ProjectRouteConfig {
 
 export interface BridgeRuntimeConfig {
   readonly port: number;
-  readonly publicUrl: string;
-  readonly gatewayUrl: string;
+  readonly ingress: IngressPolicy;
+  readonly publicUrl: string | null;
+  readonly gatewayUrl: string | null;
   readonly gatewaySecret: string | null;
   readonly botUsername: BotUsername;
   readonly aoConfigPath: ProjectConfigPath | null;

--- a/src/startup/receipt.ts
+++ b/src/startup/receipt.ts
@@ -1,0 +1,63 @@
+import { err, ok, type Result } from "../types.ts";
+import type { IngressPolicy } from "../config/ingress.ts";
+
+export type StartupReceiptError =
+  | { readonly _tag: "MissingProjectDir" }
+  | { readonly _tag: "MissingRepoList" }
+  | { readonly _tag: "UnsupportedReceiptMode"; readonly mode: string };
+
+export interface StartupReceiptInput {
+  readonly projectDir: string;
+  readonly repos: ReadonlyArray<string>;
+  readonly ingress: IngressPolicy;
+  readonly bridgePort: number;
+  readonly dashboardPort: number;
+  readonly gatewayUrl: string | null;
+  readonly publicUrl: string | null;
+  readonly logsPath: string;
+  readonly publishCommand: string;
+}
+
+export interface StartupReceipt {
+  readonly mode: IngressPolicy["mode"];
+  readonly lines: ReadonlyArray<string>;
+}
+
+export function buildStartupReceipt(
+  input: StartupReceiptInput,
+): Result<StartupReceipt, StartupReceiptError> {
+  if (input.projectDir.trim().length === 0) {
+    return err({ _tag: "MissingProjectDir" });
+  }
+  if (input.repos.length === 0) {
+    return err({ _tag: "MissingRepoList" });
+  }
+
+  const lines = [
+    `Mode:      ${input.ingress.mode}`,
+    `Project:   ${input.projectDir}`,
+    ...input.repos.map((repo) => `Repo:      https://github.com/${repo}`),
+    `Bridge:    http://localhost:${input.bridgePort}`,
+    `Dashboard: http://localhost:${input.dashboardPort}`,
+  ];
+
+  if (input.ingress.mode === "github-demo") {
+    lines.push(`Gateway:   ${input.gatewayUrl ?? input.ingress.gatewayUrl}`);
+    lines.push(`Public:    ${input.publicUrl ?? input.ingress.publicUrl}`);
+  } else {
+    lines.push("Gateway:   (local-only)");
+    lines.push("Public:    (local-only)");
+  }
+
+  lines.push(`Logs:      ${input.logsPath}`);
+  lines.push(`Publish:   ${input.publishCommand}`);
+
+  return ok({
+    mode: input.ingress.mode,
+    lines,
+  });
+}
+
+export function renderStartupReceipt(receipt: StartupReceipt): string {
+  return receipt.lines.join("\n");
+}

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -12,6 +12,7 @@ import {
   deriveConfigSourcePaths,
   loadBridgeRuntimeConfig,
 } from "../src/config/load.js";
+import type { IngressPolicy } from "../src/config/ingress.js";
 import type { ConfigDiskError } from "../src/config/types.js";
 import type { Result } from "../src/types.js";
 
@@ -21,6 +22,14 @@ function expectOk<T, E>(result: Result<T, E>): T {
   }
   return result.value;
 }
+
+const localOnlyIngress: IngressPolicy = {
+  _tag: "LocalOnly",
+  mode: "local-only",
+  gatewayUrl: null,
+  publicUrl: null,
+  requiresReachablePublicUrl: false,
+};
 
 const nodeDiskReader: ConfigDiskReader = {
   readText(path) {
@@ -75,7 +84,7 @@ projects:
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
       ZAPBOT_CONFIG: configPath,
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(1);
     expect(runtime.routes.has("chughtapan/zapbot")).toBe(true);
@@ -115,7 +124,7 @@ projects:
       ZAPBOT_API_KEY: "api-key-123",
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(2);
     expect(runtime.routes.get("chughtapan/zapbot")!.projectName).toBe("zapbot");
@@ -129,7 +138,7 @@ projects:
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
       ZAPBOT_REPO: "owner/my-repo",
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(1);
     expect(runtime.routes.has("owner/my-repo")).toBe(true);
@@ -141,7 +150,7 @@ projects:
       ZAPBOT_API_KEY: "api-key-123",
       ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
     }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(0);
   });

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -3,6 +3,7 @@ import { parseEnvFile, resolveRuntimeEnv } from "../src/config/env.js";
 import { reloadBridgeRuntimeConfig } from "../src/config/reload.js";
 import { loadBridgeRuntimeConfig } from "../src/config/load.js";
 import { readConfigFiles, type ConfigDiskReader } from "../src/config/disk.js";
+import type { IngressPolicy } from "../src/config/ingress.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -33,11 +34,19 @@ const nodeDiskReader: ConfigDiskReader = {
   },
 };
 
+const localOnlyIngress: IngressPolicy = {
+  _tag: "LocalOnly",
+  mode: "local-only",
+  gatewayUrl: null,
+  publicUrl: null,
+  requiresReachablePublicUrl: false,
+};
+
 function buildRuntime(
   env: Record<string, string | undefined>,
 ) {
   const resolvedEnv = expectOk(resolveRuntimeEnv(env, null));
-  return expectOk(loadBridgeRuntimeConfig(resolvedEnv, null, null));
+  return expectOk(loadBridgeRuntimeConfig(resolvedEnv, null, null, localOnlyIngress));
 }
 
 describe("parseEnvFile", () => {


### PR DESCRIPTION
## Summary

Restores the ingress/receipt/config trajectory on zapbot `main` per architect decision [sbd#167](https://github.com/chughtapan/safer-by-default/issues/167#issuecomment-4310247813). This closes the gap that caused `senior/166-rebase-ws2-mvp` to escalate.

**Scope widened from architect §3 table to include `src/bridge.ts` per senior-168 escalation (sbd#168, 2026-04-24); operator-approved.**

## 7-file scope table

| File | Op | Source | Notes |
|---|---|---|---|
| `src/config/ingress.ts` | **add** | `git show d9b69f0:src/config/ingress.ts` (blob `427aa03a`) | Blob-identical to ws2-mvp. |
| `src/startup/receipt.ts` | **add** | `git show d9b69f0:src/startup/receipt.ts` (blob `4ac72e8f`) | Blob-identical. |
| `src/config/types.ts` | modify | `git show d9b69f0:src/config/types.ts` (blob `cc88a4f4`) | Blob-identical. |
| `src/config/env.ts` | modify | `git show d9b69f0:src/config/env.ts` (blob `643fdece`) | Blob-identical. |
| `src/config/load.ts` | modify | `git show d9b69f0:src/config/load.ts` (blob `1137289f`) | Blob-identical. |
| `bin/webhook-bridge.ts` | modify | hand-port from `origin/architect/ws2-mvp:bin/webhook-bridge.ts` | Add `resolveIngressPolicy`, `formatIngressError`, wire ingress into config. |
| `src/bridge.ts` | modify | scope-patch from d9b69f0 blob `33e8359` | Import `IngressPolicy`; add `readonly ingress`; flip `publicUrl`/`gatewayUrl` to `string \| null`; null + ingress-mode guards in `registerAll`/`deregisterAll`. |

Additionally updated `test/config-loader.test.ts` and `test/config-reload.test.ts` to supply the required `IngressPolicy` argument to `loadBridgeRuntimeConfig` (the restored 4-arg signature).

## P1/P2 fixes (operator override)

Applied per operator override in [sbd#168 comment 4310522327](https://github.com/chughtapan/safer-by-default/issues/168#issuecomment-4310522327).

The architect plan's "blob-identical" rule was overridden for these two bugs because both were latent defects in the ws2-mvp trajectory itself — not regressions introduced by this PR — and both would block cold-start adoption of the github-demo ingress mode.

**P1 — boot bridge before probe (`bin/webhook-bridge.ts`):**
`isPublicUrlReachable` previously fired inside `loadBridgeInputs` before `startBridge()` opened the local `/healthz` endpoint. Cold starts behind ngrok/cloudflared failed with `UnreachablePublicBridgeUrl` even when the URL was valid. Fix: initial `loadBridgeInputs` skips the probe (`async () => true`); `startBridge()` boots first; a post-boot `probeHealthz` fires against the now-live endpoint. If the probe fails, `running.stop()` tears the bridge down cleanly before `process.exit(1)`. SIGHUP reloads still use the real probe (bridge already live).

**P2 — stop stale heartbeat on ingress-mode reload (`src/bridge.ts`):**
On SIGHUP reload flipping `github-demo → local-only`, `registerAll` returned early for local-only and never reached the `stopHeartbeat()` call, leaving the old heartbeat running indefinitely. Fix: gate `stopHeartbeat?.(); stopHeartbeat = null` on `current.ingress.mode === "github-demo" && nextConfig.ingress.mode === "local-only"` in `reload()`. The reverse transition (local-only → github-demo) starts a new heartbeat via `registerAll` unchanged.

Neither fix changed a public function signature (`startBridge` return shape unchanged) nor modified the `IngressPolicy` type (only reads `.mode`).

## Verification

- `bun run build`: ✅ tsc exits 0 (no errors)
- `bun test`: ✅ 282 pass, 0 fail
- `safer-diff-scope --head HEAD`: `senior` tier (9 files, 10 exports, 0 new deps)

## Rebase verification

`senior/166-rebase-ws2-mvp` rebased onto this branch — `bun run build` passes (see comment below).

## Architect decision

https://github.com/chughtapan/safer-by-default/issues/167#issuecomment-4310247813

## Scope-patch log

- **2026-04-24T03:37Z** — senior-168 escalated: architect's scope table missed `src/bridge.ts`. Evidence-backed (blob `0ecfbdc3` on main has non-nullable `publicUrl/gatewayUrl` and no `ingress` field; `bun run build` fails TS2322 + TS2339 on `bin/webhook-bridge.ts`).
- **2026-04-24T03:40Z (operator-approved)** — scope widened to include `src/bridge.ts` per senior's Option A.

## Do NOT merge

`/safer:review-senior` must run before merge. Do NOT self-gate.