### PR TITLE
[impl-staff] src/config/canonical.ts: read ~/.zapbot/config.json in bridge; delete parseEnvFile (zap#323)

### DIFF
--- a/bin/webhook-bridge.ts
+++ b/bin/webhook-bridge.ts
@@ -5,6 +5,10 @@
  * state-machine engine, SQLite store, plannotator callbacks, and recovery.
  * The live runtime now sits under `src/`; this file is only the CLI shim
  * that reads config, boots the server, and wires signals.
+ *
+ * Shared secrets (apiKey, webhookSecret) load from `~/.zapbot/config.json`
+ * via `readCanonicalConfig`. No `.env` parsing. Port and ingress knobs
+ * continue to read from `process.env` directly.
  */
 
 import { readFileSync } from "fs";
@@ -12,11 +16,17 @@ import {
   deriveConfigSourcePaths,
   loadBridgeRuntimeConfig,
 } from "../src/config/load.ts";
-import { parseEnvFile, resolveRuntimeEnv } from "../src/config/env.ts";
+import { resolveRuntimeEnv } from "../src/config/env.ts";
+import { readCanonicalConfig } from "../src/config/canonical.ts";
 import { resolveIngressPolicy } from "../src/config/ingress.ts";
 import { parseProjectConfig, readConfigFiles } from "../src/config/disk.ts";
 import { reloadBridgeRuntimeConfig } from "../src/config/reload.ts";
-import type { BridgeRuntimeConfig } from "../src/config/types.ts";
+import type {
+  BridgeRuntimeConfig,
+  ConfigDiskError,
+  ConfigReloadError,
+} from "../src/config/types.ts";
+import type { IngressResolutionError } from "../src/config/ingress.ts";
 import { createLogger } from "../src/logger.ts";
 import { loadMoltzapRuntimeConfig } from "../src/moltzap/runtime.ts";
 import { startBridge, type BridgeConfig, type RepoRoute } from "../src/bridge.ts";
@@ -34,7 +44,7 @@ process.on("unhandledRejection", (err) => {
 const log = createLogger("bridge");
 
 const nodeDiskReader = {
-  readText(path: string): Result<string, { readonly _tag: "ConfigFileUnreadable"; readonly path: string; readonly cause: string }> {
+  readText(path: string): Result<string, ConfigDiskError> {
     try {
       return ok(readFileSync(path, "utf-8"));
     } catch (cause) {
@@ -47,9 +57,8 @@ const nodeDiskReader = {
   },
 };
 
-interface LoadedBridgeInputs {
-  readonly runtime: BridgeRuntimeConfig;
-  readonly mergedEnv: Record<string, string | undefined>;
+function absurd(x: never): never {
+  throw new Error(`unreachable: ${JSON.stringify(x)}`);
 }
 
 async function probeHealthz(publicUrl: string): Promise<boolean> {
@@ -66,25 +75,20 @@ async function probeHealthz(publicUrl: string): Promise<boolean> {
 async function loadBridgeInputs(
   configPath: string | undefined,
   isPublicUrlReachable: (publicUrl: string) => Promise<boolean> = probeHealthz,
-): Promise<Result<LoadedBridgeInputs, { readonly reason: string }>> {
+): Promise<Result<BridgeRuntimeConfig, { readonly reason: string }>> {
   const sourcePaths = deriveConfigSourcePaths(configPath);
+
+  const canonical = readCanonicalConfig(sourcePaths.canonicalConfigPath, nodeDiskReader);
+  if (canonical._tag === "Err") {
+    return err({ reason: formatConfigError(canonical.error) });
+  }
+
   const rawFiles = readConfigFiles(sourcePaths, nodeDiskReader);
   if (rawFiles._tag === "Err") {
     return err({ reason: formatConfigError(rawFiles.error) });
   }
 
-  const parsedEnv = rawFiles.value.envFileText === null
-    ? ok(null)
-    : parseEnvFile(rawFiles.value.envFileText);
-  if (parsedEnv._tag === "Err") {
-    return err({ reason: formatConfigError(parsedEnv.error) });
-  }
-
-  const mergedEnv = parsedEnv.value === null
-    ? { ...process.env }
-    : { ...process.env, ...parsedEnv.value.values };
-
-  const runtimeEnv = resolveRuntimeEnv(process.env, parsedEnv.value);
+  const runtimeEnv = resolveRuntimeEnv(process.env, canonical.value);
   if (runtimeEnv._tag === "Err") {
     return err({ reason: formatConfigError(runtimeEnv.error) });
   }
@@ -107,26 +111,16 @@ async function loadBridgeInputs(
     return err({ reason: formatConfigError(projectDocument.error) });
   }
 
-  const runtime = loadBridgeRuntimeConfig(runtimeEnv.value, parsedEnv.value, projectDocument.value, ingress.value);
+  const runtime = loadBridgeRuntimeConfig(runtimeEnv.value, projectDocument.value, ingress.value);
   if (runtime._tag === "Err") {
     return err({ reason: formatConfigError(runtime.error) });
   }
 
-  return ok({
-    runtime: runtime.value,
-    mergedEnv,
-  });
+  return ok(runtime.value);
 }
 
-function applyMergedEnv(mergedEnv: Record<string, string | undefined>): void {
-  for (const [key, value] of Object.entries(mergedEnv)) {
-    if (value === undefined) continue;
-    process.env[key] = value;
-  }
-}
-
-function buildBridgeConfig(runtime: BridgeRuntimeConfig, mergedEnv: Record<string, string | undefined>): Result<BridgeConfig, { readonly reason: string }> {
-  const moltzap = loadMoltzapRuntimeConfig(mergedEnv);
+function buildBridgeConfig(runtime: BridgeRuntimeConfig): Result<BridgeConfig, { readonly reason: string }> {
+  const moltzap = loadMoltzapRuntimeConfig(process.env);
   if (moltzap._tag === "Err") {
     return err({ reason: moltzap.error.reason });
   }
@@ -158,12 +152,8 @@ function buildRepos(runtime: BridgeRuntimeConfig): ReadonlyMap<import("../src/ty
   return result;
 }
 
-function formatConfigError(error: { readonly _tag?: string; readonly reason?: string; readonly path?: string; readonly cause?: string; readonly key?: string; readonly raw?: string; readonly line?: string; readonly projectName?: string; readonly secretEnvVar?: string; readonly left?: string; readonly right?: string }): string {
+function formatConfigError(error: ConfigReloadError): string {
   switch (error._tag) {
-    case "MalformedEnvLine":
-      return `Malformed .env line: ${error.line}`;
-    case "MissingRequiredEnv":
-      return `${error.key} is required.`;
     case "InvalidPort":
       return `Invalid ZAPBOT_PORT value: ${error.raw}`;
     case "SecretCollision":
@@ -172,16 +162,20 @@ function formatConfigError(error: { readonly _tag?: string; readonly reason?: st
       return `Cannot read config file ${error.path}: ${error.cause}`;
     case "ConfigFileInvalid":
       return `Invalid config file ${error.path}: ${error.cause}`;
+    case "CanonicalConfigMissing":
+      return `Canonical config not found at ${error.path}. Run zapbot-team-init to create it.`;
+    case "CanonicalConfigInvalid":
+      return `Invalid canonical config at ${error.path}: ${error.cause}`;
     case "DeprecatedSecretBinding":
       return `Project ${error.projectName} uses deprecated webhook secret env var ${error.secretEnvVar}.`;
     case "ReloadRejected":
-      return error.reason ?? "Config reload rejected.";
+      return error.reason;
     default:
-      return error.reason ?? "Unknown config error.";
+      return absurd(error);
   }
 }
 
-function formatIngressError(error: { readonly _tag?: string; readonly mode?: string; readonly gatewayUrl?: string; readonly publicUrl?: string }): string {
+function formatIngressError(error: IngressResolutionError): string {
   switch (error._tag) {
     case "InvalidIngressMode":
       return `Unsupported ingress mode: ${error.mode}`;
@@ -192,7 +186,7 @@ function formatIngressError(error: { readonly _tag?: string; readonly mode?: str
     case "DemoModeRequiresGateway":
       return "ZAPBOT_GATEWAY_URL is required in GitHub demo mode.";
     default:
-      return "Unknown ingress error.";
+      return absurd(error);
   }
 }
 
@@ -205,15 +199,13 @@ async function main() {
     process.exit(1);
   }
 
-  applyMergedEnv(initialInputs.value.mergedEnv);
-
-  const initialConfig = buildBridgeConfig(initialInputs.value.runtime, initialInputs.value.mergedEnv);
+  const initialConfig = buildBridgeConfig(initialInputs.value);
   if (initialConfig._tag === "Err") {
     console.error(`[bridge] ${initialConfig.error.reason}`);
     process.exit(1);
   }
 
-  let liveRuntime = initialInputs.value.runtime;
+  let liveRuntime = initialInputs.value;
   const cfg = initialConfig.value;
   log.info(`Webhook bridge starting on port ${cfg.port}`);
   log.info(`Ingress mode: ${cfg.ingress.mode}`);
@@ -248,14 +240,13 @@ async function main() {
           return;
         }
 
-        const reloaded = reloadBridgeRuntimeConfig(liveRuntime, nextInputs.value.runtime);
+        const reloaded = reloadBridgeRuntimeConfig(liveRuntime, nextInputs.value);
         if (reloaded._tag === "Err") {
           log.error(`Reload failed: ${formatConfigError(reloaded.error)}`);
           return;
         }
 
-        applyMergedEnv(nextInputs.value.mergedEnv);
-        const nextConfig = buildBridgeConfig(reloaded.value.next, nextInputs.value.mergedEnv);
+        const nextConfig = buildBridgeConfig(reloaded.value.next);
         if (nextConfig._tag === "Err") {
           log.error(`Reload failed: ${nextConfig.error.reason}`);
           return;

--- a/src/config/canonical.ts
+++ b/src/config/canonical.ts
@@ -1,0 +1,58 @@
+/**
+ * src/config/canonical — decode `~/.zapbot/config.json` at the filesystem
+ * boundary.
+ *
+ * Owns one boundary only: reading the canonical shared-secrets file and
+ * decoding it through `CanonicalConfigSchema` into `CanonicalConfig`. The
+ * bridge (and any other caller) receives typed secrets or a tagged
+ * `ConfigDiskError`; no callers touch raw JSON.
+ *
+ * Per PRINCIPLES.md §2 the schema is the single decode site. Callers trust
+ * `CanonicalConfig` fields are non-empty strings.
+ */
+
+import { Schema } from "effect";
+import { err, ok, type Result } from "../types.ts";
+import type { ConfigDiskError } from "./types.ts";
+import { formatSchemaCause, type ConfigDiskReader } from "./disk.ts";
+
+export const CanonicalConfigSchema = Schema.Struct({
+  webhookSecret: Schema.NonEmptyString,
+  apiKey: Schema.NonEmptyString,
+});
+
+export type CanonicalConfig = Schema.Schema.Type<typeof CanonicalConfigSchema>;
+
+export function readCanonicalConfig(
+  path: string,
+  reader: ConfigDiskReader,
+): Result<CanonicalConfig, ConfigDiskError> {
+  const raw = reader.readText(path);
+  if (raw._tag === "Err") {
+    if (isMissingFileError(raw.error)) {
+      return err({ _tag: "CanonicalConfigMissing", path });
+    }
+    return raw;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.value);
+  } catch (cause) {
+    return err({ _tag: "CanonicalConfigInvalid", path, cause: String(cause) });
+  }
+
+  try {
+    return ok(Schema.decodeUnknownSync(CanonicalConfigSchema)(parsed));
+  } catch (cause) {
+    return err({
+      _tag: "CanonicalConfigInvalid",
+      path,
+      cause: formatSchemaCause(cause),
+    });
+  }
+}
+
+function isMissingFileError(error: ConfigDiskError): boolean {
+  return error._tag === "ConfigFileUnreadable" && /\bENOENT\b/.test(error.cause);
+}

--- a/src/config/disk.ts
+++ b/src/config/disk.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "fs";
 import { Schema } from "effect";
 import { parse as parseYaml } from "yaml";
 import {
@@ -73,7 +72,7 @@ function decodeProjectConfig(
   }
 }
 
-function formatSchemaCause(cause: unknown): string {
+export function formatSchemaCause(cause: unknown): string {
   if (cause && typeof cause === "object" && "message" in cause) {
     return String((cause as { message: unknown }).message);
   }
@@ -84,13 +83,6 @@ export function readConfigFiles(
   paths: ConfigSourcePaths,
   reader: ConfigDiskReader,
 ): Result<RawConfigFiles, ConfigDiskError> {
-  let envFileText: string | null = null;
-  if (paths.envFilePath !== null && existsSync(paths.envFilePath)) {
-    const envResult = reader.readText(paths.envFilePath);
-    if (envResult._tag === "Err") return envResult;
-    envFileText = envResult.value;
-  }
-
   let projectConfigText: string | null = null;
   if (paths.projectConfigPath !== null) {
     const configResult = reader.readText(paths.projectConfigPath);
@@ -98,7 +90,7 @@ export function readConfigFiles(
     projectConfigText = configResult.value;
   }
 
-  return ok({ envFileText, projectConfigText });
+  return ok({ projectConfigText });
 }
 
 export function parseProjectConfig(

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -8,8 +8,8 @@ import {
 import type {
   ConfigEnvError,
   NormalizedRuntimeEnv,
-  ParsedEnvFile,
 } from "./types.ts";
+import type { CanonicalConfig } from "./canonical.ts";
 
 function normalizeEnvValue(
   value: string | undefined,
@@ -19,68 +19,36 @@ function normalizeEnvValue(
   return trimmed.length === 0 ? null : trimmed;
 }
 
-export function parseEnvFile(
-  content: string,
-): Result<ParsedEnvFile, ConfigEnvError> {
-  const values: Record<string, string> = {};
-  for (const rawLine of content.split(/\r?\n/u)) {
-    const trimmed = rawLine.trim();
-    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
-    const separatorIndex = rawLine.indexOf("=");
-    if (separatorIndex === -1) {
-      return err({ _tag: "MalformedEnvLine", line: rawLine });
-    }
-    const key = rawLine.slice(0, separatorIndex).trim();
-    if (key.length === 0) {
-      return err({ _tag: "MalformedEnvLine", line: rawLine });
-    }
-    values[key] = rawLine.slice(separatorIndex + 1).trim();
-  }
-  return ok({ values });
-}
-
 export function resolveRuntimeEnv(
   processEnv: Record<string, string | undefined>,
-  parsedEnvFile: ParsedEnvFile | null,
+  canonical: CanonicalConfig,
 ): Result<NormalizedRuntimeEnv, ConfigEnvError> {
-  const mergedEnv: Record<string, string | undefined> =
-    parsedEnvFile === null
-      ? { ...processEnv }
-      : { ...processEnv, ...parsedEnvFile.values };
-
-  const rawPort = normalizeEnvValue(mergedEnv.ZAPBOT_PORT) ?? "3000";
+  const rawPort = normalizeEnvValue(processEnv.ZAPBOT_PORT) ?? "3000";
   const port = Number.parseInt(rawPort, 10);
   if (!Number.isInteger(port) || port <= 0) {
     return err({ _tag: "InvalidPort", raw: rawPort });
   }
 
-  const apiKey = normalizeEnvValue(mergedEnv.ZAPBOT_API_KEY);
-  if (apiKey === null) {
-    return err({ _tag: "MissingRequiredEnv", key: "ZAPBOT_API_KEY" });
-  }
-
-  const webhookSecret = normalizeEnvValue(mergedEnv.ZAPBOT_WEBHOOK_SECRET);
-  if (webhookSecret === null) {
-    return err({ _tag: "MissingRequiredEnv", key: "ZAPBOT_WEBHOOK_SECRET" });
-  }
+  const apiKey = canonical.apiKey;
+  const webhookSecret = canonical.webhookSecret;
 
   if (apiKey === webhookSecret) {
     return err({
       _tag: "SecretCollision",
-      left: "ZAPBOT_API_KEY",
-      right: "ZAPBOT_WEBHOOK_SECRET",
+      left: "apiKey",
+      right: "webhookSecret",
     });
   }
 
-  const publicUrl = normalizeEnvValue(mergedEnv.ZAPBOT_BRIDGE_URL);
-  const gatewayUrl = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_URL);
-  const gatewaySecret = normalizeEnvValue(mergedEnv.ZAPBOT_GATEWAY_SECRET);
+  const publicUrl = normalizeEnvValue(processEnv.ZAPBOT_BRIDGE_URL);
+  const gatewayUrl = normalizeEnvValue(processEnv.ZAPBOT_GATEWAY_URL);
+  const gatewaySecret = normalizeEnvValue(processEnv.ZAPBOT_GATEWAY_SECRET);
   const botUsername = asBotUsername(
-    normalizeEnvValue(mergedEnv.ZAPBOT_BOT_USERNAME) ?? "zapbot[bot]",
+    normalizeEnvValue(processEnv.ZAPBOT_BOT_USERNAME) ?? "zapbot[bot]",
   );
 
-  const aoConfigPathValue = normalizeEnvValue(mergedEnv.ZAPBOT_CONFIG);
-  const singleRepoValue = normalizeEnvValue(mergedEnv.ZAPBOT_REPO);
+  const aoConfigPathValue = normalizeEnvValue(processEnv.ZAPBOT_CONFIG);
+  const singleRepoValue = normalizeEnvValue(processEnv.ZAPBOT_REPO);
 
   return ok({
     port,

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,40 +1,45 @@
-import { dirname, join } from "path";
+import { join } from "path";
 import {
   asProjectName,
-  asRepoFullName,
-  err,
   ok,
   type Result,
 } from "../types.ts";
 import type {
   BridgeRuntimeConfig,
+  CanonicalConfigPath,
   ConfigLoadError,
   ConfigSourcePaths,
   NormalizedRuntimeEnv,
-  ParsedEnvFile,
   ProjectConfigDocument,
+  ProjectConfigPath,
   ProjectRouteConfig,
 } from "./types.ts";
 import type { IngressPolicy } from "./ingress.ts";
 import type { RepoFullName } from "../types.ts";
 
+function resolveCanonicalConfigPath(
+  env: Record<string, string | undefined>,
+): CanonicalConfigPath {
+  const override = env.ZAPBOT_CONFIG_JSON?.trim();
+  if (override !== undefined && override.length > 0) {
+    return override as CanonicalConfigPath;
+  }
+  const home = env.HOME ?? "";
+  return join(home, ".zapbot", "config.json") as CanonicalConfigPath;
+}
+
 export function deriveConfigSourcePaths(
   configPath: string | undefined,
+  env: Record<string, string | undefined> = process.env,
 ): ConfigSourcePaths {
-  if (!configPath) {
-    return {
-      envFilePath: null,
-      projectConfigPath: null,
-    };
-  }
-
-  const envFilePath = configPath.endsWith("agent-orchestrator.yaml")
-    ? configPath.replace(/agent-orchestrator\.yaml$/u, ".env")
-    : join(dirname(configPath), ".env");
+  const projectConfigPath =
+    configPath === undefined || configPath.length === 0
+      ? null
+      : (configPath as ProjectConfigPath);
 
   return {
-    envFilePath: envFilePath as ConfigSourcePaths["envFilePath"],
-    projectConfigPath: configPath as ConfigSourcePaths["projectConfigPath"],
+    projectConfigPath,
+    canonicalConfigPath: resolveCanonicalConfigPath(env),
   };
 }
 
@@ -60,7 +65,6 @@ export function buildRepoRoutes(
 
 export function loadBridgeRuntimeConfig(
   env: NormalizedRuntimeEnv,
-  _parsedEnvFile: ParsedEnvFile | null,
   document: ProjectConfigDocument | null,
   ingress: IngressPolicy,
 ): Result<BridgeRuntimeConfig, ConfigLoadError> {
@@ -105,3 +109,4 @@ function buildSingleRepoFallback(
     }],
   ]);
 }
+

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -5,20 +5,15 @@ import type {
 } from "../types.ts";
 import type { IngressPolicy } from "./ingress.ts";
 
-export type EnvFilePath = string & { readonly __brand: "EnvFilePath" };
 export type ProjectConfigPath = string & { readonly __brand: "ProjectConfigPath" };
+export type CanonicalConfigPath = string & { readonly __brand: "CanonicalConfigPath" };
 
 export interface ConfigSourcePaths {
-  readonly envFilePath: EnvFilePath | null;
   readonly projectConfigPath: ProjectConfigPath | null;
-}
-
-export interface ParsedEnvFile {
-  readonly values: Readonly<Record<string, string>>;
+  readonly canonicalConfigPath: CanonicalConfigPath;
 }
 
 export interface RawConfigFiles {
-  readonly envFileText: string | null;
   readonly projectConfigText: string | null;
 }
 
@@ -70,15 +65,21 @@ export interface ReloadedRuntimeConfig {
   readonly secretRotated: boolean;
 }
 
+export type CanonicalSecretField = "apiKey" | "webhookSecret";
+
 export type ConfigEnvError =
-  | { readonly _tag: "MalformedEnvLine"; readonly line: string }
-  | { readonly _tag: "MissingRequiredEnv"; readonly key: string }
   | { readonly _tag: "InvalidPort"; readonly raw: string }
-  | { readonly _tag: "SecretCollision"; readonly left: string; readonly right: string };
+  | {
+      readonly _tag: "SecretCollision";
+      readonly left: CanonicalSecretField;
+      readonly right: CanonicalSecretField;
+    };
 
 export type ConfigDiskError =
   | { readonly _tag: "ConfigFileUnreadable"; readonly path: string; readonly cause: string }
   | { readonly _tag: "ConfigFileInvalid"; readonly path: string; readonly cause: string }
+  | { readonly _tag: "CanonicalConfigMissing"; readonly path: string }
+  | { readonly _tag: "CanonicalConfigInvalid"; readonly path: string; readonly cause: string }
   | { readonly _tag: "DeprecatedSecretBinding"; readonly projectName: string; readonly secretEnvVar: string };
 
 export type ConfigLoadError = ConfigEnvError | ConfigDiskError;

--- a/start.sh
+++ b/start.sh
@@ -27,6 +27,17 @@ if [ ! -f "$PROJECT_DIR/agent-orchestrator.yaml" ]; then
   exit 1
 fi
 
+# Source project .env for non-secret operator env vars (gateway URLs, MoltZap
+# settings, etc.). Shared secrets come from ~/.zapbot/config.json below; the
+# bridge no longer parses .env on its own (zap#323), so start.sh must load it
+# here to match the systemd path's `EnvironmentFile=-PROJECT_DIR/.env`.
+if [ -f "$PROJECT_DIR/.env" ]; then
+  set -a
+  # shellcheck disable=SC1090,SC1091
+  . "$PROJECT_DIR/.env"
+  set +a
+fi
+
 # Load secrets from ~/.zapbot/config.json
 if [ ! -f "$HOME/.zapbot/config.json" ]; then
   echo "ERROR: $HOME/.zapbot/config.json not found."

--- a/templates/zapbot-bridge.service
+++ b/templates/zapbot-bridge.service
@@ -5,10 +5,9 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=__PROJECT_DIR__
-# Load secrets from ~/.zapbot/config.json (canonical path since sbd#160 / zap#320).
-# If a legacy .env still exists alongside config.json it is loaded as optional override.
-ExecStartPre=/bin/bash -c 'install -dm 700 /run/zapbot-bridge && jq -r "\"ZAPBOT_WEBHOOK_SECRET=\" + .webhookSecret, \"ZAPBOT_API_KEY=\" + .apiKey" "$HOME/.zapbot/config.json" > /run/zapbot-bridge/env'
-EnvironmentFile=/run/zapbot-bridge/env
+# Shared secrets (apiKey, webhookSecret) load from ~/.zapbot/config.json
+# inside the bridge itself. `.env` remains an optional override for legacy
+# operator env vars (e.g., MOLTZAP_*) during the broader migration.
 EnvironmentFile=-__PROJECT_DIR__/.env
 ExecStart=/usr/bin/env bun __ZAPBOT_DIR__/bin/webhook-bridge.ts
 ExecReload=/bin/kill -HUP $MAINPID

--- a/test/config-loader.test.ts
+++ b/test/config-loader.test.ts
@@ -8,6 +8,7 @@ import {
   type ConfigDiskReader,
 } from "../src/config/disk.js";
 import { resolveRuntimeEnv } from "../src/config/env.js";
+import type { CanonicalConfig } from "../src/config/canonical.js";
 import {
   deriveConfigSourcePaths,
   loadBridgeRuntimeConfig,
@@ -15,6 +16,13 @@ import {
 import type { IngressPolicy } from "../src/config/ingress.js";
 import type { ConfigDiskError } from "../src/config/types.js";
 import type { Result } from "../src/types.js";
+
+function canonical(overrides: Partial<CanonicalConfig> = {}): CanonicalConfig {
+  return {
+    apiKey: overrides.apiKey ?? "api-key-123",
+    webhookSecret: overrides.webhookSecret ?? "webhook-secret-456",
+  };
+}
 
 function expectOk<T, E>(result: Result<T, E>): T {
   if (result._tag === "Err") {
@@ -80,11 +88,9 @@ projects:
 
     const document = expectOk(parseProjectConfig(configPath, yaml));
     const env = expectOk(resolveRuntimeEnv({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
       ZAPBOT_CONFIG: configPath,
-    }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document, localOnlyIngress));
+    }, canonical()));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, document, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(1);
     expect(runtime.routes.has("chughtapan/zapbot")).toBe(true);
@@ -120,11 +126,8 @@ projects:
 `;
 
     const document = expectOk(parseProjectConfig("agent-orchestrator.yaml", yaml));
-    const env = expectOk(resolveRuntimeEnv({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
-    }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, document, localOnlyIngress));
+    const env = expectOk(resolveRuntimeEnv({}, canonical()));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, document, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(2);
     expect(runtime.routes.get("chughtapan/zapbot")!.projectName).toBe("zapbot");
@@ -134,11 +137,9 @@ projects:
 
   it("retains the single-repo fallback when no project config is present", () => {
     const env = expectOk(resolveRuntimeEnv({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
       ZAPBOT_REPO: "owner/my-repo",
-    }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null, localOnlyIngress));
+    }, canonical()));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(1);
     expect(runtime.routes.has("owner/my-repo")).toBe(true);
@@ -146,24 +147,18 @@ projects:
   });
 
   it("returns empty routes when neither project config nor ZAPBOT_REPO is provided", () => {
-    const env = expectOk(resolveRuntimeEnv({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "webhook-secret-456",
-    }, null));
-    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, null, localOnlyIngress));
+    const env = expectOk(resolveRuntimeEnv({}, canonical()));
+    const runtime = expectOk(loadBridgeRuntimeConfig(env, null, localOnlyIngress));
 
     expect(runtime.routes.size).toBe(0);
   });
 
-  it("derives .env next to the config path", () => {
-    const paths = deriveConfigSourcePaths("/tmp/project/agent-orchestrator.yaml");
-    expect(paths.projectConfigPath).toBe("/tmp/project/agent-orchestrator.yaml");
-    expect(paths.envFilePath).toBe("/tmp/project/.env");
-  });
-
   it("returns a disk error when the project config path is unreadable", () => {
     const result = readConfigFiles(
-      deriveConfigSourcePaths("/nonexistent/path/agent-orchestrator.yaml"),
+      deriveConfigSourcePaths(
+        "/nonexistent/path/agent-orchestrator.yaml",
+        { HOME: "/tmp" },
+      ),
       nodeDiskReader,
     );
 

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { parseEnvFile, resolveRuntimeEnv } from "../src/config/env.js";
+import { resolveRuntimeEnv } from "../src/config/env.js";
 import { resolveIngressPolicy } from "../src/config/ingress.js";
 import { reloadBridgeRuntimeConfig } from "../src/config/reload.js";
-import { loadBridgeRuntimeConfig } from "../src/config/load.js";
+import { deriveConfigSourcePaths, loadBridgeRuntimeConfig } from "../src/config/load.js";
+import { readCanonicalConfig } from "../src/config/canonical.js";
+import type { CanonicalConfig } from "../src/config/canonical.js";
 import { buildStartupReceipt, renderStartupReceipt } from "../src/startup/receipt.js";
 import { readConfigFiles, type ConfigDiskReader } from "../src/config/disk.js";
 import type { IngressPolicy } from "../src/config/ingress.js";
@@ -46,45 +48,115 @@ const localOnlyIngress: IngressPolicy = {
   requiresReachablePublicUrl: false,
 };
 
-function buildRuntime(
-  env: Record<string, string | undefined>,
-) {
-  const resolvedEnv = expectOk(resolveRuntimeEnv(env, null));
-  return expectOk(loadBridgeRuntimeConfig(resolvedEnv, null, null, localOnlyIngress));
+function canonical(overrides: Partial<CanonicalConfig> = {}): CanonicalConfig {
+  return {
+    apiKey: overrides.apiKey ?? "api-key-123",
+    webhookSecret: overrides.webhookSecret ?? "webhook-secret-456",
+  };
 }
 
-describe("parseEnvFile", () => {
-  it("parses simple key=value pairs", () => {
-    const result = expectOk(parseEnvFile("FOO=bar\nBAZ=qux"));
-    expect(result).toEqual({ values: { FOO: "bar", BAZ: "qux" } });
+function buildRuntime(
+  env: Record<string, string | undefined>,
+  canonicalConfig: CanonicalConfig = canonical(),
+) {
+  const resolvedEnv = expectOk(resolveRuntimeEnv(env, canonicalConfig));
+  return expectOk(loadBridgeRuntimeConfig(resolvedEnv, null, localOnlyIngress));
+}
+
+describe("readCanonicalConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "zapbot-canonical-test-"));
   });
 
-  it("skips comment lines", () => {
-    const result = expectOk(parseEnvFile("# comment\nFOO=bar\n# another"));
-    expect(result).toEqual({ values: { FOO: "bar" } });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("skips blank lines", () => {
-    const result = expectOk(parseEnvFile("FOO=bar\n\n\nBAZ=qux\n"));
-    expect(result).toEqual({ values: { FOO: "bar", BAZ: "qux" } });
+  it("decodes a valid config.json into the typed shape", () => {
+    const configPath = path.join(tmpDir, "config.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ webhookSecret: "wh-secret", apiKey: "api-key" }),
+    );
+
+    const decoded = expectOk(readCanonicalConfig(configPath, nodeDiskReader));
+    expect(decoded.webhookSecret).toBe("wh-secret");
+    expect(decoded.apiKey).toBe("api-key");
   });
 
-  it("handles values with equals signs", () => {
-    const result = expectOk(parseEnvFile("URL=http://localhost:3000?key=val&other=1"));
-    expect(result).toEqual({ values: { URL: "http://localhost:3000?key=val&other=1" } });
-  });
-
-  it("trims whitespace from keys", () => {
-    const result = expectOk(parseEnvFile("  FOO  =bar"));
-    expect(result).toEqual({ values: { FOO: "bar" } });
-  });
-
-  it("rejects malformed non-comment lines", () => {
-    const result = parseEnvFile("FOO=bar\nNOT_VALID");
+  it("reports CanonicalConfigMissing when the file is absent", () => {
+    const configPath = path.join(tmpDir, "does-not-exist.json");
+    const result = readCanonicalConfig(configPath, nodeDiskReader);
     expect(result._tag).toBe("Err");
     if (result._tag === "Err") {
-      expect(result.error._tag).toBe("MalformedEnvLine");
+      expect(result.error._tag).toBe("CanonicalConfigMissing");
     }
+  });
+
+  it("reports CanonicalConfigInvalid when JSON fails to parse", () => {
+    const configPath = path.join(tmpDir, "config.json");
+    fs.writeFileSync(configPath, "{not json");
+
+    const result = readCanonicalConfig(configPath, nodeDiskReader);
+    expect(result._tag).toBe("Err");
+    if (result._tag === "Err") {
+      expect(result.error._tag).toBe("CanonicalConfigInvalid");
+    }
+  });
+
+  it("reports CanonicalConfigInvalid when webhookSecret is empty", () => {
+    const configPath = path.join(tmpDir, "config.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ webhookSecret: "", apiKey: "api-key" }),
+    );
+
+    const result = readCanonicalConfig(configPath, nodeDiskReader);
+    expect(result._tag).toBe("Err");
+    if (result._tag === "Err") {
+      expect(result.error._tag).toBe("CanonicalConfigInvalid");
+    }
+  });
+
+  it("reports CanonicalConfigInvalid when required fields are missing", () => {
+    const configPath = path.join(tmpDir, "config.json");
+    fs.writeFileSync(configPath, JSON.stringify({ apiKey: "api-key" }));
+
+    const result = readCanonicalConfig(configPath, nodeDiskReader);
+    expect(result._tag).toBe("Err");
+    if (result._tag === "Err") {
+      expect(result.error._tag).toBe("CanonicalConfigInvalid");
+    }
+  });
+});
+
+describe("deriveConfigSourcePaths", () => {
+  it("honors ZAPBOT_CONFIG_JSON as the canonical path override", () => {
+    const override = "/tmp/custom-config.json";
+    const paths = deriveConfigSourcePaths(undefined, {
+      ZAPBOT_CONFIG_JSON: override,
+      HOME: "/home/ignored",
+    });
+    expect(paths.canonicalConfigPath).toBe(override);
+    expect(paths.projectConfigPath).toBeNull();
+  });
+
+  it("falls back to $HOME/.zapbot/config.json when no override is set", () => {
+    const paths = deriveConfigSourcePaths("/tmp/agent-orchestrator.yaml", {
+      HOME: "/home/alice",
+    });
+    expect(paths.canonicalConfigPath).toBe(path.join("/home/alice", ".zapbot", "config.json"));
+    expect(paths.projectConfigPath).toBe("/tmp/agent-orchestrator.yaml");
+  });
+
+  it("trims whitespace-only ZAPBOT_CONFIG_JSON to the default", () => {
+    const paths = deriveConfigSourcePaths(undefined, {
+      ZAPBOT_CONFIG_JSON: "   ",
+      HOME: "/home/bob",
+    });
+    expect(paths.canonicalConfigPath).toBe(path.join("/home/bob", ".zapbot", "config.json"));
   });
 });
 
@@ -235,16 +307,14 @@ describe("reloadBridgeRuntimeConfig", () => {
   });
 
   it("detects when the webhook secret rotates", () => {
-    const current = buildRuntime({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "old-secret",
-      ZAPBOT_REPO: "owner/repo",
-    });
-    const next = buildRuntime({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "new-secret",
-      ZAPBOT_REPO: "owner/repo",
-    });
+    const current = buildRuntime(
+      { ZAPBOT_REPO: "owner/repo" },
+      canonical({ webhookSecret: "old-secret" }),
+    );
+    const next = buildRuntime(
+      { ZAPBOT_REPO: "owner/repo" },
+      canonical({ webhookSecret: "new-secret" }),
+    );
 
     const result = expectOk(reloadBridgeRuntimeConfig(current, next));
     expect(result.secretRotated).toBe(true);
@@ -252,38 +322,35 @@ describe("reloadBridgeRuntimeConfig", () => {
   });
 
   it("detects when the webhook secret is unchanged", () => {
-    const current = buildRuntime({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "same-secret",
-      ZAPBOT_REPO: "owner/repo",
-    });
-    const next = buildRuntime({
-      ZAPBOT_API_KEY: "api-key-123",
-      ZAPBOT_WEBHOOK_SECRET: "same-secret",
-      ZAPBOT_REPO: "owner/repo",
-    });
+    const current = buildRuntime(
+      { ZAPBOT_REPO: "owner/repo" },
+      canonical({ webhookSecret: "same-secret" }),
+    );
+    const next = buildRuntime(
+      { ZAPBOT_REPO: "owner/repo" },
+      canonical({ webhookSecret: "same-secret" }),
+    );
 
     const result = expectOk(reloadBridgeRuntimeConfig(current, next));
     expect(result.secretRotated).toBe(false);
   });
 
-  it("treats missing .env as optional when reading config files", () => {
+  it("returns only projectConfigText when reading config files", () => {
     const configPath = path.join(tmpDir, "agent-orchestrator.yaml");
     fs.writeFileSync(configPath, "projects: {}\n");
 
     const result = expectOk(readConfigFiles({
-      envFilePath: path.join(tmpDir, ".env") as never,
       projectConfigPath: configPath as never,
+      canonicalConfigPath: path.join(tmpDir, "config.json") as never,
     }, nodeDiskReader));
 
-    expect(result.envFileText).toBeNull();
     expect(result.projectConfigText).toContain("projects:");
   });
 
   it("returns a disk error when the project config file does not exist", () => {
     const result = readConfigFiles({
-      envFilePath: null,
       projectConfigPath: path.join(tmpDir, "missing.yaml") as never,
+      canonicalConfigPath: path.join(tmpDir, "config.json") as never,
     }, nodeDiskReader);
 
     expect(result._tag).toBe("Err");
@@ -292,9 +359,11 @@ describe("reloadBridgeRuntimeConfig", () => {
     }
   });
 
-  it("resolves runtime env from parsed .env values", () => {
-    const parsed = expectOk(parseEnvFile("ZAPBOT_API_KEY=api\nZAPBOT_WEBHOOK_SECRET=secret\nZAPBOT_REPO=org/my-app\n"));
-    const result = expectOk(resolveRuntimeEnv({}, parsed));
+  it("resolves runtime env from the canonical config", () => {
+    const result = expectOk(resolveRuntimeEnv(
+      { ZAPBOT_REPO: "org/my-app" },
+      canonical({ apiKey: "api", webhookSecret: "secret" }),
+    ));
 
     expect(result.apiKey).toBe("api");
     expect(result.webhookSecret).toBe("secret");
@@ -635,7 +704,7 @@ exit 0
       fs.rmSync(tempRoot, { recursive: true, force: true });
       fs.rmSync(tempHome, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("keeps local-only startup running even if a stale bridge url is present", () => {
     const repoRoot = path.join(__dirname, "..");

--- a/test/systemd-service.test.ts
+++ b/test/systemd-service.test.ts
@@ -32,13 +32,13 @@ describe("systemd service template", () => {
     expect(content).toContain("Restart=always");
   });
 
-  it("loads secrets from config.json via ExecStartPre and keeps legacy .env as optional fallback", () => {
+  it("runs the bridge directly without an ExecStartPre preamble", () => {
     const content = fs.readFileSync(TEMPLATE_PATH, "utf-8");
-    expect(content).toContain("ExecStartPre=");
-    expect(content).toContain("config.json");
-    expect(content).toContain("ZAPBOT_WEBHOOK_SECRET");
-    expect(content).toContain("ZAPBOT_API_KEY");
-    // Legacy .env is optional (- prefix) so missing file does not abort the service
+    // Canonical config.json is read inside the bridge; no jq preamble.
+    expect(content).not.toContain("ExecStartPre=");
+    expect(content).not.toMatch(/\bjq\b/);
+    // Legacy .env is kept as an optional fallback for MOLTZAP_* and other
+    // operator env vars during the broader migration.
     expect(content).toContain("EnvironmentFile=-__PROJECT_DIR__/.env");
   });
 


### PR DESCRIPTION
Closes #323
Architect decision: https://github.com/chughtapan/zapbot/issues/322#issuecomment-4311025393

## What changed

New `src/config/canonical.ts` owns the decode of `~/.zapbot/config.json` through an Effect Schema with non-empty `webhookSecret` + `apiKey`. The bridge reads it once at boot and once per SIGHUP; `parseEnvFile` and all `.env`-parsing code are deleted per architect §6. Public signatures across `src/config/{env,load,disk,types}.ts` and `bin/webhook-bridge.ts` are rewired to carry `CanonicalConfig` instead of `ParsedEnvFile`. Two new `ConfigDiskError` variants (`CanonicalConfigMissing`, `CanonicalConfigInvalid`) are tagged and fed through `formatConfigError`, which ends in `absurd(x: never)` (Principle 4). `templates/zapbot-bridge.service` drops its `ExecStartPre`/jq preamble; `start.sh` sources `PROJECT_DIR/.env` itself to preserve direct-launch parity with systemd's `EnvironmentFile=-`.

## Traceability (architect §3 + acceptance §8)

| New artifact | Kind | Architect anchor | Acceptance § |
|---|---|---|---|
| `src/config/canonical.ts` | module | §3 row 1 | §1 |
| `CanonicalConfig` + `CanonicalConfigSchema` + `readCanonicalConfig` | public exports | §3 row 1 | §1 |
| `CanonicalConfigMissing` + `CanonicalConfigInvalid` | error variants | §3 row 3, §8 item 9 | §9 |
| `CanonicalConfigPath` branded type | public type | §3 row 3 | §5 |
| `resolveRuntimeEnv(env, canonical)` signature change | public fn | §3 row 2 | §2 |
| `deriveConfigSourcePaths` returns `{projectConfigPath, canonicalConfigPath}` | public fn | §3 row 5 | §5 |
| `loadBridgeRuntimeConfig` drops `_parsedEnvFile` | public fn | §3 row 5 | §4 |
| `parseEnvFile` + `ParsedEnvFile` + `MalformedEnvLine` | deleted | §3 rows 2-3, §6 | §3 |
| `MissingRequiredEnv` variant | deleted (dead post-canonical) | §2 (acceptance §2: "can no longer fire") | §2 |
| `bin/webhook-bridge.ts` rewire | entrypoint | §3 row 8 | §6 |
| `templates/zapbot-bridge.service` simplified | template | §3 row 9 | §7 |
| `start.sh` sources `.env` | script | codex P1 fix (§7 operator env retention) | implicit |

## Acceptance checklist

- [x] 1. `canonical.ts` exports `CanonicalConfig`, `CanonicalConfigSchema`, `readCanonicalConfig(path, reader)`
- [x] 2. `resolveRuntimeEnv(env, canonical)` — canonical fields authoritative for `apiKey`/`webhookSecret`
- [x] 3. `parseEnvFile`, `ParsedEnvFile`, `MalformedEnvLine` all deleted
- [x] 4. `loadBridgeRuntimeConfig` drops `_parsedEnvFile` param
- [x] 5. `deriveConfigSourcePaths` returns `{projectConfigPath, canonicalConfigPath}`; default `$HOME/.zapbot/config.json`; `ZAPBOT_CONFIG_JSON` override honored
- [x] 6. `bin/webhook-bridge.ts` reads canonical at boot + SIGHUP; `mergedEnv` plumbing removed
- [x] 7. `templates/zapbot-bridge.service` — no `ExecStartPre`; direct `ExecStart=`
- [x] 8. Tests updated: `config-reload.test.ts`, `systemd-service.test.ts` (+ mechanical fix to `config-loader.test.ts` from the signature changes); `team-init.test.ts` had no `.env` assertions to sweep
- [x] 9. Exhaustive switches on `ConfigDiskError` end in `absurd(x: never)`; new error tags wired into `formatConfigError`
- [x] 10. `bunx tsc --noEmit` clean; 423/423 vitest tests pass

## Scope

- **New modules:** 1 (`src/config/canonical.ts`)
- **New public exports:** `CanonicalConfig`, `CanonicalConfigSchema`, `readCanonicalConfig`, `CanonicalConfigPath`, `CanonicalSecretField`, `formatSchemaCause`
- **New deps:** 0 (Effect Schema already in tree)
- **Tier:** staff (new module + new public surface + coordinated rewire across 5 `src/config/*` files + entrypoint + template)

## Dependencies

None added. `effect` (3.21.1) already present for `src/config/disk.ts`.

## Tests

- `test/config-reload.test.ts` — new `describe("readCanonicalConfig")` (success, missing, malformed JSON, empty field, missing field) + new `describe("deriveConfigSourcePaths")` (override, default, whitespace); old `parseEnvFile` tests removed; `buildRuntime` helper takes `CanonicalConfig`.
- `test/config-loader.test.ts` — updated to new signatures; dropped `.env`-next-to-config-path assertion.
- `test/systemd-service.test.ts` — asserts no `ExecStartPre`/`jq` preamble; existing `ExecStart` assertion retained.

## Simplify skips

None. Simplify pass found 4 findings, all applied: `formatSchemaCause` exported from `disk.ts` and reused in `canonical.ts`; `existsSync` pre-check replaced with `ENOENT`-detection inside reader error; `MissingRequiredEnv` deleted as unreachable; `SecretCollision.left/right` narrowed to `CanonicalSecretField` literal union. Skipped reuse finding for `absurd`: `src/types.ts` does not export one, so each module carries its own.

## Codex diff review

Codex v0.123.0, `gpt-5.4`, `high` reasoning, review vs `origin/main`:

- **P1 (applied):** `start.sh` regresses direct-launch: `.env`-backed non-secret env vars no longer reach the bridge. Fix: `start.sh` now sources `PROJECT_DIR/.env` itself (matches systemd `EnvironmentFile=-`).
- **P2 (accepted):** SIGHUP hot-reload of `.env` edits is gone. This is the architect §6 direction — delete `parseEnvFile` and the dual-path branches it fed. Operators restart to pick up non-secret env changes; shared secrets still hot-reload via canonical config.

Verdict will be posted as a comment on sub-issue #323.

## Stamina

N=2 plan (internal cross-module, medium reversibility). Pass 1 = `/codex` above. Pass 2 = `/safer:review-senior` (team-lead gated, not self-invoked).

## Sub-issue labels

zapbot repo does not use `safer:*` labels yet; transition `planning` → `review` is tracked here instead of a label change.

## Confidence

**HIGH** — every artifact traces to architect §3 or acceptance §8; tsc clean; 423/423 tests pass; codex P1 applied; P2 deliberate per §6.