### PR TITLE
[arch] MoltZap app-sdk migration stubs (sbd#186)

### DIFF
--- a/src/moltzap/app-client.ts
+++ b/src/moltzap/app-client.ts
@@ -1,0 +1,184 @@
+/**
+ * moltzap/app-client — zapbot-scoped wrapper around `@moltzap/app-sdk`'s
+ * `MoltZapApp`.
+ *
+ * Anchors: sbd#170 SPEC rev 2, Invariants 1, 2, 6, 7, 8; §5 `MoltZapApp` and
+ * `app.onMessage` / `app.send` bullets; OQ #4 (one manifest per role); OQ #3
+ * (per-role-pair keys, no receive-side defensive check).
+ *
+ * This module is the single construction point for `MoltZapApp` in zapbot.
+ * Invariant 1 ("one `MoltZapApp` per process") is enforced here: `bootApp`
+ * returns the singleton; `currentApp` reads it; repeated `bootApp` calls
+ * error.
+ *
+ * Send-time role gate: zapbot constrains `app.send(key, parts)` to the keys
+ * `sendableKeysForRole(role)` permits. The check runs BEFORE the RPC is
+ * dispatched, so a worker that attempts to post on a key outside its role's
+ * sender set fails with `KeyDisallowedForRole` at the zapbot seam. This is
+ * the only role-pair check zapbot layers on top of the server; OQ #3 rejects
+ * client-side RECEIVE gates.
+ *
+ * Architect stage — bodies throw.
+ */
+
+import type { Effect } from "effect";
+import type {
+  AppSessionHandle,
+  MoltZapApp,
+  Part,
+  Message,
+  WsClientLogger,
+} from "@moltzap/app-sdk";
+import type { SessionRole } from "./session-role.ts";
+import type { ConversationKey } from "./conversation-keys.ts";
+import type {
+  MoltzapSenderId,
+  MoltzapConversationId,
+} from "./types.ts";
+
+// ── Boot config ─────────────────────────────────────────────────────
+
+export interface AppBootConfig {
+  readonly serverUrl: string;
+  /** The agentKey minted for this process (orchestrator or worker). */
+  readonly agentKey: string;
+  readonly role: SessionRole;
+  readonly logger?: WsClientLogger;
+  /**
+   * For the bridge/orchestrator path, the senderIds of every roster worker
+   * to invite at session-create time. Maps to `app.createSession({
+   * invitedAgentIds })` in the initial `start()` call. Ignored for worker
+   * roles (workers join an existing session driven by the bridge).
+   */
+  readonly invitedAgentIds?: readonly MoltzapSenderId[];
+}
+
+export type AppBootError =
+  | { readonly _tag: "AppBootAlreadyBooted" }
+  | { readonly _tag: "AppBootManifestInvalid"; readonly reason: string }
+  | {
+      readonly _tag: "AppBootConnectFailed";
+      readonly cause: string;
+    }
+  | {
+      readonly _tag: "AppBootSessionFailed";
+      readonly cause: string;
+    };
+
+// ── Send / receive errors ───────────────────────────────────────────
+
+export type SendErrorChannel =
+  | { readonly _tag: "KeyDisallowedForRole"; readonly role: SessionRole; readonly key: ConversationKey }
+  | { readonly _tag: "NoActiveSession" }
+  | { readonly _tag: "KeyNotInSession"; readonly key: ConversationKey }
+  | { readonly _tag: "SendRpcFailed"; readonly cause: string };
+
+export type HandlerRegistrationError =
+  | { readonly _tag: "KeyNotReceivableForRole"; readonly role: SessionRole; readonly key: ConversationKey }
+  | { readonly _tag: "HandlerAlreadyRegistered"; readonly key: ConversationKey };
+
+// ── Handle + public surface ─────────────────────────────────────────
+
+/**
+ * Opaque handle returned by `bootApp`. Narrow surface; wraps `MoltZapApp`
+ * rather than re-exporting it so Invariant 1 ("one MoltZapApp per process")
+ * stays enforced — consumers cannot construct a second `MoltZapApp` by
+ * reaching into the handle.
+ */
+export interface ZapbotMoltZapAppHandle {
+  readonly role: SessionRole;
+  /** Escape hatch for tests only. */
+  readonly __unsafeInner: MoltZapApp;
+  /** Awaited once the initial `app.start()` resolves. */
+  readonly session: AppSessionHandle;
+}
+
+export type MessageHandler = (message: Message) => void | Promise<void>;
+export type SessionReadyHandler = (
+  session: AppSessionHandle,
+) => void | Promise<void>;
+
+/**
+ * Boot the single `MoltZapApp` for this process. Calls
+ *   1. `loadAppIdentity` (manifest.ts),
+ *   2. `buildOrchestratorManifest` or `buildWorkerManifest` per `role`,
+ *   3. `verifyManifestKeys` against the role's expected keys,
+ *   4. `new MoltZapApp({...}).startAsync()`.
+ *
+ * Invariant 1: a second call to `bootApp` in the same process returns
+ * `AppBootAlreadyBooted` without connecting.
+ */
+export function bootApp(
+  config: AppBootConfig,
+): Effect.Effect<ZapbotMoltZapAppHandle, AppBootError> {
+  throw new Error("not implemented");
+}
+
+/** Return the booted app handle, or `null` if `bootApp` has not run. */
+export function currentApp(): ZapbotMoltZapAppHandle | null {
+  throw new Error("not implemented");
+}
+
+/**
+ * Stop and tear down the booted app. Invariant 1 enforcement on graceful
+ * shutdown: drains the app then clears the singleton so a subsequent
+ * `bootApp` is allowed.
+ */
+export function shutdownApp(): Effect.Effect<void, never> {
+  throw new Error("not implemented");
+}
+
+// ── Messaging ───────────────────────────────────────────────────────
+
+/**
+ * Send `parts` to the conversation named by `key`. Runs the role gate
+ * (`sendableKeysForRole`) BEFORE dispatching the RPC. OQ #3 tie: the gate is
+ * on the SEND side only; no receive-side gate.
+ */
+export function sendOnKey(
+  handle: ZapbotMoltZapAppHandle,
+  key: ConversationKey,
+  parts: readonly Part[],
+): Effect.Effect<void, SendErrorChannel> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Register a handler for inbound messages on `key`. Gated by
+ * `receivableKeysForRole`: a worker cannot register a handler on a key its
+ * role does not receive.
+ *
+ * NOTE (Invariant 6): the receiver trusts the key. This function does NOT
+ * inspect `message.senderId` or a role field in the body. The SEND-side
+ * role gate + role-scoped manifest declare what messages can appear on a
+ * given key; the receiver acts on the key alone.
+ */
+export function onMessageForKey(
+  handle: ZapbotMoltZapAppHandle,
+  key: ConversationKey,
+  handler: MessageHandler,
+): HandlerRegistrationError | null {
+  throw new Error("not implemented");
+}
+
+/** Register a session-ready handler. Thin pass-through to `MoltZapApp`. */
+export function onSessionReady(
+  handle: ZapbotMoltZapAppHandle,
+  handler: SessionReadyHandler,
+): void {
+  throw new Error("not implemented");
+}
+
+// ── Conversation-id resolution ──────────────────────────────────────
+
+/**
+ * Resolve a typed key to the live `conversationId` in the current session.
+ * Used by callers that must hand a raw id to a non-sdk path (e.g., the
+ * `conversations/addParticipant` roster-admit path in `roster-admit.ts`).
+ */
+export function resolveKeyToConversationId(
+  handle: ZapbotMoltZapAppHandle,
+  key: ConversationKey,
+): MoltzapConversationId | { readonly _tag: "KeyNotInSession"; readonly key: ConversationKey } {
+  throw new Error("not implemented");
+}

--- a/src/moltzap/conversation-keys.ts
+++ b/src/moltzap/conversation-keys.ts
@@ -1,0 +1,110 @@
+/**
+ * moltzap/conversation-keys — typed role-pair conversation keys.
+ *
+ * Anchors: sbd#170 SPEC rev 2, Invariants 2, 5, 6; §5 "one conversation key
+ * per directional role-pair"; OQ #3 resolution (per-role-pair keys, no
+ * receive-side defensive check).
+ *
+ * This module owns the finite, named set of coordination-channel keys that
+ * zapbot declares in every `AppManifest` registered with `@moltzap/app-sdk`.
+ * It is the single authoritative place where role-pair directionality is
+ * encoded; role-scoped manifests (src/moltzap/manifest.ts) project a subset
+ * of this set per `SessionRole`.
+ *
+ * Invariant 6 (verbatim): "the conversation key carries the role-pair; the
+ * receiver trusts the key, not a role field in the payload body." This module
+ * declares the key set; `manifest.ts` binds each key to the roles that may
+ * send/receive on it.
+ *
+ * Implementation stubs. Architect stage — bodies throw.
+ */
+
+import type { SessionRole } from "./session-role.ts";
+
+// ── Keys ────────────────────────────────────────────────────────────
+
+/**
+ * Finite set of role-pair conversation keys. One key per directed role-pair
+ * type per rev 2 §5 acceptance bullet. No wildcard key; no dynamic key
+ * construction; every value declared here is a compile-time string literal so
+ * the union is exhaustive at switch sites.
+ *
+ * Principle 4 handling: every switch over `ConversationKey` ends in
+ * `absurd(key)`.
+ */
+export type ConversationKey =
+  | "coord-orch-to-worker"
+  | "coord-worker-to-orch"
+  | "coord-architect-peer"
+  | "coord-implementer-to-architect"
+  | "coord-review-to-author";
+
+export const ALL_CONVERSATION_KEYS: readonly ConversationKey[] = [
+  "coord-orch-to-worker",
+  "coord-worker-to-orch",
+  "coord-architect-peer",
+  "coord-implementer-to-architect",
+  "coord-review-to-author",
+];
+
+// ── Role-pair directionality ────────────────────────────────────────
+
+/**
+ * For each key, the roles that may send on it and the roles that may receive
+ * on it. Used to build role-scoped manifests in `manifest.ts` and to gate
+ * send-time calls in `app-client.ts`.
+ *
+ * Invariant 6: directionality is declared here, not at the receive site.
+ * Receivers trust the key; the send-set + the role-scoped manifest registered
+ * with the server enforce the sender side.
+ */
+export interface RolePairBinding {
+  readonly key: ConversationKey;
+  readonly senders: ReadonlySet<SessionRole>;
+  readonly receivers: ReadonlySet<SessionRole>;
+}
+
+/**
+ * The full binding table. Every entry is referenced by at least one role's
+ * manifest; every key appears exactly once.
+ */
+export function getRolePairBindings(): readonly RolePairBinding[] {
+  throw new Error("not implemented");
+}
+
+/**
+ * Which keys a role of `role` may send on. Used to constrain
+ * `ZapbotMoltZapApp.send(key, parts)` at the zapbot seam (pre-RPC). A role
+ * that calls `send` with a key not in this set is rejected with
+ * `KeyDisallowedForRole` before any `messages/send` RPC is attempted.
+ */
+export function sendableKeysForRole(
+  role: SessionRole,
+): ReadonlySet<ConversationKey> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Which keys a role of `role` may receive on. Used to decide which
+ * `app.onMessage(key, handler)` registrations are allowed at boot in
+ * `app-client.ts`.
+ */
+export function receivableKeysForRole(
+  role: SessionRole,
+): ReadonlySet<ConversationKey> {
+  throw new Error("not implemented");
+}
+
+// ── Decode ──────────────────────────────────────────────────────────
+
+export type ConversationKeyDecodeError = {
+  readonly _tag: "UnknownConversationKey";
+  readonly raw: string;
+};
+
+/** Principle 2 boundary: wire string → typed key. */
+export function decodeConversationKey(
+  raw: string,
+): ConversationKey | ConversationKeyDecodeError {
+  throw new Error("not implemented");
+}

--- a/src/moltzap/manifest.ts
+++ b/src/moltzap/manifest.ts
@@ -1,0 +1,151 @@
+/**
+ * moltzap/manifest — role-scoped AppManifest builders.
+ *
+ * Anchors: sbd#170 SPEC rev 2, §5 bullets on bridge/worker `MoltZapApp`
+ * construction; OQ #4 resolution (one manifest per role, bridge = orchestrator
+ * manifest, each worker = role-specific manifest); Invariants 2, 5.
+ *
+ * OQ #4 decision (binding): one `AppManifest` per `SessionRole`. Bridge
+ * constructs `buildOrchestratorManifest()`; each worker constructs
+ * `buildWorkerManifest(role)`. Role-scoped manifests declare ONLY the
+ * conversation keys the role legitimately participates in (per the role-pair
+ * binding table in `conversation-keys.ts`), giving least-privilege
+ * declaration at the manifest boundary.
+ *
+ * Invariant 5 (session-level admission) is server-enforced by the bridge
+ * manifest's `participantFilter` fields + `permissions`. Worker manifests
+ * share the same `appId`; the server's authoritative session topology comes
+ * from the bridge's manifest at `apps/create` time.
+ *
+ * Architect stage — bodies throw.
+ */
+
+import type {
+  AppManifest,
+  AppManifestConversation,
+  AppPermission,
+} from "@moltzap/app-sdk";
+import type { SessionRole } from "./session-role.ts";
+import type { ConversationKey } from "./conversation-keys.ts";
+
+// ── App identity ────────────────────────────────────────────────────
+
+/**
+ * Zapbot's `appId` for `apps/register`. One global constant so every process
+ * (bridge and workers) registers against the same app. Implementations read
+ * it from env via `loadAppIdentity`.
+ */
+export const ZAPBOT_APP_ID = "zapbot-ws2" as const;
+
+export interface AppIdentity {
+  readonly appId: typeof ZAPBOT_APP_ID;
+  readonly displayName: string;
+  readonly description: string;
+}
+
+export type AppIdentityDecodeError = {
+  readonly _tag: "AppIdentityDecodeError";
+  readonly reason: string;
+};
+
+/** Principle 2 boundary. Decode env → typed identity. */
+export function loadAppIdentity(
+  env: Record<string, string | undefined>,
+): AppIdentity | AppIdentityDecodeError {
+  throw new Error("not implemented");
+}
+
+// ── Permissions ─────────────────────────────────────────────────────
+
+/**
+ * The zapbot permission set, declared once. Per-role manifests project a
+ * subset of this via `permissionsForRole`. `permissions.required` vs
+ * `permissions.optional` split is owned by the implement stage; the shape is
+ * reused from `@moltzap/app-sdk`'s `AppPermission`.
+ */
+export function getZapbotPermissions(): {
+  readonly required: readonly AppPermission[];
+  readonly optional: readonly AppPermission[];
+} {
+  throw new Error("not implemented");
+}
+
+export function permissionsForRole(role: SessionRole): {
+  readonly required: readonly AppPermission[];
+  readonly optional: readonly AppPermission[];
+} {
+  throw new Error("not implemented");
+}
+
+// ── Conversation block builders ─────────────────────────────────────
+
+/**
+ * Build an `AppManifestConversation` block for `key`. `participantFilter`
+ * is one of `"all" | "initiator"` (Invariant 5 + Spike C: `"none"` is not
+ * relied on).
+ *
+ * Bridge (orchestrator) manifest uses `"all"` for every conversation so all
+ * session-admitted agents are seeded into every conversation; role-pair
+ * directionality is enforced structurally by which role-scoped manifest
+ * declares which keys (sender side) plus the receive-key trust rule
+ * (Invariant 6).
+ */
+export function conversationBlock(
+  key: ConversationKey,
+  participantFilter: "all" | "initiator",
+): AppManifestConversation {
+  throw new Error("not implemented");
+}
+
+// ── Role-scoped manifests ───────────────────────────────────────────
+
+/**
+ * Build the bridge's orchestrator manifest. Declares ALL 5 conversation
+ * keys; this is the manifest the server uses at `apps/create` time to
+ * materialize the session's conversation topology.
+ *
+ * OQ #4 tie: "bridge uses the orchestrator manifest."
+ * Invariant 2 tie: "AppManifest is the source of truth for conversation keys."
+ */
+export function buildOrchestratorManifest(
+  identity: AppIdentity,
+): AppManifest {
+  throw new Error("not implemented");
+}
+
+/**
+ * Build a worker manifest. Declares ONLY the keys the role legitimately
+ * sends or receives on, per `conversation-keys.ts` bindings.
+ *
+ * OQ #4 tie: "each worker uses a role-specific manifest declaring only the
+ * conversation keys that role legitimately participates in."
+ *
+ * Note: the server's session topology is driven by the BRIDGE's manifest at
+ * session-create time. A worker's role-scoped manifest is still registered
+ * via `apps/register` against the worker's own agent credential; its keys
+ * are the keys the worker's own `MoltZapApp` instance is authorized to use.
+ * Role-scoping here bounds what the worker's SDK will send or subscribe to.
+ */
+export function buildWorkerManifest(
+  identity: AppIdentity,
+  role: Exclude<SessionRole, "orchestrator">,
+): AppManifest {
+  throw new Error("not implemented");
+}
+
+/**
+ * Verify that `manifest` declares exactly the keys `expected`. Invariant 2
+ * gate called at `ZapbotMoltZapApp` boot; divergence is a boot-time error.
+ */
+export type ManifestKeyMismatch = {
+  readonly _tag: "ManifestKeyMismatch";
+  readonly expected: readonly ConversationKey[];
+  readonly declared: readonly string[];
+};
+
+export function verifyManifestKeys(
+  manifest: AppManifest,
+  expected: readonly ConversationKey[],
+): ManifestKeyMismatch | null {
+  throw new Error("not implemented");
+}

--- a/src/moltzap/mcp-adapter.ts
+++ b/src/moltzap/mcp-adapter.ts
@@ -1,0 +1,106 @@
+/**
+ * moltzap/mcp-adapter — app-sdk → MCP notification forwarder.
+ *
+ * Anchors: sbd#170 SPEC rev 2, §5 "thin adapter forwards `app.onMessage`
+ * payloads to MCP notifications"; research verdict §(b) item 4 ("MCP-as-
+ * Claude-transport stays; simplify; do not remove"); deletion list
+ * `src/moltzap/bridge.ts` + `src/moltzap/channel-runtime.ts` collapse into
+ * this adapter.
+ *
+ * This module owns exactly one boundary: mapping a `@moltzap/app-sdk`
+ * `Message` (received via `onMessageForKey`) to a typed
+ * `ClaudeChannelNotification` and emitting it through the booted
+ * `ClaudeChannelServerHandle`. No protocol translation outside that seam.
+ *
+ * Design intent vs deleted `bridge.ts`: the deleted module carried a
+ * `BridgeRuntime` + dispatch table + listener lifecycle; the app-sdk now
+ * owns lifecycle, dispatch, and reconnect, so this adapter is a function
+ * that knows ONE thing: how to turn `Message` into `ClaudeChannelNotification`.
+ *
+ * Size budget: <=60 LOC implemented body. If impl exceeds this, re-read the
+ * "collapse into the adapter above" line in the deletion table.
+ *
+ * Architect stage — bodies throw.
+ */
+
+import type { Message } from "@moltzap/app-sdk";
+import type {
+  ClaudeChannelNotification,
+} from "../claude-channel/event.ts";
+import type { ClaudeChannelServerHandle } from "../claude-channel/server.ts";
+import type { ConversationKey } from "./conversation-keys.ts";
+import type { MoltzapConversationId, MoltzapSenderId } from "./types.ts";
+
+// ── Inputs ──────────────────────────────────────────────────────────
+
+export interface McpAdapterContext {
+  readonly channel: ClaudeChannelServerHandle;
+  /**
+   * Identity the local process advertises to Claude notifications.
+   * Carried through from `AppBootConfig` (orchestrator or worker sender).
+   */
+  readonly localSenderId: MoltzapSenderId;
+  /**
+   * For worker roles, the bridge's senderId — stamped on inbound
+   * notifications so Claude can reply via MCP `reply` tool. Null for the
+   * bridge itself.
+   */
+  readonly orchestratorSenderId: MoltzapSenderId | null;
+}
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+export type McpAdapterError =
+  | {
+      readonly _tag: "UnknownMessageShape";
+      readonly reason: string;
+      readonly messageId: string;
+    }
+  | {
+      readonly _tag: "McpNotifyFailed";
+      readonly cause: string;
+    };
+
+// ── Public surface ──────────────────────────────────────────────────
+
+/**
+ * Convert one `Message` on `key` into a `ClaudeChannelNotification`. Pure;
+ * no I/O. Principle 3 tie: returns an error union, never throws.
+ */
+export function toClaudeNotification(
+  key: ConversationKey,
+  message: Message,
+  ctx: McpAdapterContext,
+): ClaudeChannelNotification | McpAdapterError {
+  throw new Error("not implemented");
+}
+
+/**
+ * Forwarder registered as the `app.onMessage(key, handler)` for EVERY key
+ * in `receivableKeysForRole(role)`. Wraps `toClaudeNotification` and
+ * dispatches via `ctx.channel.emit(notification)` (or equivalent on the
+ * existing `ClaudeChannelServerHandle` surface).
+ *
+ * This is the single bridge zapbot holds between the app-sdk receive path
+ * and the MCP transport; it is the zapbot equivalent of the deleted
+ * `bridge.ts` + `channel-runtime.ts`.
+ */
+export function makeMcpForwardHandler(
+  key: ConversationKey,
+  ctx: McpAdapterContext,
+): (message: Message) => Promise<void> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Install one forwarder per receivable key at boot. Called once by the bin
+ * entrypoint (`bin/moltzap-claude-channel.ts`) after `bootApp` resolves.
+ * Returns the list of keys that were wired up — used for boot-log output
+ * and as the gate for "did we register everything we should?".
+ */
+export function wireMcpAdapter(
+  ctx: McpAdapterContext,
+  receivableKeys: readonly ConversationKey[],
+): readonly ConversationKey[] {
+  throw new Error("not implemented");
+}

--- a/src/moltzap/roster-admit.ts
+++ b/src/moltzap/roster-admit.ts
@@ -1,0 +1,130 @@
+/**
+ * moltzap/roster-admit — late-joiner conversation-level admission helper.
+ *
+ * Anchors: sbd#170 SPEC rev 2, Invariant 11; Non-goal 8; §5 "Roster-growth
+ * handling (post-Spike A)" bullet; Spike A verdict (sbd#181): public RPC
+ * `apps/admitParticipant` does NOT exist upstream; `conversations/
+ * addParticipant` admits conversation-level only.
+ *
+ * v1 scope (binding): late-joining roster members are admitted to
+ * conversations only, not to the `app_session_participants` row. This
+ * module encapsulates that one call and the set of conversations a new
+ * joiner is added to, derived from `receivableKeysForRole(role)` plus
+ * `sendableKeysForRole(role)` for the joiner's role.
+ *
+ * Non-goal 8 fence: this module does NOT paper over session-level
+ * admission. If `apps/admitParticipant` (or equivalent) ships upstream,
+ * `admitLateJoiner` gains a session-level branch; until then, the function
+ * returns `LateJoinerSessionLevelUnavailable` on request for that path —
+ * callers receive a typed no-op receipt, not a silent success.
+ *
+ * Architect stage — bodies throw.
+ */
+
+import type { Effect } from "effect";
+import type { AppSessionHandle, MoltZapApp } from "@moltzap/app-sdk";
+import type { SessionRole } from "./session-role.ts";
+import type { ConversationKey } from "./conversation-keys.ts";
+import type {
+  MoltzapSenderId,
+  MoltzapConversationId,
+} from "./types.ts";
+
+// ── Inputs ──────────────────────────────────────────────────────────
+
+export interface LateJoinerAdmitRequest {
+  readonly joinerSenderId: MoltzapSenderId;
+  readonly joinerRole: Exclude<SessionRole, "orchestrator">;
+  /**
+   * The bridge's handle; the bridge is the session initiator and holds
+   * `role: "owner"` on every manifest conversation. Only the bridge may
+   * invoke `conversations/addParticipant` (Spike A §"conversation-level
+   * admission: yes" condition).
+   */
+  readonly bridgeApp: MoltZapApp;
+  readonly session: AppSessionHandle;
+}
+
+/**
+ * Concrete per-role mapping of which conversations a late joiner is added
+ * to. Enumerated per conversation key; resolved at call time via
+ * `conversation-keys.ts`.
+ *
+ * Addresses codex round-2 "relevant conversation(s) vagueness" concern:
+ * for EACH joiner role, the concrete set of keys admitted is the union of
+ * `sendableKeysForRole(role) ∪ receivableKeysForRole(role)`. Implementation
+ * computes this union; the set is finite and enumerable at call time.
+ *
+ * v1 per-role add-to sets (computed, not hard-coded):
+ *   architect   → coord-orch-to-worker, coord-worker-to-orch,
+ *                 coord-architect-peer, coord-implementer-to-architect,
+ *                 coord-review-to-author
+ *   implementer → coord-orch-to-worker, coord-worker-to-orch,
+ *                 coord-implementer-to-architect, coord-review-to-author
+ *   reviewer    → coord-orch-to-worker, coord-worker-to-orch,
+ *                 coord-review-to-author
+ *
+ * Implementation derives these lists from the `conversation-keys.ts`
+ * bindings. The per-role union is computed there; this module only owns
+ * the wire-up.
+ */
+export function conversationsToAdmitForRole(
+  role: Exclude<SessionRole, "orchestrator">,
+): readonly ConversationKey[] {
+  throw new Error("not implemented");
+}
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+export type LateJoinerAdmitError =
+  | {
+      readonly _tag: "NotInitiator";
+      readonly reason: string;
+    }
+  | {
+      readonly _tag: "KeyNotInSession";
+      readonly key: ConversationKey;
+    }
+  | {
+      readonly _tag: "AddParticipantRpcFailed";
+      readonly key: ConversationKey;
+      readonly cause: string;
+    }
+  | {
+      readonly _tag: "LateJoinerSessionLevelUnavailable";
+      readonly upstreamIssue: "https://github.com/chughtapan/moltzap/issues/206";
+    };
+
+export interface LateJoinerAdmitResult {
+  readonly joinerSenderId: MoltzapSenderId;
+  readonly joinerRole: Exclude<SessionRole, "orchestrator">;
+  readonly admittedTo: readonly {
+    readonly key: ConversationKey;
+    readonly conversationId: MoltzapConversationId;
+  }[];
+  /**
+   * v1: always `false`. Upstream tracking ticket is moltzap#206. When the
+   * upstream RPC ships, this becomes a decision in `admitLateJoiner` and
+   * the field reflects whether the session-level admission ran.
+   */
+  readonly admittedAtSessionLevel: boolean;
+}
+
+// ── Public surface ──────────────────────────────────────────────────
+
+/**
+ * Admit a late-joining roster member to conversation-level membership.
+ * MUST be called from the bridge process (the session initiator). For
+ * each key in `conversationsToAdmitForRole(joinerRole)`, invokes
+ * `conversations/addParticipant` via `bridgeApp.client.sendRpc`.
+ *
+ * v1 scope: returns `LateJoinerAdmitResult` with
+ * `admittedAtSessionLevel: false` on success. Callers that require
+ * session-level admission (on_join hooks, getSession visibility) get a
+ * typed receipt of the limitation, not a silent gap.
+ */
+export function admitLateJoiner(
+  request: LateJoinerAdmitRequest,
+): Effect.Effect<LateJoinerAdmitResult, LateJoinerAdmitError> {
+  throw new Error("not implemented");
+}

--- a/test/integration/globalSetup.ts
+++ b/test/integration/globalSetup.ts
@@ -1,0 +1,50 @@
+/**
+ * test/integration/globalSetup — vitest globalSetup for MoltZap integration.
+ *
+ * Anchors: sbd#170 SPEC rev 2, §5 CI-fixture bullet (a)-(f); Spike B verdict
+ * (sbd#182).
+ *
+ * Spec-binding constraints this module realizes:
+ *   (a) subprocess backed by `node ~/moltzap/packages/server/dist/standalone.js`
+ *   (b) PGlite (no docker, no external DB)
+ *   (c) fresh subprocess per suite — NOT per test (12–15 s cold boot)
+ *   (d) `ENCRYPTION_MASTER_SECRET` sourced as 32-byte base64 at suite setup
+ *   (e) subprocess SIGTERMed at suite teardown
+ *   (f) tests reach the server over HTTP+WS at `localhost:<port>`
+ *
+ * Pre-req (operator note): `pnpm install && pnpm build` in `~/moltzap/` has
+ * been run once. The setup fails fast with a named error if the standalone
+ * binary is missing.
+ *
+ * Architect stage — body throws.
+ */
+
+export interface MoltzapTestServerHandle {
+  readonly httpBaseUrl: string;
+  readonly wsBaseUrl: string;
+  readonly pid: number;
+}
+
+export type GlobalSetupError =
+  | { readonly _tag: "StandaloneBinaryMissing"; readonly expectedPath: string }
+  | { readonly _tag: "BootTimeout"; readonly waitedMs: number }
+  | { readonly _tag: "UnexpectedSubprocessExit"; readonly exitCode: number; readonly stderr: string }
+  | { readonly _tag: "EncryptionSecretInvalid"; readonly reason: string };
+
+/**
+ * vitest calls this once before the suite runs. Returns a teardown function
+ * that vitest invokes after the suite completes.
+ *
+ * Impl contract:
+ *   1. Resolve path to `~/moltzap/packages/server/dist/standalone.js`.
+ *   2. Generate 32-byte base64 via `openssl rand -base64 32` (or equivalent).
+ *   3. Spawn the subprocess with env `ENCRYPTION_MASTER_SECRET`,
+ *      `MOLTZAP_CONFIG`, `PORT=0` (or fixed).
+ *   4. Poll HTTP `/health` (or equivalent) until 200 or `BootTimeout`.
+ *   5. Publish `MOLTZAP_TEST_HTTP_BASE` + `MOLTZAP_TEST_WS_BASE` to `globalThis`
+ *      so test files can read them.
+ *   6. Return teardown that SIGTERMs the pid.
+ */
+export default function setup(): Promise<() => Promise<void>> {
+  throw new Error("not implemented");
+}

--- a/test/integration/moltzap-app-addparticipant.integration.test.ts
+++ b/test/integration/moltzap-app-addparticipant.integration.test.ts
@@ -1,0 +1,26 @@
+/**
+ * test/integration/moltzap-app-addparticipant — late-joiner admission.
+ *
+ * Anchors: sbd#170 SPEC rev 2, §5 roster-growth bullet; Invariant 11;
+ * Non-goal 8; Spike A verdict (sbd#181).
+ */
+
+import { describe, it } from "vitest";
+
+describe("moltzap app-sdk integration — late-joiner conversation admission", () => {
+  it.todo(
+    "admitLateJoiner called from bridge adds joiner to conversation_participants for every receivable+sendable key of joiner role",
+  );
+  it.todo(
+    "admitLateJoiner result reports admittedAtSessionLevel=false (v1 scope)",
+  );
+  it.todo(
+    "late joiner receives WS messages posted on admitted keys after admission",
+  );
+  it.todo(
+    "late joiner is NOT listed by apps/getSession (Invariant 11)",
+  );
+  it.todo(
+    "admitLateJoiner called from a non-initiator process returns NotInitiator error",
+  );
+});

--- a/test/integration/moltzap-app-role-pair.integration.test.ts
+++ b/test/integration/moltzap-app-role-pair.integration.test.ts
@@ -1,0 +1,27 @@
+/**
+ * test/integration/moltzap-app-role-pair — role-pair key routing.
+ *
+ * Anchors: sbd#170 SPEC rev 2, §5 "architect posts via app-sdk conversation,
+ * implementer consumes via MCP notification, bridge routes per manifest";
+ * Invariants 6, 7.
+ */
+
+import { describe, it } from "vitest";
+
+describe("moltzap app-sdk integration — role-pair routing", () => {
+  it.todo(
+    "architect sendOnKey('coord-implementer-to-architect'...) is rejected at send gate (wrong direction)",
+  );
+  it.todo(
+    "implementer sendOnKey('coord-implementer-to-architect', parts) delivers to architect onMessage handler",
+  );
+  it.todo(
+    "architect sendOnKey('coord-architect-peer', parts) delivers to a second architect's handler",
+  );
+  it.todo(
+    "reviewer cannot register onMessageForKey('coord-architect-peer') — HandlerRegistrationError",
+  );
+  it.todo(
+    "orchestrator sendOnKey('coord-orch-to-worker', parts) delivers to every worker",
+  );
+});

--- a/test/integration/moltzap-app-roster.integration.test.ts
+++ b/test/integration/moltzap-app-roster.integration.test.ts
@@ -1,0 +1,26 @@
+/**
+ * test/integration/moltzap-app-roster — end-to-end integration test.
+ *
+ * Anchors: sbd#170 SPEC rev 2, §5 integration-PR bullets on
+ * `app.createSession({invitedAgentIds})` and 2-member roster round trip.
+ *
+ * Architect stage — `it.todo` entries declare the test surface. Bodies
+ * land in implement-* stage.
+ */
+
+import { describe, it } from "vitest";
+
+describe("moltzap app-sdk integration — roster session", () => {
+  it.todo(
+    "bridge constructs MoltZapApp with orchestrator manifest and starts session",
+  );
+  it.todo(
+    "app.createSession({invitedAgentIds}) seeds conversation_participants for every manifest key",
+  );
+  it.todo(
+    "second party not in invitedAgentIds is rejected at apps/create, not by the client",
+  );
+  it.todo(
+    "session conversation map carries all 5 role-pair keys for the orchestrator manifest",
+  );
+});

--- a/test/integration/vitest.integration.config.ts
+++ b/test/integration/vitest.integration.config.ts
@@ -1,0 +1,21 @@
+/**
+ * test/integration/vitest.integration.config — integration-suite vitest config.
+ *
+ * Anchors: sbd#170 SPEC rev 2, §5 "CI integration fixture (post-Spike B,
+ * operator-binding constraints)"; Spike B verdict (sbd#182): vitest
+ * `globalSetup` + `standalone.js` subprocess + PGlite + 32-byte base64
+ * `ENCRYPTION_MASTER_SECRET` + SIGTERM teardown.
+ *
+ * Architect stage — body throws. Implementation reads `globalSetup` +
+ * `globalTeardown` from the files in this directory and sets `testTimeout`
+ * high enough to amortize the 12–15 s cold boot budget spike B measured.
+ */
+
+// Stub exists so implement-* can fill in. vitest will import the default
+// export at runtime; the architect-stage body is a typed throw so an
+// accidental test invocation fails loudly instead of silently picking up
+// the unit-test config.
+
+export default (function stub(): never {
+  throw new Error("not implemented");
+})();


### PR DESCRIPTION
Architecture only. Not for merge.

**Design doc:** sbd#170 architect-stage comment (link posted after publish).
**Sub-issue:** chughtapan/safer-by-default#186
**Spec rev 2 (binding):** chughtapan/safer-by-default#170 (comment 4311660664)

## What this PR is

5 new modules + integration-test scaffolding. Every body is \`throw new Error("not implemented")\`. Downstream implement-staff lands bodies + deletes the §7 deletion list in the same implement PR.

### New modules
- \`src/moltzap/conversation-keys.ts\` — 5 role-pair keys + binding table (Invariant 6, OQ #3)
- \`src/moltzap/manifest.ts\` — per-role AppManifest builders (OQ #4)
- \`src/moltzap/app-client.ts\` — single-per-process MoltZapApp wrapper, send-side role gate (Invariants 1, 6)
- \`src/moltzap/mcp-adapter.ts\` — app.onMessage → MCP notification forwarder (deletes bridge.ts + channel-runtime.ts)
- \`src/moltzap/roster-admit.ts\` — conversations/addParticipant late-joiner path (Invariant 11, Non-goal 8)

### Test scaffolding
- \`test/integration/vitest.integration.config.ts\`, \`globalSetup.ts\`
- \`test/integration/moltzap-app-{roster,role-pair,addparticipant}.integration.test.ts\` — describe + it.todo entries only

## Out of scope (for downstream)
- Function bodies
- Deletions of the §7 deletion list
- package.json edits (\`@moltzap/app-sdk\` dep lands in implement-staff)
- Barrel-export (\`src/moltzap/index.ts\`) rewiring