### PR TITLE
[impl-senior] bridge-app robustness: __bootInFlight Effect.ensuring + shutdown ordering + ws-URL normalization (sbd#204)

### DIFF
--- a/src/moltzap/bridge-app.ts
+++ b/src/moltzap/bridge-app.ts
@@ -66,6 +66,7 @@ import {
 import type { ConversationKey } from "./conversation-keys.ts";
 import {
   loadBridgeIdentityEnv,
+  normalizeServerUrl,
   registerBridgeAgent,
   type BridgeAgentId,
   type BridgeIdentity,
@@ -182,11 +183,24 @@ function classifyStartError(
  *
  * Race-free: `__bootInFlight` is assigned synchronously (no yield* before it)
  * so the second concurrent caller always sees the sentinel and coalesces.
+ *
+ * **Fix 1 — sentinel cleanup under interruption (sbd#204).**
+ * Sentinel clear is wrapped in `Effect.ensuring` so a fiber interrupted
+ * between sentinel-assign and the success/failure clear still clears
+ * `__bootInFlight`. Without this, an interrupted boot fiber leaves the
+ * sentinel permanently non-null and all future callers deadlock awaiting
+ * a Promise that will never resolve.
+ * Codex delta-review concern (a), PR #338 post-cleanup.
  */
 export function bootBridgeApp(
   config: BridgeAppBootConfig,
 ): Effect.Effect<BridgeAppHandle, BridgeAppBootError> {
-  return Effect.gen(function* () {
+  // Resolver/rejecter captured at function scope so the Effect.ensuring
+  // finalizer can close over them regardless of where the fiber stops.
+  let resolveInFlight: ((h: BridgeAppHandle) => void) | null = null;
+  let rejectInFlight: ((e: BridgeAppBootError) => void) | null = null;
+
+  const core = Effect.gen(function* () {
     // Already booted: reject immediately.
     if (__bridgeSingleton !== null) {
       return yield* Effect.fail<BridgeAppBootError>({
@@ -195,8 +209,8 @@ export function bootBridgeApp(
     }
 
     // Boot in progress: coalesce — await the same in-flight result.
-    // If the in-flight boot fails, the rejection reason is the BridgeAppBootError
-    // from the first caller, so the second caller surfaces the same error tag.
+    // If the in-flight boot fails (or is interrupted), the rejection reason
+    // surfaces via the catch below.
     if (__bootInFlight !== null) {
       return yield* Effect.tryPromise({
         try: () => __bootInFlight!,
@@ -207,8 +221,6 @@ export function bootBridgeApp(
     // First caller: assign the sentinel SYNCHRONOUSLY before the first yield*.
     // JS is single-threaded — no other fiber can enter between the null-check
     // above and this assignment, closing the TOCTOU window.
-    let resolveInFlight!: (h: BridgeAppHandle) => void;
-    let rejectInFlight!: (e: BridgeAppBootError) => void;
     __bootInFlight = new Promise<BridgeAppHandle>((res, rej) => {
       resolveInFlight = res;
       rejectInFlight = rej;
@@ -224,16 +236,40 @@ export function bootBridgeApp(
     if (bootResult._tag === "Left") {
       // Clear sentinel so a retry starts a fresh boot.
       __bootInFlight = null;
-      rejectInFlight(bootResult.left);
+      rejectInFlight!(bootResult.left);
+      resolveInFlight = null;
+      rejectInFlight = null;
       return yield* Effect.fail(bootResult.left);
     }
 
     // Success: __bridgeSingleton set inside _doBoot.
     // Clear sentinel then resolve so concurrent waiters get the same handle.
     __bootInFlight = null;
-    resolveInFlight(bootResult.right);
+    resolveInFlight!(bootResult.right);
+    resolveInFlight = null;
+    rejectInFlight = null;
     return bootResult.right;
   });
+
+  // Ensuring finalizer: fires after success, failure, AND fiber interruption.
+  // On the success/failure paths __bootInFlight is already null (cleared above),
+  // so this is a no-op. On interruption it may still be set; clear it and reject
+  // the in-flight promise so any coalescing callers are unblocked.
+  return core.pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        if (__bootInFlight !== null) {
+          __bootInFlight = null;
+          rejectInFlight?.({
+            _tag: "BridgeAppEnvInvalid",
+            reason: "boot fiber interrupted before completing",
+          });
+          resolveInFlight = null;
+          rejectInFlight = null;
+        }
+      }),
+    ),
+  );
 }
 
 /**
@@ -248,6 +284,15 @@ function _doBoot(
     const env = config.env ?? process.env;
     const logger = config.logger ?? defaultLogger();
 
+    // Fix 3 (sbd#204): normalize the server URL before any use. The vendor
+    // ws-client appends "/ws" unconditionally; a URL already ending in "/ws"
+    // produces "/ws/ws" at connect time. Strip trailing "/ws" and "/" here
+    // so both `ws://host:port` and `ws://host:port/ws` reach the SDK as
+    // `ws://host:port`. normalizeServerUrl is in bridge-identity.ts (the
+    // boundary-decode module) and is also applied inside toHttpBaseUrl for
+    // the HTTP registration endpoint.
+    const serverUrl = normalizeServerUrl(config.serverUrl);
+
     const envResult = loadBridgeIdentityEnv(env);
     if (envResult._tag === "Err") {
       return yield* Effect.fail<BridgeAppBootError>({
@@ -260,7 +305,7 @@ function _doBoot(
 
     const registration = yield* Effect.promise(() =>
       registerBridgeAgent({
-        serverUrl: config.serverUrl,
+        serverUrl,
         registrationSecret: envResult.value.registrationSecret,
         displayName: envResult.value.displayName,
       }),
@@ -275,7 +320,7 @@ function _doBoot(
 
     const manifest = buildUnionManifest(appIdentity);
     const app = new MoltZapApp({
-      serverUrl: config.serverUrl,
+      serverUrl,
       agentKey: identity.agentKey,
       manifest,
       logger,
@@ -343,9 +388,33 @@ export function bridgeAgentId(): BridgeAgentId | null {
  * BEFORE `shutdownBridgeApp`. If the process exits via Effect defect or
  * hard-kill before the drain runs, the drain budget is bypassed and the
  * leak class falls back to moltzap#230's accepted shape.
+ *
+ * **Fix 2 — shutdown-vs-boot ordering (sbd#204, option a).**
+ * If a boot is in-flight when `shutdownBridgeApp` is called, it awaits
+ * the boot to settle (success or failure) before tearing down the
+ * resulting singleton. Without this, `shutdownBridgeApp` would no-op
+ * (singleton is still null), the boot would complete and install a live
+ * `MoltZapApp`, and nothing would ever stop it — a ghost singleton.
+ *
+ * Option (b) — cancelling the boot fiber — was considered and rejected:
+ * `bootBridgeApp` is an Effect whose fiber is owned by the caller;
+ * `shutdownBridgeApp` holds no fiber handle and cannot interrupt it
+ * without API surface that is not in the plan. Option (a) is safe,
+ * composes correctly with Fix 1 (`Effect.ensuring` guarantees
+ * `__bootInFlight` is always settled before clearing, so this await
+ * cannot deadlock), and requires zero new public surface.
+ * Codex delta-review concern (a), PR #338 post-cleanup.
  */
 export function shutdownBridgeApp(): Effect.Effect<void, never> {
   return Effect.gen(function* () {
+    // Await any in-flight boot so we do not miss a singleton that is still
+    // being constructed. The Promise settles on both success and failure
+    // (reject path is caught via the no-op second argument).
+    const inFlight = __bootInFlight;
+    if (inFlight !== null) {
+      yield* Effect.promise(() => inFlight.then(() => {}, () => {}));
+    }
+
     const state = __bridgeSingleton;
     if (state === null) return;
     yield* state.app.stop();

--- a/src/moltzap/bridge-identity.ts
+++ b/src/moltzap/bridge-identity.ts
@@ -172,12 +172,31 @@ interface FetchLike {
 
 const REGISTER_TIMEOUT_MS = 10_000;
 
+/**
+ * Normalize a MoltZap server URL before it is passed to the vendor
+ * ws-client or the HTTP registration endpoint.
+ *
+ * The vendor `@moltzap/client` ws-client appends `/ws` unconditionally
+ * (`serverUrl.replace(/^http/, "ws") + "/ws"` at ws-client.ts:341).
+ * A URL already ending in `/ws` would therefore produce `/ws/ws` at
+ * connect time. This strips any trailing `/ws` segment and any trailing
+ * `/` so the vendor gets the bare base URL every time.
+ *
+ * Both `ws://host:port` and `ws://host:port/ws` normalize to
+ * `ws://host:port`, which the vendor then turns into `ws://host:port/ws`.
+ *
+ * Codex delta-review concern (b) in PR #338 post-cleanup.
+ * Anchor: sbd#204 Fix 3.
+ */
+export function normalizeServerUrl(url: string): string {
+  return url.replace(/\/ws\/?$/u, "").replace(/\/$/u, "");
+}
+
 // Coerce ws(s)://host/path into http(s)://host/path so HTTP fetch resolves.
 function toHttpBaseUrl(serverUrl: string): string {
-  return serverUrl
+  return normalizeServerUrl(serverUrl)
     .replace(/^wss:/u, "https:")
-    .replace(/^ws:/u, "http:")
-    .replace(/\/+$/u, "");
+    .replace(/^ws:/u, "http:");
 }
 
 function decodeRegisterResponse(

--- a/test/moltzap-bridge-app.test.ts
+++ b/test/moltzap-bridge-app.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Effect } from "effect";
+import { Effect, Fiber } from "effect";
 import {
   __resetBridgeAppForTests,
   bootBridgeApp,
@@ -170,5 +170,119 @@ describe("bridge-app: concurrent boot coalesces — singleton race guard (P1 #3 
     // Second attempt should start a fresh boot (not coalesce onto the cleared sentinel).
     await Effect.runPromise(bootBridgeApp(config).pipe(Effect.either));
     expect(fetchCount).toBe(2); // sentinel was cleared → new fetch
+  });
+});
+
+describe("bridge-app: sentinel cleanup under fiber interruption (Fix 1 — sbd#204)", () => {
+  // Regression for: a boot fiber interrupted between sentinel-assign and the
+  // success/failure clear leaves __bootInFlight permanently non-null, causing
+  // all subsequent bootBridgeApp callers to deadlock awaiting a Promise that
+  // will never resolve. Fix: Effect.ensuring in bootBridgeApp always clears
+  // __bootInFlight, even on interruption.
+
+  it("interrupted boot clears sentinel — subsequent boot starts fresh and does not deadlock", async () => {
+    // A Promise that the mock fetch awaits; we hold it open to keep the boot
+    // fiber suspended in the registration step so we can interrupt it.
+    let signalFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((res) => {
+      signalFetchStarted = res;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      signalFetchStarted();
+      // Block indefinitely until the fiber is interrupted.
+      await new Promise<void>(() => {}); // never resolves
+      // Unreachable; TypeScript needs a return.
+      return new Response("ok", { status: 200 });
+    });
+
+    const config = {
+      serverUrl: "https://moltzap.example",
+      env: { ZAPBOT_MOLTZAP_REGISTRATION_SECRET: "secret" },
+    };
+
+    // Fork the boot, wait until it is in-flight, then interrupt.
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const bootFiber = yield* Effect.fork(bootBridgeApp(config));
+        // Wait until fetch has been called (sentinel is assigned, boot is async).
+        yield* Effect.promise(() => fetchStarted);
+        // Interrupt. Effect.ensuring in bootBridgeApp clears __bootInFlight.
+        yield* Fiber.interrupt(bootFiber);
+      }),
+    );
+
+    // After interrupt: sentinel should be null. Re-mock fetch to return 403.
+    let freshFetchCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      freshFetchCount++;
+      return new Response("forbidden", { status: 403 });
+    });
+
+    // Fresh boot must NOT deadlock — it should start a new registration call.
+    const result = await Effect.runPromise(
+      bootBridgeApp(config).pipe(Effect.either),
+    );
+
+    expect(freshFetchCount).toBe(1); // new fetch call confirms sentinel was cleared
+    expect(result._tag).toBe("Left");
+    if (result._tag === "Left") {
+      expect(result.left._tag).toBe("BridgeAppRegistrationFailed");
+    }
+  });
+});
+
+describe("bridge-app: shutdown-vs-boot ordering (Fix 2 — sbd#204)", () => {
+  // Regression for: shutdownBridgeApp called while a boot is in-flight
+  // would no-op immediately (singleton still null), then the boot would
+  // complete and leave a ghost MoltZapApp that nothing tears down.
+  // Fix: shutdownBridgeApp awaits __bootInFlight before inspecting the
+  // singleton (option a — see function docstring).
+
+  it("shutdownBridgeApp waits for in-flight boot to settle before tearing down", async () => {
+    let allowBootToComplete!: () => void;
+    const bootCanComplete = new Promise<void>((res) => {
+      allowBootToComplete = res;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      await bootCanComplete;
+      return new Response("forbidden", { status: 403 });
+    });
+
+    const config = {
+      serverUrl: "https://moltzap.example",
+      env: { ZAPBOT_MOLTZAP_REGISTRATION_SECRET: "secret" },
+    };
+
+    // Start boot; do not await yet.
+    const bootPromise = Effect.runPromise(
+      bootBridgeApp(config).pipe(Effect.either),
+    );
+
+    // Yield one tick so boot has time to assign the sentinel.
+    await new Promise<void>((res) => setTimeout(res, 0));
+
+    // Start shutdown while boot is in-flight.
+    // With Fix 2: shutdown awaits __bootInFlight, so it must block here.
+    let shutdownSettled = false;
+    const shutdownPromise = Effect.runPromise(shutdownBridgeApp()).then(() => {
+      shutdownSettled = true;
+    });
+
+    // Yield another tick; without Fix 2, shutdown would have resolved already.
+    await new Promise<void>((res) => setTimeout(res, 0));
+    expect(shutdownSettled).toBe(false); // shutdown is still waiting for boot
+
+    // Unblock the boot (registration returns 403; __bridgeSingleton stays null).
+    allowBootToComplete();
+
+    await bootPromise;
+    await shutdownPromise;
+
+    // Both settled; no ghost singleton.
+    expect(shutdownSettled).toBe(true);
+    expect(bridgeAgentId()).toBeNull();
+    expect(currentBridgeApp()).toBeNull();
   });
 });

--- a/test/moltzap-bridge-identity.test.ts
+++ b/test/moltzap-bridge-identity.test.ts
@@ -10,6 +10,7 @@ import {
   asBridgeAgentId,
   bridgeAgentIdAsSenderId,
   loadBridgeIdentityEnv,
+  normalizeServerUrl,
   registerBridgeAgent,
 } from "../src/moltzap/bridge-identity.ts";
 
@@ -180,5 +181,37 @@ describe("bridge-identity: branded type", () => {
     const sender = bridgeAgentIdAsSenderId(id);
     // Both projections share the same underlying string.
     expect(sender as unknown as string).toBe("bridge-xyz");
+  });
+});
+
+describe("bridge-identity: normalizeServerUrl (Fix 3 — sbd#204)", () => {
+  // The vendor ws-client appends "/ws" unconditionally. A URL already ending
+  // in "/ws" produces "/ws/ws". Both forms must normalize to the same base.
+
+  it("bare ws URL is unchanged", () => {
+    expect(normalizeServerUrl("ws://host:3000")).toBe("ws://host:3000");
+  });
+
+  it("URL with trailing /ws is stripped to bare URL", () => {
+    expect(normalizeServerUrl("ws://host:3000/ws")).toBe("ws://host:3000");
+  });
+
+  it("URL with trailing /ws/ (slash after ws) is stripped to bare URL", () => {
+    expect(normalizeServerUrl("ws://host:3000/ws/")).toBe("ws://host:3000");
+  });
+
+  it("URL with trailing / is stripped", () => {
+    expect(normalizeServerUrl("ws://host:3000/")).toBe("ws://host:3000");
+  });
+
+  it("http and https schemes are also normalized", () => {
+    expect(normalizeServerUrl("https://host:3000/ws")).toBe("https://host:3000");
+    expect(normalizeServerUrl("http://host:3000/")).toBe("http://host:3000");
+  });
+
+  it("both ws://host:port and ws://host:port/ws produce the same normalized URL", () => {
+    const base = normalizeServerUrl("ws://host:3000");
+    const withWs = normalizeServerUrl("ws://host:3000/ws");
+    expect(base).toBe(withWs);
   });
 });


### PR DESCRIPTION
Closes chughtapan/safer-by-default#204
Codex delta-review source: https://github.com/chughtapan/zapbot/pull/338#pullrequestreview-4174579694

## What changed

Three targeted hardening fixes to `src/moltzap/bridge-app.ts` and `src/moltzap/bridge-identity.ts`, each addressing a named concern from the codex delta-review on PR #338. No new modules, no new public surface outside `normalizeServerUrl`, no new deps.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `Effect.ensuring` in `bootBridgeApp` clears `__bootInFlight` on fiber interruption | sbd#204 Fix 1; codex delta-review concern (a) |
| `resolveInFlight`/`rejectInFlight` lifted to function scope for closure by finalizer | sbd#204 Fix 1 |
| `shutdownBridgeApp` awaits `__bootInFlight` before teardown (option a) | sbd#204 Fix 2; codex delta-review concern (a) |
| `normalizeServerUrl` exported from `bridge-identity.ts`, strips trailing `/ws[/]` and `/` | sbd#204 Fix 3; codex delta-review concern (b) |
| `normalizeServerUrl` applied in `_doBoot` before `registerBridgeAgent` + `new MoltZapApp` | sbd#204 Fix 3 |
| `toHttpBaseUrl` in `bridge-identity.ts` updated to delegate to `normalizeServerUrl` | sbd#204 Fix 3 (consolidates duplicate strip logic) |

## Fix 1 detail — `Effect.ensuring` sentinel cleanup

The previous code cleared `__bootInFlight` only in the explicit success and failure branches. A fiber interrupted between sentinel-assign (`bridge-app.ts:212` in PR #338) and either clear left `__bootInFlight` permanently non-null. All subsequent `bootBridgeApp` callers would coalesce onto a Promise that was never resolved or rejected, deadlocking indefinitely.

`resolveInFlight` and `rejectInFlight` are lifted to function scope. `Effect.ensuring` wraps the entire `core` gen. On interruption (when `__bootInFlight !== null`), the finalizer clears the sentinel and rejects the in-flight Promise so any coalescing callers unblock.

Interruption error uses `BridgeAppEnvInvalid` (closest available tag; see Simplify skip below).

## Fix 2 detail — shutdown-vs-boot ordering

`shutdownBridgeApp` checked `__bridgeSingleton === null` and exited immediately if boot was not yet complete. A concurrent boot completing after shutdown issued would install a live `MoltZapApp` that nothing would ever stop.

Option (a) chosen: `shutdownBridgeApp` captures `__bootInFlight` before the singleton check and awaits it (absorbing both resolve and reject) before proceeding. Option (b) (cancelling the boot fiber) was rejected — `shutdownBridgeApp` holds no fiber handle; interrupting the boot fiber requires caller-owned fiber access not present in the current API.

Fix 1 guarantees the await cannot deadlock: `Effect.ensuring` always settles `__bootInFlight` before clearing it.

## Fix 3 detail — ws-URL normalization

Vendor `@moltzap/client` ws-client at `ws-client.ts:341` does `serverUrl.replace(/^http/, "ws") + "/ws"` with no normalization. A `ZAPBOT_MOLTZAP_SERVER_URL` ending in `/ws` produces `/ws/ws` at connect time.

`normalizeServerUrl` exported from `bridge-identity.ts` (the boundary-decode module). Applied at the top of `_doBoot` so both `registerBridgeAgent` (HTTP endpoint) and `new MoltZapApp` (WS connect) receive a clean base URL. Also wired into the existing private `toHttpBaseUrl` to consolidate the strip logic.

**Note**: `src/moltzap/runtime.ts` has its own private `toHttpBaseUrl` (line 210) that strips trailing slashes but does NOT strip `/ws`. Wiring it to `normalizeServerUrl` from `bridge-identity.ts` would touch `runtime.ts`, which is outside this sub-issue's boundary (sbd#204 Fix 3 scope: `bridge-app.ts` + `bridge-identity.ts` only). Filed as a follow-up.

## Scope

- Modules touched: `src/moltzap/bridge-app.ts`, `src/moltzap/bridge-identity.ts`, `test/moltzap-bridge-app.test.ts`, `test/moltzap-bridge-identity.test.ts`
- Tier (from safer-diff-scope): senior
- New modules: 0
- New public signatures outside the plan: `normalizeServerUrl` (named in sbd#204 Fix 3 requirements)
- New deps: 0

## Tests

- `test/moltzap-bridge-app.test.ts` — new: "interrupted boot clears sentinel" (Fix 1); "shutdownBridgeApp waits for in-flight boot" (Fix 2). 12 tests total, all pass.
- `test/moltzap-bridge-identity.test.ts` — new: "normalizeServerUrl" describe block (5 cases covering bare URL, trailing /ws, trailing /, trailing /ws/, http/https schemes, idempotence). 17 tests total, all pass.

## Pre-PR passes

### `/simplify` pass
- **Reuse agent** flagged that `runtime.ts:210` has its own `toHttpBaseUrl` missing the `/ws` strip. Out of scope (touching `runtime.ts` is not within sbd#204's boundary). Filed as follow-up.
- **Reuse agent** suggested `Effect.Deferred` to replace the raw `Promise` + nullable resolver refs. Correct but architect-tier refactor — would change internal data flow shape. Not applied; noted here.
- **Quality agent** P1 applied: regex `/\/ws$/u` widened to `/\/ws\/?$/u` to handle `ws://host/ws/` (trailing slash after `/ws`). Test case added.
- **Quality agent** P2: `BridgeAppEnvInvalid` used to signal fiber interruption to coalescing callers. Correct fix would be a new `BridgeBootInterrupted` variant on `BridgeAppBootError`, but that is new public surface not named in the plan. Skipped; PR reviewer decides whether to require it before merge.
- **Efficiency agent**: no findings.

### `/codex --mode review` pass
(to be run by team-lead's stamina pass)

## Confidence

HIGH — all three fixes address exactly the named codex concerns; tests cover each path directly; no new dependencies; no architecture changes.

---
`/safer:review-senior` is required before this PR merges.