### PR TITLE
[impl-junior] add BridgeAppBootInterrupted error variant (sbd#207)

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -930,6 +930,8 @@ function formatBridgeBootError(e: BridgeAppBootError): string {
       return `BridgeAppConnectFailed: ${e.cause.message}`;
     case "BridgeAppSessionFailed":
       return `BridgeAppSessionFailed: ${e.cause.message}`;
+    case "BridgeAppBootInterrupted":
+      return `Bridge boot interrupted: ${e.reason}. Retry will start fresh.`;
     default:
       return absurd(e);
   }

--- a/src/moltzap/bridge-app.ts
+++ b/src/moltzap/bridge-app.ts
@@ -115,6 +115,10 @@ export type BridgeAppBootError =
       // one union; keyed by the original tag for operator parity.
       readonly _tag: "BridgeAppEnvInvalid";
       readonly reason: string;
+    }
+  | {
+      readonly _tag: "BridgeAppBootInterrupted";
+      readonly reason: string;
     };
 
 // ── Public handle ───────────────────────────────────────────────────
@@ -261,7 +265,7 @@ export function bootBridgeApp(
         if (__bootInFlight !== null) {
           __bootInFlight = null;
           rejectInFlight?.({
-            _tag: "BridgeAppEnvInvalid",
+            _tag: "BridgeAppBootInterrupted",
             reason: "boot fiber interrupted before completing",
           });
           resolveInFlight = null;

--- a/test/moltzap-bridge-app.test.ts
+++ b/test/moltzap-bridge-app.test.ts
@@ -286,3 +286,66 @@ describe("bridge-app: shutdown-vs-boot ordering (Fix 2 — sbd#204)", () => {
     expect(currentBridgeApp()).toBeNull();
   });
 });
+
+describe("bridge-app: boot interruption error tagging (sbd#207)", () => {
+  // Regression for: when a boot fiber is interrupted, coalesced callers
+  // should receive BridgeAppBootInterrupted, not BridgeAppEnvInvalid.
+  // The tag disambiguates boot concurrency issues from env decode failures.
+
+  it("interrupted boot propagates BridgeAppBootInterrupted to coalesced callers", async () => {
+    // Mock fetch to block indefinitely; keeps boot suspended so we can interrupt.
+    let signalFetchStarted!: () => void;
+    const fetchStarted = new Promise<void>((res) => {
+      signalFetchStarted = res;
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      signalFetchStarted();
+      // Block indefinitely until interrupted.
+      await new Promise<void>(() => {});
+      return new Response("ok", { status: 200 });
+    });
+
+    const config = {
+      serverUrl: "https://moltzap.example",
+      env: { ZAPBOT_MOLTZAP_REGISTRATION_SECRET: "secret" },
+    };
+
+    // Fork a boot and track the result of a coalesced caller.
+    let coalescedResult: Awaited<ReturnType<typeof Effect.runPromise>> | null =
+      null;
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        // Start the first boot fiber.
+        const bootFiber = yield* Effect.fork(bootBridgeApp(config));
+
+        // Wait until fetch is in-flight (sentinel is assigned).
+        yield* Effect.promise(() => fetchStarted);
+
+        // Start a coalesced boot in a separate fiber.
+        const coalescedFiber = yield* Effect.fork(
+          bootBridgeApp(config).pipe(Effect.either),
+        );
+
+        // Yield to let coalesced fiber coalesce on __bootInFlight.
+        yield* Effect.sleep("10 millis");
+
+        // Interrupt the primary boot. Effect.ensuring clears sentinel and
+        // rejects the in-flight promise with BridgeAppBootInterrupted.
+        yield* Fiber.interrupt(bootFiber);
+
+        // Coalesced fiber should now resolve with the boot error.
+        coalescedResult = yield* Fiber.join(coalescedFiber);
+      }),
+    );
+
+    // Verify the coalesced caller got BridgeAppBootInterrupted.
+    expect(coalescedResult).not.toBeNull();
+    expect(coalescedResult?._tag).toBe("Left");
+    if (coalescedResult?._tag === "Left") {
+      expect(coalescedResult.left._tag).toBe("BridgeAppBootInterrupted");
+      expect(coalescedResult.left.reason).toContain("interrupted");
+    }
+  });
+});


### PR DESCRIPTION
## What changed

Added a new `BridgeAppBootInterrupted` variant to the `BridgeAppBootError` union to disambiguate boot fiber interruption from environment decode failures. When the boot fiber is interrupted, the `Effect.ensuring` cleanup now constructs `BridgeAppBootInterrupted` instead of `BridgeAppEnvInvalid`. The `formatBridgeBootError` switch includes a case for the new variant with a clear operator message.

## Scope
- Module: src/moltzap/bridge-app.ts (error type + interrupt path)
- Switch arm: src/bridge.ts (formatBridgeBootError)
- Test: test/moltzap-bridge-app.test.ts (boot interruption error tagging)
- Tier: junior
- New exported signatures: none
- New deps: none

## Tests
- Existing tests: all passing (13 tests in moltzap-bridge-app.test.ts)
- New test: "interrupted boot propagates BridgeAppBootInterrupted to coalesced callers"

## Confidence
HIGH — Code follows the existing pattern (discriminated union + exhaustive switch), TypeScript exhaustiveness check passes, tests verify the error tag is propagated correctly to coalesced callers, and the change is isolated to one module internals plus one switch arm.

Closes #sbd/207
Relates to PR #339 (boot fiber interruption cleanup)