### PR TITLE
[impl-junior] worker self-register cleanup nits (sbd#216)

### DIFF
--- a/bin/moltzap-claude-channel.ts
+++ b/bin/moltzap-claude-channel.ts
@@ -7,10 +7,10 @@
  * resolution, AO resume metadata, debug logging) lives in
  * `src/moltzap/worker-channel.ts`.
  *
- * The transitional self-register path (sbd#205 deletion target) is
- * still reachable through `resolveWorkerCredentials`. Once sbd#205
- * lands, this bin can collapse to env decode + bootWorkerChannel +
- * signal handlers (architect rev 4 ≤50 LOC end state).
+ * The worker channel now self-registers at startup. This bin decodes
+ * the zapbot parent env (agent key, server, role) and passes it to
+ * bootWorkerChannel, which completes registration and establishes
+ * the transport identity (architect rev 4 final state).
  */
 
 import process from "node:process";

--- a/src/moltzap/runtime.ts
+++ b/src/moltzap/runtime.ts
@@ -110,7 +110,6 @@ export function buildMoltzapProcessEnv(
     case "MoltzapRegistration":
       return {
         MOLTZAP_SERVER_URL: config.serverUrl,
-        MOLTZAP_REGISTRATION_SECRET: config.registrationSecret,
         ...(config.allowlistCsv !== null
           ? { MOLTZAP_ALLOWED_SENDERS: config.allowlistCsv }
           : {}),


### PR DESCRIPTION
Closes #216

## What changed

Updated stale comment in `bin/moltzap-claude-channel.ts` lines 10-13 that referenced sbd#205 as a "deletion target" — sbd#205 has landed, so the comment now describes the current state. Removed dead propagation of `MOLTZAP_REGISTRATION_SECRET` from spawn env in `src/moltzap/runtime.ts:113` since the worker no longer needs it.

## Scope
- Files: bin/moltzap-claude-channel.ts + src/moltzap/runtime.ts  
- Tier: junior
- New exported signatures: none
- New deps: none

## Tests
- All existing tests still pass
- \`bunx tsc --noEmit\` clean

## Confidence
HIGH — Straightforward comment update + removal of dead code that was only injecting unused env variable into spawn process.