### PR TITLE
[impl-senior] real-server admission integration tests (sbd#213)

### DIFF
--- a/test/integration/moltzap-app-roster.integration.test.ts
+++ b/test/integration/moltzap-app-roster.integration.test.ts
@@ -3,13 +3,15 @@
  *
  * Anchors: sbd#203 Phase 2; sbd#170 SPEC rev 2, §5 bullets on
  * `app.createSession({invitedAgentIds})` and 2-member roster round trip.
+ * sbd#213: admission-flow integration tests (positive path, partial-admission
+ * failure, and timeout path).
  *
  * Boots a fresh bridge against the shared test server (spawned by globalSetup),
  * registers worker agents via HTTP, calls createBridgeSession, and asserts the
  * session + conversation map are correctly populated.
  *
  * Bridge is booted once in beforeAll and torn down in afterAll — one 12–15 s
- * cold boot amortised across all 4 tests in this file.
+ * cold boot amortised across all 6 tests in this file.
  */
 
 import { afterAll, beforeAll, describe, expect, it, inject } from "vitest";
@@ -125,4 +127,88 @@ describe("moltzap app-sdk integration — roster session", () => {
 
     expect(result._tag).toBe("Right");
   });
+
+  // ── sbd#213: admission-flow tests ──────────────────────────────────────
+
+  it(
+    "partial-admission failure: invite [valid-w1, bogus-uuid] returns BridgeSessionAdmissionRejected naming the unknown ID (sbd#213 case 2)",
+    async () => {
+      // This test exercises the partial-admission detection path in
+      // awaitSessionAdmission (bridge-app.ts). When an invited agentId is
+      // not present in the server DB, admitAgentsAsync rejects it silently
+      // (participantRejected is sent only to the rejected agent, not to the
+      // bridge initiator). The bridge's admission-wait handler detects the
+      // shortfall when sessionReady fires with admitted.size < invited.size,
+      // and surfaces BridgeSessionAdmissionRejected.
+      //
+      // Protocol path:
+      //   1. valid-w1 registered (dev mode: auto-owned, admitted immediately)
+      //   2. apps/create([valid-w1, bogus-uuid]) → server forks admitAgentsAsync
+      //   3. valid-w1: admitted → app/participantAdmitted sent to bridge
+      //   4. bogus-uuid: not in DB → rejectAgent → app/participantRejected
+      //      sent only to bogus-uuid (unknown; nobody receives it)
+      //   5. not allRejected → status = "active" → app/sessionReady sent to bridge
+      //   6. bridge: admitted={w1}, invited={w1,bogus} → size mismatch →
+      //      BridgeSessionAdmissionRejected (agentId = bogus-uuid)
+      const w1 = await Effect.runPromise(
+        registerAgent(HTTP_BASE, "roster-partial-w1"),
+      );
+      // Use a well-formed UUID that cannot exist in the PGlite DB (all zeros
+      // with a distinct last octet prevents collision with real agent rows).
+      const bogusId =
+        "00000000-0000-0000-0000-000000000099" as MoltzapSenderId;
+
+      const result = await Effect.runPromise(
+        createBridgeSession({
+          invitedAgentIds: [w1.agentId as MoltzapSenderId, bogusId],
+          admissionTimeoutMs: 10_000,
+        }).pipe(Effect.either),
+      );
+
+      expect(result._tag).toBe("Left");
+      if (result._tag !== "Left") return;
+      const err = result.left;
+      expect(err._tag).toBe("BridgeSessionAdmissionRejected");
+      if (err._tag !== "BridgeSessionAdmissionRejected") return;
+      // reason includes all un-admitted IDs; agentId is the first missing one.
+      expect(err.reason).toContain(bogusId);
+    },
+    30_000,
+  );
+
+  it(
+    "timeout path: invite bogus-only agentId returns BridgeSessionAdmissionTimeout (sbd#213 case 3)",
+    async () => {
+      // This test exercises the timeout branch of awaitSessionAdmission.
+      // When ALL invited agents are unknown (not in DB), admitAgentsAsync
+      // sets the session to "failed" and emits app/sessionFailed to the
+      // bridge. The bridge does not handle sessionFailed, so the admission
+      // wait timer fires after admissionTimeoutMs.
+      //
+      // Protocol path:
+      //   1. apps/create([bogus-uuid]) → server forks admitAgentsAsync
+      //   2. bogus-uuid: not in DB → rejectAgent → allRejected = true →
+      //      status = "failed" → app/sessionFailed sent to bridge (not handled)
+      //   3. bridge waits for app/sessionReady or app/participantAdmitted —
+      //      neither fires → timer fires → BridgeSessionAdmissionTimeout
+      const bogusId =
+        "00000000-0000-0000-0000-000000000098" as MoltzapSenderId;
+
+      const result = await Effect.runPromise(
+        createBridgeSession({
+          invitedAgentIds: [bogusId],
+          admissionTimeoutMs: 2_000,
+        }).pipe(Effect.either),
+      );
+
+      expect(result._tag).toBe("Left");
+      if (result._tag !== "Left") return;
+      const err = result.left;
+      expect(err._tag).toBe("BridgeSessionAdmissionTimeout");
+      if (err._tag !== "BridgeSessionAdmissionTimeout") return;
+      expect(err.waitedMs).toBe(2_000);
+    },
+    // Give the test itself 10s headroom beyond the 2s admission wait.
+    12_000,
+  );
 });


### PR DESCRIPTION
Closes sub-issue: https://github.com/chughtapan/safer-by-default/issues/213
Predecessor: PR #344 (sbd#203) — live integration test infrastructure

## Audit table (Step 1)

| Case | Description | Status in sbd#203 (PR #344) | This PR |
|------|-------------|------------------------------|---------|
| 1 | Positive path: `createBridgeSession([w1,w2])` resolves when both admitted | ✅ **COVERED** — "app.createSession returns non-null id": Right return proves `awaitSessionAdmission` resolved | No change |
| 2 | Partial-admission failure: `[valid, INVALID-ID]` → `BridgeSessionAdmissionRejected` naming the unknown ID | ❌ **NOT COVERED** | ✅ Added |
| 3 | Timeout path: bogus-only invitee → `BridgeSessionAdmissionTimeout` | ❌ **NOT COVERED** | ✅ Added |

## What changed

Single file: `test/integration/moltzap-app-roster.integration.test.ts` — two new `it()` blocks appended to the existing `describe` (4 tests → 6 tests).

### Case 2 — partial-admission failure (sbd#213 case 2)

Protocol path exercised:
1. `valid-w1` registered via HTTP (dev mode: auto-owned → admitted immediately)
2. `apps/create([valid-w1, bogus-uuid])` → server forks `admitAgentsAsync`
3. `valid-w1`: admitted → `app/participantAdmitted` sent to bridge
4. `bogus-uuid`: not in DB → `rejectAgent` → `app/participantRejected` to bogus (nobody receives it)
5. `not allRejected` → status = `"active"` → `app/sessionReady` to bridge
6. Bridge: `admitted.size (1) < invited.size (2)` → `BridgeSessionAdmissionRejected` (`reason` contains bogus UUID)

Assertions: `result._tag === "Left"`, `err._tag === "BridgeSessionAdmissionRejected"`, `err.reason` contains the bogus UUID.

### Case 3 — timeout path (sbd#213 case 3)

Protocol path exercised:
1. `apps/create([bogus-uuid])` → server forks `admitAgentsAsync`
2. `bogus-uuid`: not in DB → `allRejected = true` → status = `"failed"` → `app/sessionFailed` sent to bridge
3. Bridge does not handle `sessionFailed` → waits for `sessionReady`/`participantAdmitted` — neither fires
4. Timer fires after `admissionTimeoutMs: 2_000` → `BridgeSessionAdmissionTimeout`

Assertions: `result._tag === "Left"`, `err._tag === "BridgeSessionAdmissionTimeout"`, `err.waitedMs === 2_000`.

## Test bar

- All 4 existing tests unmodified, continue to pass
- 2 new tests pass against the spawned server
- `bunx tsc --noEmit` clean (verified in main zapbot with vendor packages built)
- Per Boundaries (Principle 6): confined to `test/integration/*`, no `src/` changes, no new public surface