### PR TITLE
[impl-junior] fix then-chain lint error in bridge-app.ts (sbd#218)

### DIFF
--- a/src/moltzap/bridge-app.ts
+++ b/src/moltzap/bridge-app.ts
@@ -488,7 +488,10 @@ export function shutdownBridgeApp(): Effect.Effect<void, never> {
     // (reject path is caught via the no-op second argument).
     const inFlight = __bootInFlight;
     if (inFlight !== null) {
-      yield* Effect.promise(() => inFlight.then(() => {}, () => {}));
+      yield* Effect.tryPromise({
+        try: () => inFlight,
+        catch: () => undefined,
+      }).pipe(Effect.ignore);
     }
 
     const state = __bridgeSingleton;


### PR DESCRIPTION
## Summary

Fix the `agent-code-guard/then-chain` lint error in `src/moltzap/bridge-app.ts:491` by rewriting the promise await in `shutdownBridgeApp()` to use `Effect.tryPromise` with proper error handling instead of `Effect.promise` with a then-chain.

**Before:**
```typescript
yield* Effect.promise(() => inFlight.then(() => {}, () => {}));
```

**After:**
```typescript
yield* Effect.tryPromise({
  try: () => inFlight,
  catch: () => undefined,
}).pipe(Effect.ignore);
```

1 file changed, ~5 LOC. No other changes.