### PR TITLE
[impl-senior] sbd#216 + sbd#217 cleanup combined (clean retry off origin/main)

### DIFF
--- a/bin/moltzap-claude-channel.ts
+++ b/bin/moltzap-claude-channel.ts
@@ -7,10 +7,9 @@
  * resolution, AO resume metadata, debug logging) lives in
  * `src/moltzap/worker-channel.ts`.
  *
- * The transitional self-register path (sbd#205 deletion target) is
- * still reachable through `resolveWorkerCredentials`. Once sbd#205
- * lands, this bin can collapse to env decode + bootWorkerChannel +
- * signal handlers (architect rev 4 ≤50 LOC end state).
+ * Workers receive pre-minted credentials from the bridge via spawn env
+ * (`MOLTZAP_AGENT_KEY` + `MOLTZAP_LOCAL_SENDER_ID`); the self-register
+ * path was removed in PR #343 (sbd#205).
  */
 
 import process from "node:process";

--- a/src/moltzap/runtime.ts
+++ b/src/moltzap/runtime.ts
@@ -102,7 +102,6 @@ export function buildMoltzapProcessEnv(
     case "MoltzapRegistration":
       return {
         MOLTZAP_SERVER_URL: config.serverUrl,
-        MOLTZAP_REGISTRATION_SECRET: config.registrationSecret,
       };
     default:
       return absurd(config);

--- a/test/integration/globalSetup.ts
+++ b/test/integration/globalSetup.ts
@@ -194,6 +194,10 @@ function sleep(ms: number): Promise<void> {
  * Best-effort: kill any process listening on `port` before we spawn our own.
  * Uses `fuser -k PORT/tcp`; silently swallows errors (fuser absent, no
  * process, permission denied). Waits up to 800 ms for the port to be released.
+ *
+ * Port-scoped (not PID-scoped): we only know the port at global-setup time,
+ * not the PID of any prior test-server instance. PID-scoping would require
+ * persisting the child PID across vitest worker boundaries; that is deferred.
  */
 async function killPortIfOccupied(port: number): Promise<void> {
   try {

--- a/test/integration/moltzap-app-addparticipant.integration.test.ts
+++ b/test/integration/moltzap-app-addparticipant.integration.test.ts
@@ -126,17 +126,12 @@ describe("moltzap app-sdk integration — late-joiner conversation admission", (
           ),
       );
 
-      // The RPC must succeed (Right) or fail with a typed RPC error.
-      // Failure is acceptable here if the helper agent is not the conversation
-      // owner; what matters is the RPC is reachable (no 5xx / connection error).
-      if (addResult._tag === "Left") {
-        // Allow permission-level RPC failures (not a transport/crash failure).
-        const err = addResult.left;
-        expect(typeof err).not.toBe("undefined");
-      } else {
-        // Success case: participant was added.
-        expect(addResult.right).toBeDefined();
-      }
+      // Dev-mode server (test-open secret) grants open access to all connected
+      // agents; conversations/addParticipant must succeed without a permission
+      // error. This is the concrete Spike A outcome: the primitive works E2E.
+      expect(addResult._tag).toBe("Right");
+      if (addResult._tag !== "Right") return;
+      expect(addResult.right).toBeDefined();
     } finally {
       await Effect.runPromise(helperClient.close());
     }

--- a/test/integration/moltzap-app-role-pair.integration.test.ts
+++ b/test/integration/moltzap-app-role-pair.integration.test.ts
@@ -24,7 +24,7 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it, inject } from "vitest";
-import { Effect, Duration } from "effect";
+import { Effect } from "effect";
 import {
   __resetBridgeAppForTests,
   bootBridgeApp,

--- a/test/integration/moltzap-bridge-app.integration.test.ts
+++ b/test/integration/moltzap-bridge-app.integration.test.ts
@@ -137,7 +137,7 @@ describe("bridge-app integration: start-error-tag classification against live se
     __resetBridgeAppForTests();
   });
 
-  it("bootBridgeApp returns BridgeAppRegistrationFailed when registration secret is rejected (403)", async () => {
+  it("bootBridgeApp returns BridgeAppEnvInvalid when registration secret is absent from env", async () => {
     // Server has no YAML registration secret configured. This test triggers
     // HTTP-level registration failure by disabling MOLTZAP_DEV_MODE context
     // and using an empty env so loadBridgeIdentityEnv returns a missing-secret
@@ -171,12 +171,9 @@ describe("bridge-app integration: start-error-tag classification against live se
     expect(result._tag).toBe("Left");
     if (result._tag !== "Left") return;
     // Registration itself will fail (ECONNREFUSED) → BridgeAppRegistrationFailed.
-    // Both BridgeAppRegistrationFailed and BridgeAppConnectFailed are valid:
-    // registration occurs before WS connect, so ECONNREFUSED on the HTTP side
-    // gives BridgeAppRegistrationFailed.
-    expect(["BridgeAppRegistrationFailed", "BridgeAppConnectFailed"]).toContain(
-      result.left._tag,
-    );
+    // Registration occurs before WS connect, so ECONNREFUSED on the HTTP side
+    // surfaces as BridgeAppRegistrationFailed before any WS connect is attempted.
+    expect(result.left._tag).toBe("BridgeAppRegistrationFailed");
   });
 });
 

--- a/test/moltzap-runtime.test.ts
+++ b/test/moltzap-runtime.test.ts
@@ -134,7 +134,6 @@ describe("moltzap runtime / buildMoltzapProcessEnv", () => {
     if (result._tag !== "Ok" || result.value._tag !== "MoltzapRegistration") return;
     expect(buildMoltzapProcessEnv(result.value)).toEqual({
       MOLTZAP_SERVER_URL: "wss://moltzap.example/ws",
-      MOLTZAP_REGISTRATION_SECRET: "reg-secret",
     });
   });
 });


### PR DESCRIPTION
## Summary

Clean retry of the sbd#216 + sbd#217 combined cleanup PR. Branch base is `origin/main` at `3646346` (PR #350 merge). No wip-recovery merges. Contamination-safe: `bin/moltzap-claude-channel.ts` diff is comment-only (verified via `git diff`).

## Per-item evidence

### sbd#216 — worker self-register cleanup nits

**Item 1 — `bin/moltzap-claude-channel.ts` comment (lines 10–12, comment-only):**
- Replaced stale "sbd#205 deletion target / future work" block with accurate description: workers receive pre-minted credentials from the bridge via spawn env (`MOLTZAP_AGENT_KEY` + `MOLTZAP_LOCAL_SENDER_ID`); self-register path was removed in PR #343 (sbd#205).
- `git diff bin/moltzap-claude-channel.ts` shows zero deleted lines containing `resolveWorkerCredentials`, `bootWorkerChannel`, `writeWorkerMetadata`, or `keepAlive`.

**Item 2 — `src/moltzap/runtime.ts` `buildMoltzapProcessEnv` (1-line removal):**
- Removed dead `MOLTZAP_REGISTRATION_SECRET: config.registrationSecret` line. The bridge no longer propagates the registration secret into worker spawn env after sbd#205 landed.

**Item 3 — `test/moltzap-runtime.test.ts` test alignment (1-line removal):**
- Updated `buildMoltzapProcessEnv` assertion to not expect `MOLTZAP_REGISTRATION_SECRET` in the returned env map. Addresses reviewer-346 P1 #1.
- `test/moltzap-runtime.test.ts` passes: 9/9 tests ✓.

### sbd#217 — integration test polish (5 items)

**Item 1 — Phase 3b test #1 name fix:**
- `moltzap-bridge-app.integration.test.ts` test name was "returns BridgeAppRegistrationFailed when registration secret is rejected (403)" but the assertion checked for `BridgeAppEnvInvalid`. Fixed name to "returns BridgeAppEnvInvalid when registration secret is absent from env".

**Item 2 — Phase 3b test #2 disjunctive assertion tightened:**
- Changed `expect(["BridgeAppRegistrationFailed", "BridgeAppConnectFailed"]).toContain(...)` to `expect(result.left._tag).toBe("BridgeAppRegistrationFailed")`. Registration occurs before WS connect; ECONNREFUSED on the HTTP side surfaces as `BridgeAppRegistrationFailed`.

**Item 3 — Spike A baseline assertion tightened:**
- `moltzap-app-addparticipant.integration.test.ts`: replaced permissive if/else (passes regardless of Left/Right) with `expect(addResult._tag).toBe("Right")`. Dev-mode server (test-open secret) grants open access to all connected agents — `conversations/addParticipant` must succeed.

**Item 4 — Unused `Duration` import removed:**
- `moltzap-app-role-pair.integration.test.ts`: removed `Duration` from `import { Effect, Duration } from "effect"`.

**Item 5 — `killPortIfOccupied` JSDoc scope rationale:**
- `test/integration/globalSetup.ts`: added explanation that port-scoping is used (not PID-scoping) because the PID of a prior test-server instance is not available at global-setup time across vitest worker boundaries; PID-scoping is deferred.

## Test bar

- `test/moltzap-runtime.test.ts`: 9/9 ✓
- All other non-vendored-package test suites: 313/313 ✓
- `bun run lint`: 0 errors (272 pre-existing warnings)
- `bunx tsc --noEmit`: errors only in files importing missing vendored `@moltzap/*` packages (pre-existing, unrelated to this diff)

## Contamination greps clean

```
git diff --stat origin/main
# 7 files: bin/moltzap-claude-channel.ts, src/moltzap/runtime.ts,
#   test/moltzap-runtime.test.ts, test/integration/globalSetup.ts,
#   test/integration/moltzap-app-addparticipant.integration.test.ts,
#   test/integration/moltzap-app-role-pair.integration.test.ts,
#   test/integration/moltzap-bridge-app.integration.test.ts

git diff bin/moltzap-claude-channel.ts
# No deleted lines containing resolveWorkerCredentials, bootWorkerChannel,
# writeWorkerMetadata, or keepAlive. Comment block only.
```

Branch base: `origin/main` at `3646346` (PR #350 merge). No wip-recovery merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)