### PR TITLE
[impl-staff] bridge-process lifecycle bodies (sbd#220 / sbd#215 impl)

### DIFF
--- a/src/bridge-process.ts
+++ b/src/bridge-process.ts
@@ -443,10 +443,27 @@ export function installBridgeProcessLifecycle(
   return {
     state: () => state,
     markReady: (r, runtime) => {
-      if (state._tag !== "Booting") return;
-      running = r;
-      liveRuntimeRef = runtime;
-      state = { _tag: "Ready" };
+      // Always stash the running bridge on the FIRST hand-off — even if a
+      // signal pre-empted boot and flipped state to `ShuttingDown` between
+      // `start(cfg)` resolving and the boot caller reaching `markReady`.
+      // Without this, `running` is leaked: the lifecycle's
+      // `requestShutdown`/`performShutdown` see `running === null` and skip
+      // graceful `running.stop()`, dropping gateway deregistration and
+      // MoltZap session drain (codex review P1+P2 against impl-staff/sbd-220).
+      if (running === null) {
+        running = r;
+        liveRuntimeRef = runtime;
+      }
+      if (state._tag === "Booting") {
+        state = { _tag: "Ready" };
+        return;
+      }
+      if (state._tag === "ShuttingDown") {
+        // Signal flipped state during boot; drive the shutdown the signal
+        // handler couldn't (it had no `running` to stop). Idempotent via
+        // `shutdownPromise`.
+        void startShutdown(state.reason);
+      }
     },
     liveRuntime: () => liveRuntimeRef,
     requestShutdown: async (reason) => {

--- a/src/bridge-process.ts
+++ b/src/bridge-process.ts
@@ -21,8 +21,9 @@
  *
  *   - `installBridgeProcessLifecycle` installs SIGHUP/SIGINT/SIGTERM
  *     handlers BEFORE any boot I/O. Handlers dispatch through an explicit
- *     state machine: signals received during `Booting` queue (SIGHUP) or
- *     pre-empt boot (SIGINT/SIGTERM); signals during `Reloading` defer
+ *     state machine: SIGHUP during `Booting` is a no-op (logged + dropped,
+ *     same shape as SIGHUP during `Reloading`/`ShuttingDown`); SIGINT/SIGTERM
+ *     during `Booting` pre-empts boot; signals during `Reloading` defer
  *     shutdown until the reload commit/rollback completes; SIGHUP during
  *     `ShuttingDown` is a no-op.
  *
@@ -49,12 +50,16 @@ import type { Result } from "./types.ts";
  *                    └─ ShuttingDown   (terminal)
  *
  * - `Booting`: handlers installed; no live `RunningBridge` yet. SIGHUP
- *   queues until `markReady`. SIGTERM/SIGINT pre-empts boot — the
- *   caller of `installBridgeProcessLifecycle` MUST observe `state()`
+ *   is a no-op (logged + dropped — there is no `RunningBridge` to reload
+ *   against, and no queue; matches the "no-op-on-non-Ready" pattern used
+ *   by `Reloading` and `ShuttingDown`). SIGTERM/SIGINT pre-empts boot —
+ *   the caller of `installBridgeProcessLifecycle` MUST observe `state()`
  *   between boot steps and bail with `requestShutdown` if it has flipped.
  * - `Ready`: server up, registered, post-boot probe passed.
  * - `Reloading`: SIGHUP in flight. SIGHUP arriving in this phase logs
- *   and no-ops (existing `reloadInFlight` semantics, preserved).
+ *   and no-ops (existing `reloadInFlight` semantics, preserved). SIGINT/
+ *   SIGTERM records a shutdown intent and waits for the reload's
+ *   commit-or-rollback to settle before transitioning to `ShuttingDown`.
  * - `ShuttingDown`: terminal. SIGHUP is a no-op. SIGINT/SIGTERM is
  *   idempotent (prior `shuttingDown` flag, preserved).
  */
@@ -78,9 +83,10 @@ export interface BridgeProcessLifecycle {
 
   /**
    * Transition `Booting` → `Ready`. Idempotent: no-op if state is not
-   * `Booting`. After this call, queued SIGHUPs (if any) are dispatched
-   * onto the supplied `running` handle. The `runtime` param becomes the
-   * initial value of the live runtime ref returned by `liveRuntime()`.
+   * `Booting`. The `runtime` param becomes the initial value of the live
+   * runtime ref returned by `liveRuntime()`. SIGHUPs received during
+   * `Booting` are NOT queued — they were dropped at receive time, so
+   * `markReady` does not dispatch a deferred reload.
    */
   readonly markReady: (
     running: RunningBridge,

--- a/src/bridge-process.ts
+++ b/src/bridge-process.ts
@@ -1,9 +1,10 @@
 /**
  * bridge-process — boot/reload/shutdown lifecycle primitive for `runBridgeProcess`.
  *
- * STUBS ONLY (architect, sbd#215). Function bodies throw. Implementer
- * (`/safer:implement-staff` or `/safer:implement-senior`) fills the bodies
- * against the design doc on https://github.com/chughtapan/safer-by-default/issues/215.
+ * Architect plan (sbd#215 rev 2 + addendum):
+ *   - rev 1:    https://github.com/chughtapan/safer-by-default/issues/215#issuecomment-4318454290
+ *   - addendum: https://github.com/chughtapan/safer-by-default/issues/215#issuecomment-4318476863
+ *   - rev 2:    https://github.com/chughtapan/safer-by-default/issues/215#issuecomment-4318477234
  *
  * This module exists to fix three pre-existing races in `runBridgeProcess`
  * (preserved verbatim from the pre-collapse `bin/webhook-bridge.ts::main()`):
@@ -35,11 +36,24 @@
  * Confined to the lifecycle/signal/reload surface of `runBridgeProcess`.
  * `startBridge` (HTTP server, gateway register/deregister, MoltZap boot)
  * is unchanged.
+ *
+ * Atomicity boundary (rev 2 P1 #1): `commitReload` is transactional at the
+ * `running.reload` THROW boundary only. Per-repo gateway register/deregister
+ * failures returned via `Promise.allSettled` inside `running.reload` are
+ * pre-existing semantics and are NOT rolled back here. The §6.3 follow-up
+ * (gateway-layer transactionality) is a separate sub-issue (sbd#219).
+ *
+ * Boot pre-emption latency (rev 1 §6.1, default a): shutdown latency during
+ * `Booting` is bounded by the longest remaining boot await — the boot caller
+ * polls `state()` between awaits and bails to `requestShutdown` once a signal
+ * has flipped state to `ShuttingDown`.
  */
 
-import type { BridgeRuntimeConfig, ConfigReloadError } from "./config/types.ts";
+import { absurd, err, ok, type Result } from "./types.ts";
+import { buildBridgeConfig, loadBridgeInputs } from "./bridge.ts";
 import type { BridgeConfig, RunningBridge } from "./bridge.ts";
-import type { Result } from "./types.ts";
+import { reloadBridgeRuntimeConfig } from "./config/reload.ts";
+import type { BridgeRuntimeConfig, ConfigReloadError } from "./config/types.ts";
 
 // ── State ───────────────────────────────────────────────────────────
 
@@ -190,7 +204,278 @@ export interface BridgeProcessLifecycleDeps {
 export function installBridgeProcessLifecycle(
   deps: BridgeProcessLifecycleDeps,
 ): BridgeProcessLifecycle {
-  throw new Error("not implemented");
+  // Mutable lifecycle state. Closed over by the signal handlers and the
+  // returned handle; never escapes this function.
+  let state: BridgeProcessState = { _tag: "Booting" };
+  let running: RunningBridge | null = null;
+  let liveRuntimeRef: BridgeRuntimeConfig | null = null;
+
+  // Reload coordination. `reloadSettled` resolves once the in-flight
+  // SIGHUP-triggered reload has finished its commit-or-rollback work.
+  let reloadSettled: Promise<void> | null = null;
+
+  // Pending shutdown intent recorded during `Reloading`. After the reload
+  // settles, the finally block reads this and drives the transition.
+  // Signal beats Manual per rev 2 P1 #3 (signal-wins-over-§6.2).
+  let pendingShutdown: ShutdownReason | null = null;
+
+  // Idempotent shutdown promise. First call to `requestShutdown` (or the
+  // signal-driven internal equivalent) creates it; subsequent callers
+  // await the same promise.
+  let shutdownPromise: Promise<void> | null = null;
+
+  function exitCodeFor(reason: ShutdownReason): 0 | 1 {
+    switch (reason._tag) {
+      case "Signal":
+        return 0;
+      case "BootProbeFailed":
+      case "BootConfigInvalid":
+      case "Manual":
+        return 1;
+      default:
+        return absurd(reason);
+    }
+  }
+
+  async function performShutdown(reason: ShutdownReason): Promise<void> {
+    state = { _tag: "ShuttingDown", reason };
+    if (running !== null) {
+      try {
+        await running.stop();
+      } catch (e) {
+        deps.logger.error(
+          `running.stop() failed during shutdown: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
+    }
+    deps.exit(exitCodeFor(reason));
+  }
+
+  function startShutdown(reason: ShutdownReason): Promise<void> {
+    if (shutdownPromise !== null) return shutdownPromise;
+    shutdownPromise = performShutdown(reason);
+    return shutdownPromise;
+  }
+
+  function describePrepareError(error: ReloadPrepareError): string {
+    switch (error._tag) {
+      case "ReloadInputsFailed":
+        return error.reason;
+      case "ReloadConfigInvalid":
+        return `config rejected: ${error.cause._tag}`;
+      case "ReloadBuildFailed":
+        return error.reason;
+      default:
+        return absurd(error);
+    }
+  }
+
+  function recordSignalIntent(signal: "SIGINT" | "SIGTERM"): void {
+    const reason: ShutdownReason = { _tag: "Signal", signal };
+    // Signal always wins over a previously-recorded Manual intent
+    // (rev 2 P1 #3: signal-wins-over-§6.2 even when ReloadRollbackFailed
+    // would otherwise drive force-shutdown).
+    if (pendingShutdown === null || pendingShutdown._tag !== "Signal") {
+      pendingShutdown = reason;
+    }
+  }
+
+  function onSighup(): void {
+    switch (state._tag) {
+      case "Booting":
+        // Race-3 fix per rev 2 P1 #2: no-op (no queue, no deferred dispatch).
+        deps.logger.warn("SIGHUP ignored during boot");
+        return;
+      case "Reloading":
+        // Existing `reloadInFlight` semantics preserved.
+        deps.logger.warn("SIGHUP received while reload in flight; ignoring");
+        return;
+      case "ShuttingDown":
+        // Race-3 fix: SIGHUP during shutdown does not race shutdown finalizers.
+        deps.logger.warn("SIGHUP ignored during shutdown");
+        return;
+      case "Ready":
+        // Fall through to the reload kickoff below.
+        break;
+      default:
+        absurd(state);
+    }
+
+    // Capture a snapshot of the previous runtime so that rollback (if it
+    // fires) has a consistent baseline.
+    const previousRuntime = liveRuntimeRef;
+    const liveRunning = running;
+    if (previousRuntime === null || liveRunning === null) {
+      // Defensive: Ready implies both are set (markReady wrote them).
+      // If we get here, the lifecycle invariant is broken — fail loud.
+      deps.logger.error(
+        "SIGHUP in Ready state but live runtime/running missing; aborting reload",
+      );
+      return;
+    }
+
+    state = { _tag: "Reloading" };
+
+    reloadSettled = (async () => {
+      try {
+        // Rebuild the previous BridgeConfig from the previous runtime.
+        // buildBridgeConfig is pure-fold over env + runtime; it can only
+        // fail if the Moltzap env env decode fails, which is identical to
+        // boot — env hasn't moved, so a failure here is anomalous.
+        const previousConfigResult = buildBridgeConfig(deps.env, previousRuntime);
+        if (previousConfigResult._tag === "Err") {
+          deps.logger.error(
+            `Reload aborted: cannot rebuild current config: ${previousConfigResult.error.reason}`,
+          );
+          return;
+        }
+
+        const planResult = await prepareReload(
+          deps.env,
+          previousRuntime,
+          deps.probe,
+        );
+        if (planResult._tag === "Err") {
+          deps.logger.error(`Reload failed: ${describePrepareError(planResult.error)}`);
+          return;
+        }
+
+        const committed = await commitReload(
+          liveRunning,
+          planResult.value,
+          previousRuntime,
+          previousConfigResult.value,
+        );
+        if (committed._tag === "Err") {
+          if (committed.error._tag === "ReloadCommitFailed") {
+            deps.logger.error(
+              `Reload failed: ${committed.error.cause}` +
+                (committed.error.rolledBack
+                  ? " (rolled back to previous config)"
+                  : ""),
+            );
+            return;
+          }
+          // ReloadRollbackFailed: §6.2 default is force-shutdown.
+          // Rev 2 P1 #3: if a SIGTERM is already pending, signal wins;
+          // pendingShutdown stays as Signal.
+          deps.logger.error(
+            `Reload rollback failed: original=${committed.error.originalCause}; ` +
+              `rollback=${committed.error.rollbackCause}`,
+          );
+          if (pendingShutdown === null) {
+            pendingShutdown = {
+              _tag: "Manual",
+              reason: "rollback failed",
+            };
+          }
+          return;
+        }
+
+        // Race-2 fix: liveRuntime advances ONLY after `commitReload` resolves Ok.
+        liveRuntimeRef = committed.value;
+        deps.logger.info(
+          `Config reloaded (${planResult.value.nextConfig.repos.size} repos, ` +
+            `secret rotated: ${planResult.value.secretRotated})`,
+        );
+      } catch (e) {
+        deps.logger.error(
+          `Reload failed: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      } finally {
+        // Settle the state. If a signal arrived during the reload, the
+        // pendingShutdown drives the transition (signal wins per rev 2).
+        // Otherwise, return to Ready unless a Manual shutdown was queued
+        // by a rollback failure.
+        if (pendingShutdown !== null) {
+          const reason = pendingShutdown;
+          pendingShutdown = null;
+          // Kick off shutdown asynchronously so we don't block the
+          // SIGHUP handler's microtask further. Errors are observable
+          // via the shutdownPromise.
+          void startShutdown(reason);
+        } else if (state._tag === "Reloading") {
+          state = { _tag: "Ready" };
+        }
+      }
+    })();
+  }
+
+  function onSignal(signal: "SIGINT" | "SIGTERM"): void {
+    const reason: ShutdownReason = { _tag: "Signal", signal };
+    switch (state._tag) {
+      case "Booting":
+        // Race-1 fix: handlers exist throughout boot. Flip state; the
+        // boot caller polls `state()` between awaits and calls
+        // `requestShutdown` once it observes the transition. Latency is
+        // bounded by the longest remaining boot await (rev 1 §6.1 "a").
+        deps.logger.info(`${signal} received during boot; pre-empting boot`);
+        state = { _tag: "ShuttingDown", reason };
+        return;
+      case "Ready":
+        deps.logger.info(`${signal} received; shutting down`);
+        void startShutdown(reason);
+        return;
+      case "Reloading":
+        // Rev 2 P1 #3 (a): do NOT abort the in-flight reload. Record the
+        // intent; the reload's finally block drives the transition.
+        deps.logger.info(
+          `${signal} received during reload; deferring shutdown until reload settles`,
+        );
+        recordSignalIntent(signal);
+        return;
+      case "ShuttingDown":
+        deps.logger.info(`${signal} ignored: already shutting down`);
+        return;
+      default:
+        absurd(state);
+    }
+  }
+
+  const sighupHandler = (): void => onSighup();
+  const sigintHandler = (): void => onSignal("SIGINT");
+  const sigtermHandler = (): void => onSignal("SIGTERM");
+
+  deps.process.on("SIGHUP", sighupHandler);
+  deps.process.on("SIGINT", sigintHandler);
+  deps.process.on("SIGTERM", sigtermHandler);
+
+  return {
+    state: () => state,
+    markReady: (r, runtime) => {
+      if (state._tag !== "Booting") return;
+      running = r;
+      liveRuntimeRef = runtime;
+      state = { _tag: "Ready" };
+    },
+    liveRuntime: () => liveRuntimeRef,
+    requestShutdown: async (reason) => {
+      // If a reload is mid-flight, let it settle first — tearing down a
+      // half-applied reload is exactly race 2.
+      if (state._tag === "Reloading") {
+        if (pendingShutdown === null || pendingShutdown._tag !== "Signal") {
+          pendingShutdown = reason;
+        }
+        // Wait for the reload to settle; the finally block will start
+        // the shutdown via pendingShutdown.
+        if (reloadSettled !== null) {
+          try {
+            await reloadSettled;
+          } catch {
+            /* settled with rejection; finally block already ran */
+          }
+        }
+        if (shutdownPromise !== null) await shutdownPromise;
+        return;
+      }
+      await startShutdown(reason);
+    },
+    dispose: () => {
+      deps.process.off("SIGHUP", sighupHandler);
+      deps.process.off("SIGINT", sigintHandler);
+      deps.process.off("SIGTERM", sigtermHandler);
+    },
+  };
 }
 
 /**
@@ -208,7 +493,26 @@ export async function prepareReload(
   currentRuntime: BridgeRuntimeConfig,
   probe: (publicUrl: string) => Promise<boolean>,
 ): Promise<Result<ReloadPlan, ReloadPrepareError>> {
-  throw new Error("not implemented");
+  const nextInputs = await loadBridgeInputs(env, env.ZAPBOT_CONFIG, probe);
+  if (nextInputs._tag === "Err") {
+    return err({ _tag: "ReloadInputsFailed", reason: nextInputs.error.reason });
+  }
+
+  const reloaded = reloadBridgeRuntimeConfig(currentRuntime, nextInputs.value);
+  if (reloaded._tag === "Err") {
+    return err({ _tag: "ReloadConfigInvalid", cause: reloaded.error });
+  }
+
+  const nextConfig = buildBridgeConfig(env, reloaded.value.next);
+  if (nextConfig._tag === "Err") {
+    return err({ _tag: "ReloadBuildFailed", reason: nextConfig.error.reason });
+  }
+
+  return ok({
+    nextRuntime: reloaded.value.next,
+    nextConfig: nextConfig.value,
+    secretRotated: reloaded.value.secretRotated,
+  });
 }
 
 /**
@@ -224,12 +528,41 @@ export async function prepareReload(
  * Race 2 from sbd#215 is resolved here: the `liveRuntime` mutation in
  * `runBridgeProcess` (formerly at `bridge.ts:1218`, before
  * `running.reload`) moves AFTER this function resolves Ok.
+ *
+ * Atomicity is at the throw boundary only (rev 2 P1 #1). Per-repo
+ * gateway register/deregister failures returned as `Err` via
+ * `Promise.allSettled` inside `running.reload` are NOT detected here;
+ * sbd#219 (§6.3 follow-up) addresses gateway-layer transactionality.
  */
 export async function commitReload(
   running: RunningBridge,
   plan: ReloadPlan,
-  previousRuntime: BridgeRuntimeConfig,
+  _previousRuntime: BridgeRuntimeConfig,
   previousConfig: BridgeConfig,
 ): Promise<Result<BridgeRuntimeConfig, ReloadCommitError>> {
-  throw new Error("not implemented");
+  try {
+    await running.reload(plan.nextConfig);
+  } catch (commitError) {
+    const originalCause =
+      commitError instanceof Error ? commitError.message : String(commitError);
+    try {
+      await running.reload(previousConfig);
+    } catch (rollbackError) {
+      const rollbackCause =
+        rollbackError instanceof Error
+          ? rollbackError.message
+          : String(rollbackError);
+      return err({
+        _tag: "ReloadRollbackFailed",
+        originalCause,
+        rollbackCause,
+      });
+    }
+    return err({
+      _tag: "ReloadCommitFailed",
+      cause: originalCause,
+      rolledBack: true,
+    });
+  }
+  return ok(plan.nextRuntime);
 }

--- a/src/bridge-process.ts
+++ b/src/bridge-process.ts
@@ -319,8 +319,8 @@ export function installBridgeProcessLifecycle(
     reloadSettled = (async () => {
       try {
         // Rebuild the previous BridgeConfig from the previous runtime.
-        // buildBridgeConfig is pure-fold over env + runtime; it can only
-        // fail if the Moltzap env env decode fails, which is identical to
+        // buildBridgeConfig is a pure fold over env + runtime; it can only
+        // fail if the Moltzap env decode fails, which is identical to
         // boot — env hasn't moved, so a failure here is anomalous.
         const previousConfigResult = buildBridgeConfig(deps.env, previousRuntime);
         if (previousConfigResult._tag === "Err") {

--- a/src/bridge-process.ts
+++ b/src/bridge-process.ts
@@ -1,0 +1,229 @@
+/**
+ * bridge-process — boot/reload/shutdown lifecycle primitive for `runBridgeProcess`.
+ *
+ * STUBS ONLY (architect, sbd#215). Function bodies throw. Implementer
+ * (`/safer:implement-staff` or `/safer:implement-senior`) fills the bodies
+ * against the design doc on https://github.com/chughtapan/safer-by-default/issues/215.
+ *
+ * This module exists to fix three pre-existing races in `runBridgeProcess`
+ * (preserved verbatim from the pre-collapse `bin/webhook-bridge.ts::main()`):
+ *
+ *   1. Signal handlers were installed AFTER the post-boot health probe.
+ *      A SIGTERM during boot was lost (or terminated the process via the
+ *      Node default handler) before in-flight registration could finish.
+ *   2. `liveRuntime` was mutated BEFORE `running.reload(...)` resolved.
+ *      If `running.reload` threw, `liveRuntime` was already advanced and
+ *      the bridge runtime entered a half-replaced state.
+ *   3. SIGHUP was not gated by `shuttingDown`. A SIGHUP arriving during
+ *      graceful shutdown started a reload that raced shutdown finalizers.
+ *
+ * The two primitives published here address all three:
+ *
+ *   - `installBridgeProcessLifecycle` installs SIGHUP/SIGINT/SIGTERM
+ *     handlers BEFORE any boot I/O. Handlers dispatch through an explicit
+ *     state machine: signals received during `Booting` queue (SIGHUP) or
+ *     pre-empt boot (SIGINT/SIGTERM); signals during `Reloading` defer
+ *     shutdown until the reload commit/rollback completes; SIGHUP during
+ *     `ShuttingDown` is a no-op.
+ *
+ *   - `prepareReload` / `commitReload` enforce validate-then-commit. The
+ *     plan is built without touching the live runtime; the live runtime
+ *     ref is updated only after `running.reload(plan.nextConfig)` resolves
+ *     Ok. On reject, the previous runtime stays installed.
+ *
+ * Confined to the lifecycle/signal/reload surface of `runBridgeProcess`.
+ * `startBridge` (HTTP server, gateway register/deregister, MoltZap boot)
+ * is unchanged.
+ */
+
+import type { BridgeRuntimeConfig, ConfigReloadError } from "./config/types.ts";
+import type { BridgeConfig, RunningBridge } from "./bridge.ts";
+import type { Result } from "./types.ts";
+
+// ── State ───────────────────────────────────────────────────────────
+
+/**
+ * Lifecycle phase. The state machine is linear with one branch:
+ *
+ *   Booting → Ready ─┬─ Reloading → Ready
+ *                    └─ ShuttingDown   (terminal)
+ *
+ * - `Booting`: handlers installed; no live `RunningBridge` yet. SIGHUP
+ *   queues until `markReady`. SIGTERM/SIGINT pre-empts boot — the
+ *   caller of `installBridgeProcessLifecycle` MUST observe `state()`
+ *   between boot steps and bail with `requestShutdown` if it has flipped.
+ * - `Ready`: server up, registered, post-boot probe passed.
+ * - `Reloading`: SIGHUP in flight. SIGHUP arriving in this phase logs
+ *   and no-ops (existing `reloadInFlight` semantics, preserved).
+ * - `ShuttingDown`: terminal. SIGHUP is a no-op. SIGINT/SIGTERM is
+ *   idempotent (prior `shuttingDown` flag, preserved).
+ */
+export type BridgeProcessState =
+  | { readonly _tag: "Booting" }
+  | { readonly _tag: "Ready" }
+  | { readonly _tag: "Reloading" }
+  | { readonly _tag: "ShuttingDown"; readonly reason: ShutdownReason };
+
+export type ShutdownReason =
+  | { readonly _tag: "Signal"; readonly signal: "SIGINT" | "SIGTERM" }
+  | { readonly _tag: "BootProbeFailed"; readonly publicUrl: string }
+  | { readonly _tag: "BootConfigInvalid"; readonly reason: string }
+  | { readonly _tag: "Manual"; readonly reason: string };
+
+// ── Lifecycle handle ────────────────────────────────────────────────
+
+export interface BridgeProcessLifecycle {
+  /** Read-only snapshot of the current phase. */
+  readonly state: () => BridgeProcessState;
+
+  /**
+   * Transition `Booting` → `Ready`. Idempotent: no-op if state is not
+   * `Booting`. After this call, queued SIGHUPs (if any) are dispatched
+   * onto the supplied `running` handle. The `runtime` param becomes the
+   * initial value of the live runtime ref returned by `liveRuntime()`.
+   */
+  readonly markReady: (
+    running: RunningBridge,
+    runtime: BridgeRuntimeConfig,
+  ) => void;
+
+  /**
+   * Current live runtime ref. Mutated only by `commitReload` on success.
+   * Returns `null` while in `Booting` (no runtime installed yet).
+   */
+  readonly liveRuntime: () => BridgeRuntimeConfig | null;
+
+  /**
+   * Trigger graceful shutdown from a non-signal source (boot probe
+   * failure, fatal config error). Idempotent. Resolves once `running.stop()`
+   * has finished and `process.exit` has been requested. Callers in
+   * `Booting` may invoke this before any `RunningBridge` exists; the
+   * lifecycle drops the exit through `deps.exit(1)`.
+   */
+  readonly requestShutdown: (reason: ShutdownReason) => Promise<void>;
+
+  /**
+   * Detach signal handlers. Test-only; production never disposes (the
+   * process is exiting). Must be called from a non-signal context.
+   */
+  readonly dispose: () => void;
+}
+
+// ── Reload validation/commit ────────────────────────────────────────
+
+/**
+ * Validated reload plan. Construct only via `prepareReload`. Holds the
+ * staged `nextRuntime` and `nextConfig` — neither has been applied to
+ * the live bridge yet.
+ */
+export interface ReloadPlan {
+  readonly nextRuntime: BridgeRuntimeConfig;
+  readonly nextConfig: BridgeConfig;
+  readonly secretRotated: boolean;
+}
+
+export type ReloadPrepareError =
+  | { readonly _tag: "ReloadInputsFailed"; readonly reason: string }
+  | { readonly _tag: "ReloadConfigInvalid"; readonly cause: ConfigReloadError }
+  | { readonly _tag: "ReloadBuildFailed"; readonly reason: string };
+
+export type ReloadCommitError =
+  | {
+      readonly _tag: "ReloadCommitFailed";
+      readonly cause: string;
+      /** True if `running.reload(previous)` succeeded after the failed swap. */
+      readonly rolledBack: boolean;
+    }
+  | {
+      readonly _tag: "ReloadRollbackFailed";
+      readonly originalCause: string;
+      readonly rollbackCause: string;
+    };
+
+// ── Public surface ──────────────────────────────────────────────────
+
+export interface BridgeProcessLifecycleDeps {
+  /** Process env (test-injectable). */
+  readonly env: NodeJS.ProcessEnv;
+  /** `/healthz` reachability probe; injectable for tests. */
+  readonly probe: (publicUrl: string) => Promise<boolean>;
+  /**
+   * The Node `process`-like object whose `.on` we register signal
+   * handlers against. Test-injectable; production passes `process`.
+   */
+  readonly process: Pick<NodeJS.Process, "on" | "off">;
+  /**
+   * Process-exit shim. Test-injectable; production passes
+   * `(code) => process.exit(code)`. Architect note: NEVER call
+   * `process.exit` directly inside this module — always go through
+   * `deps.exit` so tests can observe shutdown without killing the runner.
+   */
+  readonly exit: (code: number) => never;
+  /** Logger; reuses `createLogger("bridge")` in production. */
+  readonly logger: {
+    readonly info: (msg: string) => void;
+    readonly warn: (msg: string) => void;
+    readonly error: (msg: string) => void;
+  };
+}
+
+/**
+ * Install SIGHUP/SIGINT/SIGTERM handlers and return a lifecycle handle.
+ *
+ * **MUST be called BEFORE any boot I/O.** Specifically: before
+ * `loadBridgeInputs`, before `startBridge`, before the post-boot probe.
+ * Race 1 from sbd#215 is resolved by this ordering invariant — the
+ * signal handlers exist throughout boot, so a SIGTERM mid-boot trips
+ * the lifecycle's `Booting → ShuttingDown` transition rather than being
+ * caught by the Node default handler.
+ *
+ * Returned handle starts in state `Booting`. Caller boots, then calls
+ * `markReady(running, runtime)`. If boot fails, caller calls
+ * `requestShutdown({ _tag: "Boot..." })`.
+ */
+export function installBridgeProcessLifecycle(
+  deps: BridgeProcessLifecycleDeps,
+): BridgeProcessLifecycle {
+  throw new Error("not implemented");
+}
+
+/**
+ * Validate-then-commit phase 1. Reads disk, runs ingress resolution,
+ * runs `reloadBridgeRuntimeConfig` and `buildBridgeConfig` — all of
+ * which can fail without touching the live bridge. Returns the
+ * `ReloadPlan` that `commitReload` will apply atomically.
+ *
+ * **Pure failure mode — never mutates the live runtime ref.** Race 2
+ * from sbd#215 is resolved at this seam: validation is a separate
+ * call from commit, and only the commit advances state.
+ */
+export async function prepareReload(
+  env: NodeJS.ProcessEnv,
+  currentRuntime: BridgeRuntimeConfig,
+  probe: (publicUrl: string) => Promise<boolean>,
+): Promise<Result<ReloadPlan, ReloadPrepareError>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Validate-then-commit phase 2. Calls `running.reload(plan.nextConfig)`,
+ * then on success returns `plan.nextRuntime` for the caller to install
+ * as the new live runtime.
+ *
+ * On `running.reload` rejection, attempts rollback by re-applying the
+ * `previousConfig` derived from `previousRuntime`. The lifecycle's
+ * `liveRuntime` ref is updated by the caller (`installBridgeProcessLifecycle`'s
+ * SIGHUP handler) — this function is purely transactional over `running`.
+ *
+ * Race 2 from sbd#215 is resolved here: the `liveRuntime` mutation in
+ * `runBridgeProcess` (formerly at `bridge.ts:1218`, before
+ * `running.reload`) moves AFTER this function resolves Ok.
+ */
+export async function commitReload(
+  running: RunningBridge,
+  plan: ReloadPlan,
+  previousRuntime: BridgeRuntimeConfig,
+  previousConfig: BridgeConfig,
+): Promise<Result<BridgeRuntimeConfig, ReloadCommitError>> {
+  throw new Error("not implemented");
+}

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1227,8 +1227,9 @@ export async function runBridgeProcess(
   const running = await start(cfg);
 
   if (lifecycle.state()._tag === "ShuttingDown") {
-    // Signal arrived during start(). Hand `running` to the lifecycle so
-    // requestShutdown can stop it cleanly, then drive shutdown.
+    // Signal arrived during start(). Hand `running` to the lifecycle —
+    // markReady stashes it even when state is ShuttingDown so the
+    // signal-driven shutdown path can stop it gracefully.
     lifecycle.markReady(running, initialInputs.value);
     await lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGTERM" });
     return;
@@ -1247,6 +1248,19 @@ export async function runBridgeProcess(
       });
       return;
     }
+  }
+
+  // Race-1 corner case (codex review P1): a signal arriving DURING the
+  // post-boot probe (when the probe returns true) flips state to
+  // ShuttingDown without the boot caller noticing. Without this check,
+  // markReady would stash `running` + auto-fire startShutdown but
+  // runBridgeProcess would return before the shutdown promise resolved,
+  // and the boot caller would not log "listening". Stop the bridge
+  // explicitly so the operator sees a clean shutdown trace.
+  if (lifecycle.state()._tag === "ShuttingDown") {
+    lifecycle.markReady(running, initialInputs.value);
+    await lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGTERM" });
+    return;
   }
 
   log.info(`Webhook bridge listening on ${cfg.ingress.mode === "github-demo" ? cfg.publicUrl : "local-only ingress"}`);

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -29,7 +29,6 @@ import { readCanonicalConfig } from "./config/canonical.ts";
 import { resolveIngressPolicy } from "./config/ingress.ts";
 import type { IngressResolutionError } from "./config/ingress.ts";
 import { parseProjectConfig, readConfigFiles } from "./config/disk.ts";
-import { reloadBridgeRuntimeConfig } from "./config/reload.ts";
 import type {
   BridgeRuntimeConfig,
   ConfigDiskError,
@@ -84,6 +83,7 @@ import {
   handleInstallationTokenRequest,
   type InstallationTokenStatus,
 } from "./http/routes/installation-token.ts";
+import { installBridgeProcessLifecycle } from "./bridge-process.ts";
 
 const WRITE_PERMISSIONS = new Set(["write", "maintain", "admin"]);
 const log = createLogger("bridge");
@@ -1140,12 +1140,20 @@ export function formatIngressError(error: IngressResolutionError): string {
 }
 
 /**
- * Run the bridge process: load config, boot the HTTP server, install
- * SIGHUP reload + SIGINT/SIGTERM shutdown handlers. Returns a Promise
- * that never resolves under normal operation — the signal handlers
- * call `process.exit(0)` once `running.stop()` finishes.
+ * Run the bridge process: install signal handlers, load config, boot
+ * the HTTP server. Returns once `markReady` has handed ownership of
+ * `running` to the lifecycle. The lifecycle owns SIGHUP reload and
+ * SIGINT/SIGTERM shutdown; the HTTP server keeps the event loop alive
+ * until `running.stop()` resolves and `process.exit` is requested.
  *
- * On config-load or reachability failure, exits with code 1.
+ * On config-load or reachability failure, the lifecycle exits with code 1.
+ *
+ * Race fixes (sbd#215, see `bridge-process.ts` module header):
+ *   - Race 1: `installBridgeProcessLifecycle` is the FIRST line — signal
+ *     handlers exist throughout boot.
+ *   - Race 2: `liveRuntime` advances inside the lifecycle's SIGHUP path
+ *     ONLY after `commitReload` resolves Ok.
+ *   - Race 3: SIGHUP no-ops on `Booting`, `Reloading`, and `ShuttingDown`.
  *
  * Tests can stub out `startBridge` and `probeHealthz` via the optional
  * second arg; production callers (the bin) pass nothing.
@@ -1153,6 +1161,13 @@ export function formatIngressError(error: IngressResolutionError): string {
 export interface RunBridgeProcessOverrides {
   readonly start?: (config: BridgeConfig) => Promise<RunningBridge>;
   readonly probe?: (publicUrl: string) => Promise<boolean>;
+  /**
+   * Test-injectable lifecycle factory. Production callers omit this
+   * and the default `installBridgeProcessLifecycle` is used (which
+   * installs handlers against the real `process` and calls
+   * `process.exit` for shutdown).
+   */
+  readonly installLifecycle?: typeof installBridgeProcessLifecycle;
 }
 
 export async function runBridgeProcess(
@@ -1161,87 +1176,81 @@ export async function runBridgeProcess(
 ): Promise<void> {
   const start = overrides.start ?? startBridge;
   const probe = overrides.probe ?? probeHealthz;
+  const installLifecycle =
+    overrides.installLifecycle ?? installBridgeProcessLifecycle;
+
+  // Race-1 fix: install signal handlers BEFORE any boot I/O.
+  const lifecycle = installLifecycle({
+    env,
+    probe,
+    process,
+    exit: ((code: number) => process.exit(code)) as (code: number) => never,
+    logger: log,
+  });
 
   // Skip the reachability probe on initial load — the bridge isn't running yet
   // so /healthz isn't open. We boot first, then probe the live endpoint below.
   const initialInputs = await loadBridgeInputs(env, env.ZAPBOT_CONFIG, async () => true);
   if (initialInputs._tag === "Err") {
     console.error(`[bridge] ${initialInputs.error.reason}`);
-    process.exit(1);
+    await lifecycle.requestShutdown({
+      _tag: "BootConfigInvalid",
+      reason: initialInputs.error.reason,
+    });
+    return;
+  }
+
+  if (lifecycle.state()._tag === "ShuttingDown") {
+    await lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGTERM" });
+    return;
   }
 
   const initialConfig = buildBridgeConfig(env, initialInputs.value);
   if (initialConfig._tag === "Err") {
     console.error(`[bridge] ${initialConfig.error.reason}`);
-    process.exit(1);
+    await lifecycle.requestShutdown({
+      _tag: "BootConfigInvalid",
+      reason: initialConfig.error.reason,
+    });
+    return;
   }
 
-  let liveRuntime = initialInputs.value;
+  if (lifecycle.state()._tag === "ShuttingDown") {
+    await lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGTERM" });
+    return;
+  }
+
   const cfg = initialConfig.value;
   log.info(`Webhook bridge starting on port ${cfg.port}`);
   log.info(`Ingress mode: ${cfg.ingress.mode}`);
 
   const running = await start(cfg);
 
+  if (lifecycle.state()._tag === "ShuttingDown") {
+    // Signal arrived during start(). Hand `running` to the lifecycle so
+    // requestShutdown can stop it cleanly, then drive shutdown.
+    lifecycle.markReady(running, initialInputs.value);
+    await lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGTERM" });
+    return;
+  }
+
   // Post-boot reachability probe — fires against the now-live /healthz endpoint.
   // If the probe fails, tear down the bridge cleanly before exiting.
   if (cfg.ingress.mode === "github-demo" && cfg.publicUrl !== null) {
     const reachable = await probe(cfg.publicUrl);
     if (!reachable) {
-      await running.stop();
       console.error(`[bridge] ZAPBOT_BRIDGE_URL is unreachable: ${cfg.publicUrl}`);
-      process.exit(1);
+      lifecycle.markReady(running, initialInputs.value);
+      await lifecycle.requestShutdown({
+        _tag: "BootProbeFailed",
+        publicUrl: cfg.publicUrl,
+      });
+      return;
     }
   }
 
   log.info(`Webhook bridge listening on ${cfg.ingress.mode === "github-demo" ? cfg.publicUrl : "local-only ingress"}`);
 
-  let reloadInFlight = false;
-  process.on("SIGHUP", () => {
-    if (reloadInFlight) {
-      log.warn("SIGHUP received while reload in flight; ignoring");
-      return;
-    }
-    reloadInFlight = true;
-    (async () => {
-      try {
-        const nextInputs = await loadBridgeInputs(env, env.ZAPBOT_CONFIG, probe);
-        if (nextInputs._tag === "Err") {
-          log.error(`Reload failed: ${nextInputs.error.reason}`);
-          return;
-        }
-
-        const reloaded = reloadBridgeRuntimeConfig(liveRuntime, nextInputs.value);
-        if (reloaded._tag === "Err") {
-          log.error(`Reload failed: ${formatConfigError(reloaded.error)}`);
-          return;
-        }
-
-        const nextConfig = buildBridgeConfig(env, reloaded.value.next);
-        if (nextConfig._tag === "Err") {
-          log.error(`Reload failed: ${nextConfig.error.reason}`);
-          return;
-        }
-
-        liveRuntime = reloaded.value.next;
-        await running.reload(nextConfig.value);
-        log.info(`Config reloaded (${nextConfig.value.repos.size} repos, secret rotated: ${reloaded.value.secretRotated})`);
-      } catch (err) {
-        log.error(`Reload failed: ${err instanceof Error ? err.message : err}`);
-      } finally {
-        reloadInFlight = false;
-      }
-    })();
-  });
-
-  let shuttingDown = false;
-  async function shutdown(): Promise<void> {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    log.info("Shutting down...");
-    await running.stop();
-    process.exit(0);
-  }
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  // Hand off ownership: the lifecycle now drives reload + shutdown.
+  lifecycle.markReady(running, initialInputs.value);
 }

--- a/test/bridge-process-lifecycle.test.ts
+++ b/test/bridge-process-lifecycle.test.ts
@@ -653,3 +653,50 @@ describe("BridgeProcessLifecycle handle", () => {
     expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
   });
 });
+
+// ── Codex review regression: signal-during-boot must not orphan running ──
+
+describe("installBridgeProcessLifecycle: late-arriving running on signal-preempted boot", () => {
+  it("markReady stashes running even when state is ShuttingDown (codex P2)", async () => {
+    const { deps, fakeProcess, exitTrap } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      // Simulate signal-during-start: SIGTERM fires BEFORE the boot caller
+      // hands `running` to the lifecycle.
+      fakeProcess.fire("SIGTERM");
+      expect(lifecycle.state()._tag).toBe("ShuttingDown");
+
+      // Boot caller now reaches markReady with the just-created `running`.
+      const running = makeFakeRunning();
+      lifecycle.markReady(running, makeRuntime());
+
+      // markReady must trigger graceful shutdown — running.stop() and
+      // exit(0). Without the fix, running was orphaned: stop() never fired.
+      const code = await exitTrap.next();
+      expect(code).toBe(0);
+      expect(running.stopCalls).toBe(1);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("markReady-after-signal is idempotent with a concurrent requestShutdown", async () => {
+    const { deps, fakeProcess, exitTrap } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      fakeProcess.fire("SIGINT");
+      const running = makeFakeRunning();
+      lifecycle.markReady(running, makeRuntime());
+      // Boot caller also calls requestShutdown explicitly (race-cleanup pattern).
+      await Promise.all([
+        lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGINT" }),
+        lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGINT" }),
+      ]);
+      // Exactly one stop, exactly one exit.
+      expect(running.stopCalls).toBe(1);
+      expect(exitTrap.exitCalls).toEqual([0]);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+});

--- a/test/bridge-process-lifecycle.test.ts
+++ b/test/bridge-process-lifecycle.test.ts
@@ -1,0 +1,655 @@
+/**
+ * Tests for `src/bridge-process.ts` — the boot/reload/shutdown lifecycle
+ * primitive that fixes sbd#215 races 1, 2, and 3.
+ *
+ * Architect plan: rev 2 + addendum.
+ *   https://github.com/chughtapan/safer-by-default/issues/215#issuecomment-4318477234
+ *
+ * Coverage map (per architect §7 + rev 2 sub-table):
+ *   - Race 1: signals during Booting flip state synchronously; boot caller
+ *     observes and bails.
+ *   - Race 2: prepareReload validation failure leaves liveRuntime intact;
+ *     commitReload throw on swap rolls back; commitReload throw on rollback
+ *     surfaces ReloadRollbackFailed.
+ *   - Race 3: SIGHUP during Booting/Reloading/ShuttingDown is a no-op.
+ *   - SIGTERM-during-Reloading: reload settles before stop fires; signal
+ *     wins over Manual rollback-failure escalation (rev 2 P1 #3).
+ *   - State machine: every transition in the rev 2 transition table.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  commitReload,
+  installBridgeProcessLifecycle,
+  prepareReload,
+  type BridgeProcessLifecycle,
+  type BridgeProcessLifecycleDeps,
+  type ReloadPlan,
+} from "../src/bridge-process.ts";
+import type { BridgeConfig, RunningBridge } from "../src/bridge.ts";
+import type { BridgeRuntimeConfig } from "../src/config/types.ts";
+
+// ── Test doubles ───────────────────────────────────────────────────
+
+interface FakeProcess extends Pick<NodeJS.Process, "on" | "off"> {
+  fire(signal: "SIGHUP" | "SIGINT" | "SIGTERM"): void;
+  listenerCount(signal: "SIGHUP" | "SIGINT" | "SIGTERM"): number;
+}
+
+function makeFakeProcess(): FakeProcess {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+  return {
+    on(signal: NodeJS.Signals | string, handler: (...args: unknown[]) => void) {
+      const key = String(signal);
+      handlers[key] = handlers[key] ?? [];
+      handlers[key].push(handler);
+      return this as unknown as NodeJS.Process;
+    },
+    off(signal: NodeJS.Signals | string, handler: (...args: unknown[]) => void) {
+      const key = String(signal);
+      handlers[key] = (handlers[key] ?? []).filter((h) => h !== handler);
+      return this as unknown as NodeJS.Process;
+    },
+    fire(signal) {
+      for (const h of handlers[signal] ?? []) h();
+    },
+    listenerCount(signal) {
+      return (handlers[signal] ?? []).length;
+    },
+  } as FakeProcess;
+}
+
+interface ExitTrap {
+  exit: (code: number) => never;
+  exitCalls: number[];
+  /** Resolves the next time exit fires. */
+  next(): Promise<number>;
+}
+
+function makeExitTrap(): ExitTrap {
+  const exitCalls: number[] = [];
+  let pendingResolve: ((code: number) => void) | null = null;
+  return {
+    exit: ((code: number) => {
+      exitCalls.push(code);
+      if (pendingResolve !== null) {
+        pendingResolve(code);
+        pendingResolve = null;
+      }
+      // Returning never-typed value without throwing — tests don't fork a
+      // process. The signature lies in the static type but we don't depend
+      // on the runtime non-return behavior in tests.
+      return undefined as never;
+    }) as (code: number) => never,
+    exitCalls,
+    next() {
+      return new Promise<number>((r) => {
+        pendingResolve = r;
+      });
+    },
+  };
+}
+
+interface TestLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+  /** All logged messages, prefixed by level. */
+  readonly messages: string[];
+}
+
+function makeLogger(): TestLogger {
+  const messages: string[] = [];
+  return {
+    info: (m) => messages.push(`info: ${m}`),
+    warn: (m) => messages.push(`warn: ${m}`),
+    error: (m) => messages.push(`error: ${m}`),
+    messages,
+  };
+}
+
+function makeRuntime(overrides: Partial<BridgeRuntimeConfig> = {}): BridgeRuntimeConfig {
+  return {
+    port: 3000,
+    ingress: { mode: "local-only" },
+    publicUrl: null,
+    gatewayUrl: null,
+    gatewaySecret: null,
+    botUsername: "test-bot" as never,
+    aoConfigPath: null,
+    apiKey: "api-key",
+    webhookSecret: "wh-secret",
+    routes: new Map(),
+    ...overrides,
+  };
+}
+
+function makeConfig(): BridgeConfig {
+  return {
+    port: 3000,
+    ingress: { mode: "local-only" },
+    publicUrl: null,
+    gatewayUrl: null,
+    gatewaySecret: null,
+    botUsername: "test-bot" as never,
+    aoConfigPath: "",
+    apiKey: "api-key",
+    webhookSecret: "wh-secret",
+    moltzap: null,
+    repos: new Map(),
+  };
+}
+
+interface FakeRunning extends RunningBridge {
+  /** Per-call hooks. The Nth call (0-indexed) reads hooks[n]. */
+  hooks: Array<() => Promise<void>>;
+  reloadCalls: number;
+  stopCalls: number;
+}
+
+function makeFakeRunning(): FakeRunning {
+  const r: FakeRunning = {
+    hooks: [],
+    reloadCalls: 0,
+    stopCalls: 0,
+    stop: async () => {
+      r.stopCalls += 1;
+    },
+    reload: async () => {
+      const idx = r.reloadCalls;
+      r.reloadCalls += 1;
+      const hook = r.hooks[idx];
+      if (hook !== undefined) await hook();
+    },
+  };
+  return r;
+}
+
+function makeDeps(over: Partial<BridgeProcessLifecycleDeps> = {}): {
+  deps: BridgeProcessLifecycleDeps;
+  fakeProcess: FakeProcess;
+  exitTrap: ExitTrap;
+  logger: TestLogger;
+} {
+  const fakeProcess = makeFakeProcess();
+  const exitTrap = makeExitTrap();
+  const logger = makeLogger();
+  const deps: BridgeProcessLifecycleDeps = {
+    env: {},
+    probe: async () => true,
+    process: fakeProcess,
+    exit: exitTrap.exit,
+    logger,
+    ...over,
+  };
+  return { deps, fakeProcess, exitTrap, logger };
+}
+
+// ── Race-1: signal handlers installed before any boot I/O ──────────
+
+describe("installBridgeProcessLifecycle: signal handlers (race-1 fix)", () => {
+  it("installs SIGHUP/SIGINT/SIGTERM synchronously on call", () => {
+    const { deps, fakeProcess } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      expect(fakeProcess.listenerCount("SIGHUP")).toBe(1);
+      expect(fakeProcess.listenerCount("SIGINT")).toBe(1);
+      expect(fakeProcess.listenerCount("SIGTERM")).toBe(1);
+      expect(lifecycle.state()._tag).toBe("Booting");
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("SIGTERM during Booting flips state to ShuttingDown synchronously", () => {
+    const { deps, fakeProcess } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      expect(lifecycle.state()._tag).toBe("Booting");
+      fakeProcess.fire("SIGTERM");
+      const s = lifecycle.state();
+      expect(s._tag).toBe("ShuttingDown");
+      if (s._tag !== "ShuttingDown") return;
+      expect(s.reason._tag).toBe("Signal");
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("requestShutdown after SIGTERM during Booting calls deps.exit(0) without running.stop", async () => {
+    const { deps, fakeProcess, exitTrap } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      fakeProcess.fire("SIGTERM");
+      await lifecycle.requestShutdown({ _tag: "Signal", signal: "SIGTERM" });
+      expect(exitTrap.exitCalls).toEqual([0]);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("SIGINT during Booting also flips state and exits 0 via requestShutdown", async () => {
+    const { deps, fakeProcess, exitTrap } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      fakeProcess.fire("SIGINT");
+      const s = lifecycle.state();
+      expect(s._tag).toBe("ShuttingDown");
+      if (s._tag !== "ShuttingDown" || s.reason._tag !== "Signal") return;
+      expect(s.reason.signal).toBe("SIGINT");
+      await lifecycle.requestShutdown(s.reason);
+      expect(exitTrap.exitCalls).toEqual([0]);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+});
+
+// ── Race-3: SIGHUP no-ops on non-Ready states ──────────────────────
+
+describe("installBridgeProcessLifecycle: SIGHUP no-op states (race-3 fix)", () => {
+  it("SIGHUP during Booting is a no-op (no queue, no deferred dispatch)", async () => {
+    const { deps, fakeProcess, logger } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      fakeProcess.fire("SIGHUP");
+      expect(lifecycle.state()._tag).toBe("Booting");
+      // Even after markReady, the dropped SIGHUP must not dispatch.
+      const running = makeFakeRunning();
+      lifecycle.markReady(running, makeRuntime());
+      // Allow any deferred microtasks to flush.
+      await Promise.resolve();
+      expect(running.reloadCalls).toBe(0);
+      expect(logger.messages.some((m) => m.includes("SIGHUP ignored during boot"))).toBe(true);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("SIGHUP during ShuttingDown is a no-op", async () => {
+    const { deps, fakeProcess, logger } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const running = makeFakeRunning();
+      lifecycle.markReady(running, makeRuntime());
+      // Drive into ShuttingDown.
+      fakeProcess.fire("SIGTERM");
+      await new Promise((r) => setTimeout(r, 10));
+      expect(lifecycle.state()._tag).toBe("ShuttingDown");
+      // Now fire SIGHUP — must no-op.
+      fakeProcess.fire("SIGHUP");
+      await new Promise((r) => setTimeout(r, 10));
+      expect(running.reloadCalls).toBe(0);
+      expect(logger.messages.some((m) => m.includes("SIGHUP ignored during shutdown"))).toBe(true);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+});
+
+// ── Reload state machine + race-2 + race-3 (SIGHUP-during-Reloading) ──
+
+describe("installBridgeProcessLifecycle: reload state machine", () => {
+  let tempHome: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "zapbot-bp-lifecycle-"));
+    mkdirSync(join(tempHome, ".zapbot"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".zapbot", "config.json"),
+      JSON.stringify({ webhookSecret: "wh-secret", apiKey: "api-key" }),
+    );
+    env = { HOME: tempHome, ZAPBOT_BOT_USERNAME: "test-bot" };
+  });
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("SIGHUP in Ready transitions through Reloading and back to Ready on success", async () => {
+    const { deps, fakeProcess } = makeDeps({ env });
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const running = makeFakeRunning();
+      lifecycle.markReady(running, makeRuntime());
+      expect(lifecycle.state()._tag).toBe("Ready");
+
+      fakeProcess.fire("SIGHUP");
+      // Wait for the async reload work to settle.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(running.reloadCalls).toBe(1);
+      expect(lifecycle.state()._tag).toBe("Ready");
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("SIGHUP during Reloading no-ops (race-3 reloadInFlight regression)", async () => {
+    const { deps, fakeProcess, logger } = makeDeps({ env });
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const running = makeFakeRunning();
+      let releaseFirst!: () => void;
+      const firstReloadGate = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      running.hooks[0] = () => firstReloadGate;
+      lifecycle.markReady(running, makeRuntime());
+
+      fakeProcess.fire("SIGHUP");
+      // Wait long enough for prepareReload to settle and reach commitReload.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(lifecycle.state()._tag).toBe("Reloading");
+
+      fakeProcess.fire("SIGHUP");
+      await new Promise((r) => setTimeout(r, 5));
+      expect(running.reloadCalls).toBe(1);
+      expect(
+        logger.messages.some((m) => m.includes("SIGHUP received while reload in flight")),
+      ).toBe(true);
+
+      releaseFirst();
+      await new Promise((r) => setTimeout(r, 30));
+      expect(lifecycle.state()._tag).toBe("Ready");
+      expect(running.reloadCalls).toBe(1);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("SIGTERM during Reloading defers shutdown until reload settles (rev 2 P1 #3 a)", async () => {
+    const { deps, fakeProcess, exitTrap } = makeDeps({ env });
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const running = makeFakeRunning();
+      const callOrder: string[] = [];
+      let releaseFirst!: () => void;
+      const reloadGate = new Promise<void>((r) => {
+        releaseFirst = r;
+      });
+      running.hooks[0] = async () => {
+        callOrder.push("reload");
+        await reloadGate;
+      };
+      const originalStop = running.stop;
+      running.stop = async () => {
+        callOrder.push("stop");
+        await originalStop();
+      };
+      lifecycle.markReady(running, makeRuntime());
+
+      fakeProcess.fire("SIGHUP");
+      await new Promise((r) => setTimeout(r, 30));
+      expect(lifecycle.state()._tag).toBe("Reloading");
+
+      // SIGTERM during Reloading — must NOT abort the reload.
+      fakeProcess.fire("SIGTERM");
+      await new Promise((r) => setTimeout(r, 5));
+      // Reload still in flight; stop must not have been called yet.
+      expect(running.stopCalls).toBe(0);
+      expect(lifecycle.state()._tag).toBe("Reloading");
+
+      // Release the reload — it commits, then shutdown drains.
+      releaseFirst();
+      // Wait for shutdown to fire.
+      const code = await exitTrap.next();
+      expect(code).toBe(0);
+      expect(callOrder[0]).toBe("reload");
+      expect(callOrder).toContain("stop");
+      // Stop fired AFTER reload — order check.
+      expect(callOrder.indexOf("stop")).toBeGreaterThan(callOrder.indexOf("reload"));
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+});
+
+// ── prepareReload: validation failure (race-2 fix) ────────────────
+
+describe("prepareReload: pure validation", () => {
+  let tempHome: string;
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "zapbot-bp-prepare-"));
+    mkdirSync(join(tempHome, ".zapbot"), { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("returns ReloadInputsFailed when canonical config is missing — never touches running", async () => {
+    const env: NodeJS.ProcessEnv = { HOME: tempHome };
+    const result = await prepareReload(env, makeRuntime(), async () => true);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("ReloadInputsFailed");
+    if (result.error._tag !== "ReloadInputsFailed") return;
+    expect(result.error.reason).toContain("Canonical config not found");
+  });
+
+  it("returns Ok with a ReloadPlan when inputs validate", async () => {
+    writeFileSync(
+      join(tempHome, ".zapbot", "config.json"),
+      JSON.stringify({ webhookSecret: "wh-secret", apiKey: "api-key" }),
+    );
+    const env: NodeJS.ProcessEnv = {
+      HOME: tempHome,
+      ZAPBOT_BOT_USERNAME: "test-bot",
+    };
+    const result = await prepareReload(env, makeRuntime(), async () => true);
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value.nextRuntime.botUsername).toBe("test-bot");
+    expect(result.value.secretRotated).toBe(false);
+  });
+});
+
+// ── commitReload: transactional swap + rollback (race-2 fix) ──────
+
+describe("commitReload: throw-boundary atomicity", () => {
+  function makePlan(): ReloadPlan {
+    return {
+      nextRuntime: makeRuntime({ port: 4000 }),
+      nextConfig: { ...makeConfig(), port: 4000 },
+      secretRotated: false,
+    };
+  }
+
+  it("returns Ok and never calls reload twice when running.reload succeeds", async () => {
+    const running = makeFakeRunning();
+    const plan = makePlan();
+    const result = await commitReload(running, plan, makeRuntime(), makeConfig());
+    expect(result._tag).toBe("Ok");
+    if (result._tag !== "Ok") return;
+    expect(result.value.port).toBe(4000);
+    expect(running.reloadCalls).toBe(1);
+  });
+
+  it("rolls back to previousConfig on running.reload throw (ReloadCommitFailed, rolledBack=true)", async () => {
+    const running = makeFakeRunning();
+    running.hooks[0] = async () => {
+      throw new Error("first-reload boom");
+    };
+    const plan = makePlan();
+    const previousConfig = makeConfig();
+    const result = await commitReload(running, plan, makeRuntime(), previousConfig);
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("ReloadCommitFailed");
+    if (result.error._tag !== "ReloadCommitFailed") return;
+    expect(result.error.rolledBack).toBe(true);
+    expect(result.error.cause).toContain("first-reload boom");
+    // Reload called twice: swap + rollback.
+    expect(running.reloadCalls).toBe(2);
+  });
+
+  it("returns ReloadRollbackFailed when both reload calls throw", async () => {
+    const running = makeFakeRunning();
+    running.hooks[0] = async () => {
+      throw new Error("commit-boom");
+    };
+    running.hooks[1] = async () => {
+      throw new Error("rollback-boom");
+    };
+    const plan = makePlan();
+    const result = await commitReload(running, plan, makeRuntime(), makeConfig());
+    expect(result._tag).toBe("Err");
+    if (result._tag !== "Err") return;
+    expect(result.error._tag).toBe("ReloadRollbackFailed");
+    if (result.error._tag !== "ReloadRollbackFailed") return;
+    expect(result.error.originalCause).toContain("commit-boom");
+    expect(result.error.rollbackCause).toContain("rollback-boom");
+    expect(running.reloadCalls).toBe(2);
+  });
+});
+
+// ── Rev 2 P1 #3 sub-table: SIGTERM + ReloadRollbackFailed precedence ─
+
+describe("installBridgeProcessLifecycle: signal-wins-over-rollback-failure (rev 2 P1 #3)", () => {
+  let tempHome: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "zapbot-bp-rollback-"));
+    mkdirSync(join(tempHome, ".zapbot"), { recursive: true });
+    writeFileSync(
+      join(tempHome, ".zapbot", "config.json"),
+      JSON.stringify({ webhookSecret: "wh-secret", apiKey: "api-key" }),
+    );
+    env = { HOME: tempHome, ZAPBOT_BOT_USERNAME: "test-bot" };
+  });
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("SIGTERM during Reloading + ReloadRollbackFailed → ShuttingDown(Signal), exit 0", async () => {
+    const { deps, fakeProcess, exitTrap } = makeDeps({ env });
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const running = makeFakeRunning();
+      let releaseCommit!: () => void;
+      const commitGate = new Promise<void>((r) => {
+        releaseCommit = r;
+      });
+      // First reload (commit) blocks until SIGTERM has been recorded; then throws.
+      running.hooks[0] = async () => {
+        await commitGate;
+        throw new Error("commit-boom");
+      };
+      // Second reload (rollback) also throws — triggers ReloadRollbackFailed.
+      running.hooks[1] = async () => {
+        throw new Error("rollback-boom");
+      };
+      lifecycle.markReady(running, makeRuntime());
+
+      fakeProcess.fire("SIGHUP");
+      // Wait until lifecycle is mid-reload.
+      await new Promise((r) => setTimeout(r, 30));
+      expect(lifecycle.state()._tag).toBe("Reloading");
+
+      // SIGTERM arrives during Reloading. Per rev 2 P1 #3, signal wins
+      // over the §6.2 force-shutdown that ReloadRollbackFailed would
+      // otherwise drive.
+      fakeProcess.fire("SIGTERM");
+
+      releaseCommit();
+      const code = await exitTrap.next();
+      expect(code).toBe(0); // Signal beats Manual.
+      const s = lifecycle.state();
+      expect(s._tag).toBe("ShuttingDown");
+      if (s._tag !== "ShuttingDown") return;
+      expect(s.reason._tag).toBe("Signal");
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("ReloadRollbackFailed without pending signal → ShuttingDown(Manual), exit 1 (§6.2 default)", async () => {
+    const { deps, fakeProcess, exitTrap } = makeDeps({ env });
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const running = makeFakeRunning();
+      running.hooks[0] = async () => {
+        throw new Error("commit-boom");
+      };
+      running.hooks[1] = async () => {
+        throw new Error("rollback-boom");
+      };
+      lifecycle.markReady(running, makeRuntime());
+
+      fakeProcess.fire("SIGHUP");
+      const code = await exitTrap.next();
+      expect(code).toBe(1);
+      const s = lifecycle.state();
+      expect(s._tag).toBe("ShuttingDown");
+      if (s._tag !== "ShuttingDown") return;
+      expect(s.reason._tag).toBe("Manual");
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+});
+
+// ── markReady idempotency + liveRuntime read-through ──────────────
+
+describe("BridgeProcessLifecycle handle", () => {
+  it("markReady transitions Booting → Ready exactly once", () => {
+    const { deps } = makeDeps();
+    const lifecycle: BridgeProcessLifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const r1 = makeFakeRunning();
+      const rt1 = makeRuntime();
+      lifecycle.markReady(r1, rt1);
+      expect(lifecycle.state()._tag).toBe("Ready");
+      expect(lifecycle.liveRuntime()).toBe(rt1);
+
+      // Second call must be a no-op (state machine guards it).
+      const rt2 = makeRuntime({ port: 9999 });
+      lifecycle.markReady(makeFakeRunning(), rt2);
+      expect(lifecycle.liveRuntime()).toBe(rt1);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("liveRuntime returns null while in Booting", () => {
+    const { deps } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      expect(lifecycle.liveRuntime()).toBeNull();
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("requestShutdown is idempotent (repeated calls do not double-exit)", async () => {
+    const { deps, exitTrap } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    try {
+      const running = makeFakeRunning();
+      lifecycle.markReady(running, makeRuntime());
+      await Promise.all([
+        lifecycle.requestShutdown({ _tag: "Manual", reason: "test" }),
+        lifecycle.requestShutdown({ _tag: "Manual", reason: "test" }),
+      ]);
+      expect(exitTrap.exitCalls).toEqual([1]);
+      expect(running.stopCalls).toBe(1);
+    } finally {
+      lifecycle.dispose();
+    }
+  });
+
+  it("dispose detaches all signal handlers", () => {
+    const { deps, fakeProcess } = makeDeps();
+    const lifecycle = installBridgeProcessLifecycle(deps);
+    expect(fakeProcess.listenerCount("SIGHUP")).toBe(1);
+    lifecycle.dispose();
+    expect(fakeProcess.listenerCount("SIGHUP")).toBe(0);
+    expect(fakeProcess.listenerCount("SIGINT")).toBe(0);
+    expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
+  });
+});

--- a/test/config-reload.test.ts
+++ b/test/config-reload.test.ts
@@ -950,19 +950,38 @@ describe("systemd integration: team-init reload", () => {
   });
 });
 
-describe("SIGHUP handler: bridge registers signal handler", () => {
+describe("SIGHUP handler: lifecycle module owns signal handlers", () => {
   // sbd#202: SIGHUP wiring relocated from bin/webhook-bridge.ts into
-  // src/bridge.ts::runBridgeProcess (architect rev 4 §2 collapse — bin
-  // is now ≤30 LOC). The bin invokes runBridgeProcess; the runtime
-  // sequencer owns SIGHUP + reloadBridgeRuntimeConfig.
-  it("src/bridge.ts runBridgeProcess registers SIGHUP handler", () => {
+  // src/bridge.ts::runBridgeProcess.
+  // sbd#220 (sbd#215 impl): SIGHUP wiring relocated again from the inline
+  // blocks in runBridgeProcess into src/bridge-process.ts so the signal
+  // handlers can be installed BEFORE any boot I/O (race-1 fix). The bin
+  // still invokes runBridgeProcess; runBridgeProcess installs the
+  // lifecycle FIRST and then drives boot.
+  it("src/bridge-process.ts owns SIGHUP/SIGINT/SIGTERM and the reload state machine", () => {
+    const lifecycle = fs.readFileSync(
+      path.join(__dirname, "../src/bridge-process.ts"),
+      "utf-8"
+    );
+
+    expect(lifecycle).toContain('"SIGHUP"');
+    expect(lifecycle).toContain('"SIGINT"');
+    expect(lifecycle).toContain('"SIGTERM"');
+    expect(lifecycle).toContain("reloadBridgeRuntimeConfig");
+  });
+
+  it("src/bridge.ts invokes installBridgeProcessLifecycle as the first boot step", () => {
     const bridge = fs.readFileSync(
       path.join(__dirname, "../src/bridge.ts"),
       "utf-8"
     );
 
-    expect(bridge).toContain('process.on("SIGHUP"');
-    expect(bridge).toContain("reloadBridgeRuntimeConfig");
+    expect(bridge).toContain("installBridgeProcessLifecycle");
+    // Inline `process.on("SIGHUP", ...)` blocks must be gone from bridge.ts —
+    // race-1 invariant requires the handlers to live in the lifecycle module.
+    expect(bridge).not.toContain('process.on("SIGHUP"');
+    expect(bridge).not.toContain('process.on("SIGINT"');
+    expect(bridge).not.toContain('process.on("SIGTERM"');
   });
 
   it("bin/webhook-bridge.ts is the thin shim that invokes runBridgeProcess", () => {


### PR DESCRIPTION
Closes sbd#220 (https://github.com/chughtapan/safer-by-default/issues/220).

Implements the architect plan rev 2 from sbd#215 (https://github.com/chughtapan/safer-by-default/issues/215) — boot/reload/shutdown lifecycle for `runBridgeProcess`. Fixes 3 pre-existing race conditions and pins the rev 2 P1 #3 sub-table semantics.

## What changed

- New module `src/bridge-process.ts` (568 LOC). Implements `installBridgeProcessLifecycle`, `prepareReload`, `commitReload` against the architect rev 2 stubs at `architect/sbd-215-lifecycle@dd57f06`.
- `src/bridge.ts::runBridgeProcess` refactored to install the lifecycle FIRST, then drive boot. Inline `process.on("SIGHUP|SIGINT|SIGTERM", ...)` blocks DELETED.
- Two test files: 22-case unit suite for lifecycle state machine + race regressions; existing `bridge-process.test.ts` retargeted to the new owner; `config-reload.test.ts` source-shape assertion updated to verify the race-1 invariant cannot regress.

## Race fixes (sbd#215)

- **Race 1** — Signal handlers install BEFORE any boot I/O. `installBridgeProcessLifecycle` is the FIRST line of `runBridgeProcess`. SIGINT/SIGTERM during boot flips state to `ShuttingDown(Signal)`; the boot caller polls `state()` between awaits and bails to `requestShutdown`. Latency bounded by the longest remaining boot await (rev 1 §6.1 default a).
- **Race 2** — `liveRuntime` advances ONLY after `commitReload` resolves Ok. `commitReload` is transactional at the `running.reload` THROW boundary (rev 2 P1 #1 narrowing). Per-repo gateway register/deregister failures inside `running.reload` are pre-existing semantics; sbd#219 is the §6.3 follow-up.
- **Race 3** — SIGHUP no-ops on `Booting` (rev 2 P1 #2: no-op, no queue), `Reloading`, and `ShuttingDown`.

## Rev 2 P1 #3 sub-table pinned

| From | Signal | Reload settles as | Effect |
|---|---|---|---|
| Reloading | SIGINT/SIGTERM | Ok | liveRuntime advances; → ShuttingDown(Signal); exit 0 |
| Reloading | SIGINT/SIGTERM | ReloadCommitFailed | liveRuntime unchanged; log; → ShuttingDown(Signal); exit 0 |
| Reloading | SIGINT/SIGTERM | ReloadRollbackFailed | log; **→ ShuttingDown(Signal) — signal beats §6.2**; exit 0 |

SIGTERM during Reloading does NOT abort the in-flight reload; it sets a pending Signal intent. After the reload settles, the signal drives shutdown. The `pendingShutdown === null \|\| pendingShutdown._tag !== "Signal"` guard ensures Signal beats Manual.

## Acceptance evidence (sbd#220 acceptance criteria)

- [x] All 3 race conditions verifiably fixed — covered by `bridge-process-lifecycle.test.ts` (race-1, race-2, race-3 sections) + the new regression tests for codex P1/P2.
- [x] Existing tests pass — `bridge-process.test.ts` (8 tests) green against the new lifecycle owner.
- [x] State machine transitions per rev 2 sub-table tested — see "signal-wins-over-rollback-failure" describe block.
- [x] Stamina N=3 review — codex P1+P2 already applied (commit 4816e6f); `/simplify` ran (commit 20d7579); senior review pending.

## Files

- `src/bridge-process.ts` (NEW, 568 LOC + bodies layered on architect rev 2 stubs)
- `src/bridge.ts` (-66 / +96; deletes inline `process.on` blocks; installs lifecycle as first boot step)
- `test/bridge-process-lifecycle.test.ts` (NEW, 30 tests)
- `test/config-reload.test.ts` (retargets the SIGHUP source-shape assertion to `bridge-process.ts`)

## Simplify pass

Ran `/simplify`. Findings:

- Comment typo fix applied (commit 20d7579: "env env decode" → "env decode"). No code changes.
- Boot-phase `requestShutdown({ signal: "SIGTERM" })` overwriting an actual SIGINT in `state.reason` — flagged, **skipped**: functionally harmless (Signal exits 0 either way) and changing it would touch the architect-named contract.
- Triplicated "Signal-wins-over-Manual" intent merge (3 sites with slightly different policy) — flagged, **skipped**: extracting would obscure per-site policy and the named state machine is frozen per architect rev 2.
- Defensive null-guard at `onSighup` lines 304-313 — flagged-as-paranoid; **kept** because it's load-bearing for type narrowing across mutable closure refs.

No-skip lint findings: clean. Pre-existing warnings on bridge-process.ts are the codebase-wide `agent-code-guard/promise-type` and `async-keyword` Effect-preference warnings, which match the rest of `src/bridge.ts` (Promise<>-based by convention).

## Codex diff review

Ran `/codex --mode review`. **Caught 2 real bugs** that I fixed before requesting senior review (commit 4816e6f):

- **[P1]** github-demo mode: SIGINT/SIGTERM during the post-boot probe followed by a successful probe would leave the bridge serving forever. State was already `ShuttingDown` by the time `markReady` ran, so `markReady` was a no-op and no shutdown was ever driven. Future signals were ignored as "already shutting down."
- **[P2]** SIGINT/SIGTERM during `await start(cfg)` left `running` orphaned. The lifecycle's `requestShutdown` ran with `running === null` and skipped graceful `running.stop()` — dropping gateway deregister and MoltZap session drain.

**Fix:** `markReady` now always stashes `running` on first call (even when state is `ShuttingDown`), and auto-fires `startShutdown(state.reason)` when it observes a `ShuttingDown` state. `runBridgeProcess` adds an explicit state check after the post-boot probe for the P1 corner case so the operator sees a clean shutdown trace. Two new regression tests cover the fixes.

## Confidence

HIGH — state machine matches rev 2 explicitly; race fixes have direct unit tests; codex review found two real bugs and they are fixed with regression tests. SIGTERM-during-Reloading sub-table cells all have tests. The `/simplify` skips are documented above with plan citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)