### PR TITLE
refactor: dedupe local absurd helpers across src/

### DIFF
--- a/src/ao/claude-channel-launch.ts
+++ b/src/ao/claude-channel-launch.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Result } from "../types.ts";
-import { err, ok } from "../types.ts";
+import { absurd, err, ok } from "../types.ts";
 
 export type ClaudeChannelEntry =
   | { readonly _tag: "DevelopmentServer"; readonly serverName: string }
@@ -140,6 +140,3 @@ function isValidEntryName(value: string): boolean {
   return /^[A-Za-z0-9_-]+$/.test(value);
 }
 
-function absurd(x: never): never {
-  throw new Error(`unreachable: ${JSON.stringify(x)}`);
-}

--- a/src/http/routes/installation-token.ts
+++ b/src/http/routes/installation-token.ts
@@ -20,6 +20,7 @@
  */
 
 import { timingSafeEqual } from "node:crypto";
+import { absurd } from "../../types.ts";
 
 // ── Branded types ──────────────────────────────────────────────────
 
@@ -64,12 +65,6 @@ export interface MintedInstallationToken {
 export interface InstallationTokenDeps {
   readonly mintToken: () => Promise<MintedInstallationToken | null>;
   readonly apiKey: string;
-}
-
-// ── Exhaustiveness helper ──────────────────────────────────────────
-
-function absurd(x: never): never {
-  throw new Error(`unreachable installation-token status: ${JSON.stringify(x)}`);
 }
 
 // ── Bearer auth middleware ─────────────────────────────────────────

--- a/src/moltzap/runtime.ts
+++ b/src/moltzap/runtime.ts
@@ -9,7 +9,7 @@
  * public shape only.
  */
 
-import { err, ok } from "../types.ts";
+import { absurd, err, ok } from "../types.ts";
 import type {
   AoSessionName,
   IssueNumber,
@@ -236,8 +236,4 @@ function shortSuffix(): string {
 
 function stringifyCause(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause);
-}
-
-function absurd(x: never): never {
-  throw new Error(`unreachable: ${JSON.stringify(x)}`);
 }

--- a/src/moltzap/types.ts
+++ b/src/moltzap/types.ts
@@ -29,7 +29,3 @@ export function asMoltzapSenderId(s: string): MoltzapSenderId {
   return s as MoltzapSenderId;
 }
 
-/** Exhaustiveness helper (mirrors `src/types.ts`). */
-export function absurd(x: never): never {
-  throw new Error(`unreachable: ${JSON.stringify(x)}`);
-}


### PR DESCRIPTION
Closes #325
Closes #357

## Summary

Four local redefinitions of the \`absurd\` exhaustiveness helper duplicated the canonical export at \`src/types.ts\`. Removed them; each call site now imports from \`src/types.ts\`.

| File | Change |
|---|---|
| \`src/http/routes/installation-token.ts\` | Drop local \`absurd\` (line 71-73), import from \`../../types.ts\`. The custom error prefix \"unreachable installation-token status:\" is gone, but the file:line in the stack trace already identifies the call site. |
| \`src/moltzap/runtime.ts\` | Drop local \`absurd\` (line 241-243), add \`absurd\` to existing \`../types.ts\` import. |
| \`src/ao/claude-channel-launch.ts\` | Drop local \`absurd\` (line 143-145), add \`absurd\` to existing \`../types.ts\` import. |
| \`src/moltzap/types.ts\` | Drop the duplicated \`export function absurd\` (line 33-35) — the comment in that file even acknowledged it \"mirrors src/types.ts\". No external callers imported from this path. |

Net: 4 files changed, 3 insertions, 19 deletions.

## Notes on the umbrella issue (#356)

Issue #357's literal target — \`bin/webhook-bridge.ts:52-54\` — was already removed in the architect rev 4 collapse (\`bin/webhook-bridge.ts\` is now 26 lines of pure glue). This PR addresses the same intent (no duplicate \`absurd\` in the codebase) at the four sites where the duplication actually lived after the collapse.

The other two open items in #356 were also stale and have been closed:
- #361 (\`applyMergedEnv\`): function no longer exists; \`.env\` is sourced once by \`start.sh\`, not re-read on SIGHUP.
- #363 (\`resolveChannelBootstrap\` test): function no longer exists in the codebase.

After this PR + #364 merge, all 7 sub-issues of #356 are resolved and the umbrella can close.

## Test plan

- [x] \`bun run build\` — clean tsc
- [x] \`bun run test\` — 367/367 pass (vitest)
- [x] \`bun run lint\` — 0 errors / 282 pre-existing warnings (no new violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
