### PR TITLE
fix(start.sh, bootstrap): boot stack cleanly on a fresh checkout (#390)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "vitest run",
     "lint": "eslint 'src/**/*.ts' 'gateway/src/**/*.ts' 'bin/**/*.ts'",
     "bridge": "bun run bin/webhook-bridge.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "postinstall": "bash scripts/prune-vendor-symlinks.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/prune-vendor-symlinks.sh
+++ b/scripts/prune-vendor-symlinks.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/prune-vendor-symlinks.sh — remove broken nested pnpm symlinks under
+# node_modules/@moltzap/*/node_modules/.
+#
+# bun install of the vendored `file:./vendor/moltzap/packages/<pkg>` deps
+# carries each upstream package's own node_modules/ symlinks pointing at the
+# upstream's pnpm store (`../../../node_modules/.pnpm/effect@<v>/...`). zapbot
+# uses bun, not pnpm, so there is no `.pnpm/` dir at the project root and
+# every nested pointer resolves to ENOENT.
+#
+# tsc and vitest tolerate this because they walk up the resolution chain
+# and find the real `node_modules/effect/` at the top level. bun's runtime
+# resolver does NOT walk up the same way: when an orchestrator/bridge
+# subprocess imports `effect`, bun finds the broken nested symlink first
+# and exits with `ENOENT reading "node_modules/@moltzap/runtimes/node_modules/effect"`.
+#
+# The fix is to delete every broken symlink under node_modules/@moltzap/.
+# After deletion, the resolver walks up cleanly to the project-root copy.
+# Runs idempotently; safe to re-run after every `bun install`.
+#
+# This script is wired as `package.json` postinstall so it runs automatically.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCAN_ROOT="$REPO_ROOT/node_modules/@moltzap"
+
+if [ ! -d "$SCAN_ROOT" ]; then
+  # No @moltzap installed yet (running pre-install). Quiet exit.
+  exit 0
+fi
+
+REMOVED=0
+while IFS= read -r link; do
+  if [ ! -e "$link" ]; then
+    rm "$link"
+    REMOVED=$((REMOVED + 1))
+  fi
+done < <(find "$SCAN_ROOT" -type l 2>/dev/null)
+
+if [ "$REMOVED" -gt 0 ]; then
+  echo "[prune-vendor-symlinks] removed $REMOVED broken symlink(s) under node_modules/@moltzap/"
+fi

--- a/start.sh
+++ b/start.sh
@@ -66,9 +66,54 @@ BRIDGE_PORT="${ZAPBOT_PORT:-3000}"
 ORCHESTRATOR_PORT="${ZAPBOT_ORCHESTRATOR_PORT:-3002}"
 MOLTZAP_PORT="${MOLTZAP_PORT:-3100}"
 MOLTZAP_SERVER_URL="${MOLTZAP_SERVER_URL:-http://127.0.0.1:${MOLTZAP_PORT}}"
+MOLTZAP_YAML="$HOME/.zapbot/moltzap.yaml"
 ORCHESTRATOR_LOG_FILE="/tmp/zapbot-orchestrator.log"
 MOLTZAP_LOG_FILE="/tmp/zapbot-moltzap.log"
 BRIDGE_LOG_FILE="/tmp/zapbot-bridge.log"
+
+# MoltZap local-server config: auto-mint secrets + write yaml on first run
+# so the operator never hand-stages config. Stored alongside the bridge's
+# webhookSecret/apiKey under ~/.zapbot/. The yaml is regenerated when missing
+# so MOLTZAP_PORT changes propagate cleanly; existing yamls are left alone.
+ZAPBOT_MOLTZAP_REGISTRATION_SECRET="$(jq -r '.moltzap.registrationSecret // empty' "$HOME/.zapbot/config.json" 2>/dev/null)"
+MOLTZAP_ENCRYPTION_SECRET="$(jq -r '.moltzap.encryptionSecret // empty' "$HOME/.zapbot/config.json" 2>/dev/null)"
+if [ -z "$ZAPBOT_MOLTZAP_REGISTRATION_SECRET" ] || [ -z "$MOLTZAP_ENCRYPTION_SECRET" ]; then
+  echo "Initialising MoltZap local-dev secrets in $HOME/.zapbot/config.json..."
+  ZAPBOT_MOLTZAP_REGISTRATION_SECRET="$(openssl rand -hex 32)"
+  MOLTZAP_ENCRYPTION_SECRET="$(openssl rand -hex 32)"
+  jq --arg reg "$ZAPBOT_MOLTZAP_REGISTRATION_SECRET" \
+     --arg enc "$MOLTZAP_ENCRYPTION_SECRET" \
+     --arg url "$MOLTZAP_SERVER_URL" \
+     '.moltzap = (.moltzap // {}) | .moltzap.registrationSecret = $reg | .moltzap.encryptionSecret = $enc | .moltzap.serverUrl = $url' \
+     "$HOME/.zapbot/config.json" > "$HOME/.zapbot/config.json.tmp"
+  mv "$HOME/.zapbot/config.json.tmp" "$HOME/.zapbot/config.json"
+fi
+if [ ! -f "$MOLTZAP_YAML" ]; then
+  echo "Writing $MOLTZAP_YAML..."
+  cat > "$MOLTZAP_YAML" <<MZ_YAML
+# Local-dev MoltZap server config managed by zapbot's start.sh.
+# - Embedded PGlite (no external Postgres needed).
+# - dev_mode bypasses external auth handshake — localhost only.
+# - registration.secret + encryption.master_secret pull from ~/.zapbot/config.json.
+server:
+  port: ${MOLTZAP_PORT}
+  cors_origins:
+    - "*"
+encryption:
+  master_secret: ${MOLTZAP_ENCRYPTION_SECRET}
+registration:
+  secret: ${ZAPBOT_MOLTZAP_REGISTRATION_SECRET}
+dev_mode:
+  enabled: true
+log_level: info
+MZ_YAML
+fi
+# The bridge consumes ZAPBOT_MOLTZAP_SERVER_URL (zapbot-namespaced); the
+# orchestrator + moltzap-server adapters consume MOLTZAP_SERVER_URL (upstream
+# convention). Export both so neither side has to translate.
+ZAPBOT_MOLTZAP_SERVER_URL="$MOLTZAP_SERVER_URL"
+export ZAPBOT_MOLTZAP_REGISTRATION_SECRET MOLTZAP_ENCRYPTION_SECRET
+export MOLTZAP_SERVER_URL ZAPBOT_MOLTZAP_SERVER_URL
 
 trim_env_value() {
   printf '%s' "${1:-}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
@@ -132,8 +177,11 @@ if [ "${ZAPBOT_SKIP_MOLTZAP_SERVER:-0}" != "1" ]; then
   fi
   echo "Starting moltzap-server on port ${MOLTZAP_PORT}..."
   : > "$MOLTZAP_LOG_FILE"
-  MOLTZAP_PORT="$MOLTZAP_PORT" \
-    "$MOLTZAP_BIN" > "$MOLTZAP_LOG_FILE" 2>&1 &
+  # cd to ~/.zapbot/ so moltzap-server finds moltzap.yaml in cwd. Embedded
+  # PGlite writes data into cwd too, so this also keeps state out of the
+  # zapbot source tree. Use a subshell so the parent's cwd stays put.
+  ( cd "$HOME/.zapbot" && MOLTZAP_PORT="$MOLTZAP_PORT" \
+    "$MOLTZAP_BIN" > "$MOLTZAP_LOG_FILE" 2>&1 ) &
   MOLTZAP_PID=$!
 
   for i in $(seq 1 20); do


### PR DESCRIPTION
## Summary

Closes #390. Two real defects surfaced by smoke-test follow-up to epic #369:

1. **41 broken pnpm symlinks** under `node_modules/@moltzap/*/node_modules/` ENOENT bun runtime imports (orchestrator exits at boot). Auto-prune script wired as `package.json` postinstall.
2. **moltzap-server CORS_ORIGINS error** + **bridge env mismatch** — start.sh's PR #380 trim went too far: removed moltzap secret-mint + yaml-write + cd-to-~/.zapbot/ before launch, AND only exported `MOLTZAP_SERVER_URL` while the bridge needs `ZAPBOT_MOLTZAP_SERVER_URL` too. Re-added all four.

## Files changed

- `scripts/prune-vendor-symlinks.sh` (NEW, 41 LOC) — idempotent broken-symlink prune under `node_modules/@moltzap/`
- `package.json` — `postinstall` script wired to call the prune
- `start.sh` — re-added moltzap secret-mint + yaml-write on first run, subshell cd to `~/.zapbot/` before moltzap-server launch, dual-namespace env export

## End-to-end smoke (against fresh-operator simulation)

Sanitized `~/.zapbot/config.json` moltzap.* keys + removed `~/.zapbot/moltzap.yaml` to simulate first-time operator. Then:

```
bun install                              # postinstall pruned 41 broken symlinks
./start.sh /tmp/smoke-test-project       # no SKIP env vars
```

Output:
```
Initialising MoltZap local-dev secrets in /Users/tapanc/.zapbot/config.json...
Writing /Users/tapanc/.zapbot/moltzap.yaml...
Starting moltzap-server on port 3100... moltzap-server ready
Starting zapbot-orchestrator on port 3002... Orchestrator ready
Starting webhook bridge on port 3000... Bridge ready
================================================
  Zapbot is running!
================================================
```

Healthz probes:
- moltzap (3100): `{"status":"ok","connections":0}`
- orchestrator (3002): `{"ok":true,"port":3002,"projects":0}`
- bridge (3000): `ok`

SIGTERM teardown clean — all 3 ports freed.

## Verification gates

- [x] `bun run build` clean
- [x] `bun run test` 282/282
- [x] `bun run lint` 0 errors / 204 warnings (no new pinned-warn violations)
- [x] Manual `./start.sh` on a fresh-operator checkout — all 3 services healthz green
- [x] Manual `kill -TERM` teardown — all 3 ports freed

Refs #369 #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)