### PR TITLE
fix(orchestrator, bridge): three end-to-end fixes from real-network smoke

### DIFF
--- a/bin/zapbot-orchestrator.ts
+++ b/bin/zapbot-orchestrator.ts
@@ -460,14 +460,52 @@ function makeProductionRunnerDeps(input: ProductionRunnerDepsInput): RunnerDeps 
             ),
           );
         } else {
+          // `git init --bare` + `remote add origin` + fetch. We can't use
+          // `git clone --bare` directly: it copies `refs/heads/*` from the
+          // remote into the bare clone, which then conflicts with
+          // `git worktree add --track -b <branch>` ("a branch named '<branch>'
+          // already exists"). `--mirror` has the same problem because its
+          // `+refs/*:refs/*` refspec also lands branches in `refs/heads/`.
+          // Init-bare starts the refs empty; the standard fetch refspec
+          // populates ONLY `refs/remotes/origin/*`, leaving `refs/heads/`
+          // free for worktree-add to write to.
+          yield* Effect.try({
+            try: (): void => {
+              fs.mkdirSync(bareClonePath, { recursive: true });
+            },
+            catch: (cause): OrchestratorError => checkoutFailure(cause, "clone"),
+          });
           yield* Effect.tryPromise({
             try: () =>
               execFileAsync("git", [
-                "clone",
+                "--git-dir",
+                bareClonePath,
+                "init",
                 "--bare",
                 "--quiet",
-                cloneUrl,
+              ]),
+            catch: (cause): OrchestratorError => checkoutFailure(cause, "clone"),
+          });
+          yield* Effect.tryPromise({
+            try: () =>
+              execFileAsync("git", [
+                "--git-dir",
                 bareClonePath,
+                "remote",
+                "add",
+                "origin",
+                cloneUrl,
+              ]),
+            catch: (cause): OrchestratorError => checkoutFailure(cause, "clone"),
+          });
+          yield* Effect.tryPromise({
+            try: () =>
+              execFileAsync("git", [
+                "--git-dir",
+                bareClonePath,
+                "fetch",
+                "--quiet",
+                "origin",
               ]),
             catch: (cause): OrchestratorError => checkoutFailure(cause, "clone"),
           });
@@ -650,12 +688,20 @@ function productionSpawnClaude(
 ): Effect.Effect<ClaudeSpawnResult, OrchestratorError, never> {
   return Effect.async<ClaudeSpawnResult, OrchestratorError, never>((resume) => {
     fs.mkdirSync(path.dirname(args.logFilePath), { recursive: true });
-    const claudeArgs: string[] = ["-p"];
+    // --output-format json so the runner can extract session_id (the
+    // default text mode prints only the response text, no session id —
+    // every fresh turn would then look like a session-corruption case
+    // and dispatch fails 503 even on a clean lead-session exit).
+    const claudeArgs: string[] = ["-p", "--output-format", "json"];
     if (args.resumeSessionId !== null) {
       claudeArgs.push("--resume", args.resumeSessionId);
     }
     claudeArgs.push("--mcp-config", args.mcpConfigPath);
-    claudeArgs.push(args.message);
+    // `--` ends `--mcp-config`'s variadic <configs...> consumption, so
+    // claude treats the message as the prompt positional and not as
+    // another MCP config path. Without `--`, claude swallows the message
+    // into --mcp-config and exits with "MCP config file not found".
+    claudeArgs.push("--", args.message);
 
     const child = spawn("claude", claudeArgs, {
       cwd: args.cwd,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -817,18 +817,29 @@ export function buildFetchHandler(
 }
 
 /**
- * Default `mintToken` implementation — delegates to the v1 singleton
- * `getInstallationToken` and maps `null`/throw into `DispatchError`.
+ * Default `mintToken` implementation — tries GitHub App auth first
+ * (`getInstallationToken`), then falls back to `ZAPBOT_GITHUB_TOKEN` (PAT
+ * mode). PAT mode is the supported single-operator path; without the
+ * fallback dispatch fails with `no installation token available` even
+ * when the bridge's other GitHub API calls (reactions, comments) work
+ * fine via the PAT. Mirrors the App-then-PAT priority in
+ * `createGitHubClient`.
  */
 export async function defaultMintToken(): Promise<Result<InstallationToken, DispatchError>> {
   try {
     const t = await getInstallationToken();
-    if (!t) return err({ _tag: "TokenMintFailed", cause: "no installation token available" });
-    return ok(t.token as unknown as InstallationToken);
+    if (t) return ok(t.token as unknown as InstallationToken);
   } catch (e) {
     const cause = e instanceof Error ? e.message : String(e);
     return err({ _tag: "TokenMintFailed", cause });
   }
+  const pat = process.env.ZAPBOT_GITHUB_TOKEN?.trim();
+  if (pat) return ok(pat as unknown as InstallationToken);
+  return err({
+    _tag: "TokenMintFailed",
+    cause:
+      "no installation token available — set GITHUB_APP_ID + GITHUB_APP_INSTALLATION_ID + GITHUB_APP_PRIVATE_KEY for App auth, or ZAPBOT_GITHUB_TOKEN for PAT mode",
+  });
 }
 
 export async function startBridge(config: BridgeConfig): Promise<RunningBridge> {


### PR DESCRIPTION
## Summary

Three real production bugs surfaced by running an HMAC-signed `@zapbot plan this` webhook through the full bridge → orchestrator → claude → GitHub flow. None of these were caught by the existing test suite or the in-process integration smoke from PR #384.

## Fixes

### 1. `ensureProjectCheckout` — `git init --bare` instead of `git clone --bare`

`bin/zapbot-orchestrator.ts`. `git clone --bare URL DIR` populates `refs/heads/*` from the remote. The follow-on `git worktree add --track -b <branch>` then fails because the local branch already exists in the bare clone. Tried `--mirror` (folds remote refs into `refs/heads/*` same way) and `--bare` + manual refspec (now have BOTH `refs/heads/<branch>` and `refs/remotes/origin/<branch>`, still conflicts).

Fix: `git init --bare` + `git remote add origin <url>` + `git fetch origin`. Empty `refs/heads/`, fetch lands remote refs at `refs/remotes/origin/*`. Worktree-add now works cleanly.

### 2. `defaultMintToken` — fall back to `ZAPBOT_GITHUB_TOKEN`

`src/bridge.ts`. `getInstallationToken()` returns null when GitHub App env vars (`GITHUB_APP_ID` etc.) aren't set, even when `ZAPBOT_GITHUB_TOKEN` is. `defaultMintToken` mapped that null → `DispatchError "no installation token available"`, so PAT-mode operators couldn't dispatch — even though the bridge's other GitHub API calls (reactions, comments) worked fine on the same PAT via `createGitHubClient` / `getGitHubApiToken`, both of which DO fall through to PAT mode.

Fix: mirror the App-then-PAT priority of `createGitHubClient`. Try `getInstallationToken` first, fall back to `process.env.ZAPBOT_GITHUB_TOKEN` if the App route returns null. Improve the error message to name both auth modes when neither is configured.

### 3. claude args — `--output-format json` + `--` separator

`bin/zapbot-orchestrator.ts`. Two bugs in `productionSpawnClaude`:

**(a)** `claude --mcp-config <path>` is variadic (`<configs...>`), so claude consumed the prompt message as another MCP config path and exited with `MCP config file not found: <message-content>`. Fix: add `--` before the message positional so claude knows the variadic flag is done.

**(b)** Default `--output-format text` prints only the response text. The session id never appears in stdout, so `extractSessionId` returns null and every clean (exit 0) turn looked like `LeadProcessFailed` (newSessionId null → 503). Fix: pass `--output-format json` which emits `"session_id":"<uuid>"` in every event. The existing regex catches it.

## Verified end-to-end

After all three fixes, fired an HMAC-signed `@zapbot plan this` webhook against a fresh-bootstrapped stack (`./start.sh /tmp/smoke-test-project` with `ZAPBOT_GITHUB_TOKEN` from `gh auth token`):

- Bridge HMAC verified ✓
- Mention parsed (`plan_this` command) ✓
- `defaultMintToken` returned PAT ✓
- Bridge POSTed `/turn` to orchestrator ✓
- Orchestrator runner spawned `claude -p --output-format json --mcp-config <path> -- <prompt>` ✓
- Lead claude session ran the prompt with the full ORCHESTRATOR_DOCTRINE + `request_worker_spawn` MCP tool registered + connected
- Claude opened https://github.com/chughtapan/zapbot-test/pull/26 (real PR, real branch, real test passing)
- Claude posted issue acknowledgement on chughtapan/zapbot-test#1 with PR link
- Exit code 0, session_id extracted from json output via existing regex (verified manually against captured json)

Follow-up `@zapbot status` webhook returned `HTTP 200 {"ok":true,"outcome":{"kind":"replied","command":"status"}}` — bridge replied directly without dispatching.

## Verification gates

- [x] `bun run build` clean
- [x] `bun run test` 282/282
- [x] `bun run lint` 0 errors / 204 warnings (no new pinned-warn violations)
- [x] Manual `./start.sh` end-to-end with real GitHub
- [x] Real PR opened at chughtapan/zapbot-test#26
- [x] Real issue comment posted at chughtapan/zapbot-test#1

Refs #369 #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)